### PR TITLE
test(coverage): add real tests for _revocation and _hw_providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Run tests with coverage
         working-directory: python
+        shell: bash
         run: |
           pytest -v --tb=short \
             --cov=agent_manifest \

--- a/python/tests/test_hw_providers.py
+++ b/python/tests/test_hw_providers.py
@@ -1,0 +1,483 @@
+"""Tests for hardware attestation providers: SEVSNPProvider, TDXProvider, OPAQUEProvider.
+
+Strategy:
+  Initialization failures (no device / no env var): tested on all platforms by
+    mocking os.path.exists — no hardware required.
+  get_attestation_report() before extend_manifest_hash(): always raises, no mock.
+  verify_manifest_in_report(): pure Python hash comparison, no mock.
+  extend_manifest_hash for SEVSNPProvider/TDXProvider: mock fcntl.ioctl + open
+    so struct packing and report-parsing code paths run without hardware.
+    Gated by sys.platform == "linux" because fcntl is Linux-only.
+  extend_manifest_hash for OPAQUEProvider: mock httpx.post, runs on all platforms.
+    Tests auth header, pre-image encoding, HTTP error handling.
+  Integration markers: NEEDS_SEV_SNP, NEEDS_TDX, NEEDS_OPAQUE for real hardware.
+"""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_manifest._hw_providers import (
+    OPAQUEProvider,
+    SEVSNPProvider,
+    TDXProvider,
+)
+from agent_manifest._providers import AttestationReport, AttestationUnavailableError
+
+LINUX = sys.platform == "linux"
+
+NEEDS_SEV_SNP = pytest.mark.skipif(
+    not os.path.exists("/dev/sev-guest"),
+    reason="requires AMD SEV-SNP hardware (/dev/sev-guest)",
+)
+NEEDS_TDX = pytest.mark.skipif(
+    not os.path.exists("/dev/tdx-guest"),
+    reason="requires Intel TDX hardware (/dev/tdx-guest)",
+)
+NEEDS_OPAQUE = pytest.mark.skipif(
+    not os.environ.get("OPAQUE_ATTESTATION_URL"),
+    reason="set OPAQUE_ATTESTATION_URL to run OPAQUE integration tests",
+)
+
+SAMPLE_MANIFEST = {
+    "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+    "agent_id": "spiffe://trust.example/agent/kyc/prod",
+    "version": "0.1",
+    "issued_at": "2026-06-23T09:00:00Z",
+    "expires_at": "2026-09-21T09:00:00Z",
+    "issuer": "spiffe://trust.example/signing-authority",
+    "crypto_profile": "standard",
+    "artifacts": {},
+    "delegation_chain": [],
+    "hitl_record": None,
+    "signature": {"algorithm": "Ed25519", "signature_value": "abc"},
+}
+
+
+# ---------------------------------------------------------------------------
+# SEVSNPProvider — initialization and pure-Python paths
+# ---------------------------------------------------------------------------
+
+
+def test_sevsnp_raises_without_device(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: False)
+    with pytest.raises(AttestationUnavailableError, match="SEV-SNP"):
+        SEVSNPProvider()
+
+
+def test_sevsnp_report_before_extend_raises(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/sev-guest")
+    provider = SEVSNPProvider()
+    with pytest.raises(AttestationUnavailableError, match="extend_manifest_hash"):
+        provider.get_attestation_report()
+
+
+def test_sevsnp_verify_manifest_match(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/sev-guest")
+    provider = SEVSNPProvider()
+    expected = provider.manifest_hash_value(SAMPLE_MANIFEST)
+    report = AttestationReport(platform="amd-sev-snp", manifest_hash=expected)
+    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+def test_sevsnp_verify_manifest_mismatch(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/sev-guest")
+    provider = SEVSNPProvider()
+    report = AttestationReport(platform="amd-sev-snp", manifest_hash="sha256:" + "00" * 32)
+    assert not provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+@pytest.mark.skipif(not LINUX, reason="fcntl only available on Linux")
+def test_sevsnp_extend_with_mocked_ioctl(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/sev-guest")
+    provider = SEVSNPProvider()
+
+    mock_buf = bytearray(4096)
+    mock_buf[0x90:0x90 + 48] = bytes(range(48))   # fake measurement
+    mock_buf[0x140:0x180] = bytes(range(64))        # fake HOST_DATA
+
+    import fcntl
+
+    def mock_ioctl(fd, op, buf):
+        buf[:] = mock_buf
+
+    mock_dev = MagicMock()
+    mock_dev.__enter__ = lambda s: mock_dev
+    mock_dev.__exit__ = MagicMock(return_value=False)
+
+    monkeypatch.setattr(fcntl, "ioctl", mock_ioctl)
+    with patch("builtins.open", return_value=mock_dev):
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    report = provider.get_attestation_report()
+    assert report.platform == "amd-sev-snp"
+    assert report.manifest_hash.startswith("sha256:")
+    assert report.raw["measurement"] == bytes(range(48)).hex()
+    assert report.raw["host_data"] == bytes(range(64)).hex()
+    assert report.raw["vmpl"] == 0
+
+
+@pytest.mark.skipif(not LINUX, reason="fcntl only available on Linux")
+def test_sevsnp_extend_ioctl_oserror_raises(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/sev-guest")
+    provider = SEVSNPProvider()
+
+    import fcntl
+
+    monkeypatch.setattr(fcntl, "ioctl", MagicMock(side_effect=OSError("perm denied")))
+    mock_dev = MagicMock()
+    mock_dev.__enter__ = lambda s: mock_dev
+    mock_dev.__exit__ = MagicMock(return_value=False)
+    with patch("builtins.open", return_value=mock_dev):
+        with pytest.raises(AttestationUnavailableError, match="ioctl"):
+            provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+
+@pytest.mark.skipif(not LINUX, reason="fcntl only available on Linux")
+def test_sevsnp_extend_manifest_hash_value_matches(monkeypatch):
+    """manifest_hash in the report must equal manifest_hash_value(manifest)."""
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/sev-guest")
+    provider = SEVSNPProvider()
+
+    import fcntl
+
+    monkeypatch.setattr(fcntl, "ioctl", lambda fd, op, buf: None)
+    mock_dev = MagicMock()
+    mock_dev.__enter__ = lambda s: mock_dev
+    mock_dev.__exit__ = MagicMock(return_value=False)
+    with patch("builtins.open", return_value=mock_dev):
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    report = provider.get_attestation_report()
+    assert report.manifest_hash == provider.manifest_hash_value(SAMPLE_MANIFEST)
+    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+# ---------------------------------------------------------------------------
+# TDXProvider — initialization and pure-Python paths
+# ---------------------------------------------------------------------------
+
+
+def test_tdx_raises_without_device(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: False)
+    with pytest.raises(AttestationUnavailableError, match="TDX"):
+        TDXProvider()
+
+
+def test_tdx_report_before_extend_raises(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/tdx-guest")
+    provider = TDXProvider()
+    with pytest.raises(AttestationUnavailableError, match="extend_manifest_hash"):
+        provider.get_attestation_report()
+
+
+def test_tdx_default_rtmr_index(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/tdx-guest")
+    provider = TDXProvider()
+    assert provider._rtmr == 1
+
+
+def test_tdx_custom_rtmr_index(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/tdx-guest")
+    provider = TDXProvider(rtmr_index=2)
+    assert provider._rtmr == 2
+
+
+def test_tdx_verify_manifest_match(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/tdx-guest")
+    provider = TDXProvider()
+    expected = provider.manifest_hash_value(SAMPLE_MANIFEST)
+    report = AttestationReport(platform="intel-tdx", manifest_hash=expected)
+    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+def test_tdx_verify_manifest_mismatch(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/tdx-guest")
+    provider = TDXProvider()
+    report = AttestationReport(platform="intel-tdx", manifest_hash="sha256:" + "ff" * 32)
+    assert not provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+@pytest.mark.skipif(not LINUX, reason="fcntl only available on Linux")
+def test_tdx_extend_with_mocked_ioctl(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/tdx-guest")
+    provider = TDXProvider(rtmr_index=1)
+
+    mock_report = bytearray(512)
+    for i in range(64):
+        mock_report[i] = i  # recognizable report_data pattern
+
+    import fcntl
+
+    def mock_ioctl(fd, op, buf):
+        buf[:512] = mock_report
+
+    mock_dev = MagicMock()
+    mock_dev.__enter__ = lambda s: mock_dev
+    mock_dev.__exit__ = MagicMock(return_value=False)
+
+    monkeypatch.setattr(fcntl, "ioctl", mock_ioctl)
+    with patch("builtins.open", return_value=mock_dev):
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    report = provider.get_attestation_report()
+    assert report.platform == "intel-tdx"
+    assert report.manifest_hash.startswith("sha256:")
+    assert report.raw["rtmr_index"] == 1
+    assert report.raw["report_data"] == bytes(range(64)).hex()
+
+
+@pytest.mark.skipif(not LINUX, reason="fcntl only available on Linux")
+def test_tdx_extend_ioctl_oserror_raises(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/tdx-guest")
+    provider = TDXProvider()
+
+    import fcntl
+
+    monkeypatch.setattr(fcntl, "ioctl", MagicMock(side_effect=OSError("no perm")))
+    mock_dev = MagicMock()
+    mock_dev.__enter__ = lambda s: mock_dev
+    mock_dev.__exit__ = MagicMock(return_value=False)
+    with patch("builtins.open", return_value=mock_dev):
+        with pytest.raises(AttestationUnavailableError, match="TDX"):
+            provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+
+@pytest.mark.skipif(not LINUX, reason="fcntl only available on Linux")
+def test_tdx_extend_manifest_hash_value_matches(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/tdx-guest")
+    provider = TDXProvider()
+
+    import fcntl
+
+    monkeypatch.setattr(fcntl, "ioctl", lambda fd, op, buf: None)
+    mock_dev = MagicMock()
+    mock_dev.__enter__ = lambda s: mock_dev
+    mock_dev.__exit__ = MagicMock(return_value=False)
+    with patch("builtins.open", return_value=mock_dev):
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    report = provider.get_attestation_report()
+    assert report.manifest_hash == provider.manifest_hash_value(SAMPLE_MANIFEST)
+    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+# ---------------------------------------------------------------------------
+# OPAQUEProvider — all platforms (mock httpx)
+# ---------------------------------------------------------------------------
+
+
+def test_opaque_raises_without_env_var(monkeypatch):
+    monkeypatch.delenv("OPAQUE_ATTESTATION_URL", raising=False)
+    with pytest.raises(AttestationUnavailableError, match="OPAQUE_ATTESTATION_URL"):
+        OPAQUEProvider()
+
+
+def test_opaque_raises_on_empty_env_var(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "")
+    with pytest.raises(AttestationUnavailableError, match="OPAQUE_ATTESTATION_URL"):
+        OPAQUEProvider()
+
+
+def test_opaque_report_before_extend_raises(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+    with pytest.raises(AttestationUnavailableError, match="extend_manifest_hash"):
+        provider.get_attestation_report()
+
+
+def test_opaque_extend_success(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+
+    fake_trace = {"eat_profile": "tag:agentrust.io,2026:trace-v0.1", "iat": 1234567890}
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = fake_trace
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    called_url = mock_post.call_args[0][0]
+    assert called_url == "https://attest.example.com/v1/attest"
+
+    report = provider.get_attestation_report()
+    assert report.platform == "opaque"
+    assert report.manifest_hash.startswith("sha256:")
+    assert report.raw == fake_trace
+
+
+def test_opaque_extend_posts_pre_image(monkeypatch):
+    import base64
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    body = mock_post.call_args.kwargs["json"]
+    assert "manifest_pre_image" in body
+    decoded = base64.b64decode(body["manifest_pre_image"])
+    assert len(decoded) > 0
+
+
+def test_opaque_extend_pre_image_is_correct(monkeypatch):
+    """The posted pre-image must match manifest_pre_image()."""
+    import base64
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    body = mock_post.call_args.kwargs["json"]
+    posted = base64.b64decode(body["manifest_pre_image"])
+    expected = provider.manifest_pre_image(SAMPLE_MANIFEST)
+    assert posted == expected
+
+
+def test_opaque_extend_with_api_key(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    monkeypatch.setenv("OPAQUE_API_KEY", "secret-key-123")
+    provider = OPAQUEProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers.get("Authorization") == "Bearer secret-key-123"
+
+
+def test_opaque_extend_without_api_key_sends_empty_headers(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    monkeypatch.delenv("OPAQUE_API_KEY", raising=False)
+    provider = OPAQUEProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert "Authorization" not in headers
+
+
+def test_opaque_extend_http_error_raises(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.text = "Service Unavailable"
+
+    with patch("httpx.post", return_value=mock_response):
+        with pytest.raises(AttestationUnavailableError, match="503"):
+            provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+
+def test_opaque_extend_401_raises(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_response.text = "Unauthorized"
+
+    with patch("httpx.post", return_value=mock_response):
+        with pytest.raises(AttestationUnavailableError, match="401"):
+            provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+
+def test_opaque_manifest_hash_format(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+
+    with patch("httpx.post", return_value=mock_response):
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    report = provider.get_attestation_report()
+    assert report.manifest_hash.startswith("sha256:")
+    assert len(report.manifest_hash) == 7 + 64
+
+
+def test_opaque_verify_manifest_match(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+    expected = provider.manifest_hash_value(SAMPLE_MANIFEST)
+    report = AttestationReport(platform="opaque", manifest_hash=expected)
+    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+def test_opaque_verify_manifest_mismatch(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
+    provider = OPAQUEProvider()
+    report = AttestationReport(platform="opaque", manifest_hash="sha256:" + "aa" * 32)
+    assert not provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+def test_opaque_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com/")
+    provider = OPAQUEProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        provider.extend_manifest_hash(SAMPLE_MANIFEST)
+
+    called_url = mock_post.call_args[0][0]
+    assert not called_url.startswith("https://attest.example.com//")
+    assert called_url == "https://attest.example.com/v1/attest"
+
+
+# ---------------------------------------------------------------------------
+# Hardware integration tests — only run on actual hardware
+# ---------------------------------------------------------------------------
+
+
+@NEEDS_SEV_SNP
+def test_sevsnp_hardware_roundtrip():
+    provider = SEVSNPProvider()
+    provider.extend_manifest_hash(SAMPLE_MANIFEST)
+    report = provider.get_attestation_report()
+    assert report.platform == "amd-sev-snp"
+    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+    assert len(report.raw.get("measurement", "")) > 0
+
+
+@NEEDS_TDX
+def test_tdx_hardware_roundtrip():
+    provider = TDXProvider()
+    provider.extend_manifest_hash(SAMPLE_MANIFEST)
+    report = provider.get_attestation_report()
+    assert report.platform == "intel-tdx"
+    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
+
+
+@NEEDS_OPAQUE
+def test_opaque_hardware_roundtrip():
+    provider = OPAQUEProvider()
+    provider.extend_manifest_hash(SAMPLE_MANIFEST)
+    report = provider.get_attestation_report()
+    assert report.platform == "opaque"
+    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)

--- a/python/tests/test_revocation.py
+++ b/python/tests/test_revocation.py
@@ -1,0 +1,308 @@
+"""Tests for _revocation: signed revocation records, file-backed CRL, FastAPI router.
+
+Strategy:
+  sign_revocation / verify_revocation_signature — cryptographic correctness:
+    round-trip, tampered manifest ID, tampered reason, wrong key.
+  FileCRL — file persistence: revoke, reload-from-disk, double-revoke, list, 404.
+  create_crl_router — HTTP contract via FastAPI TestClient:
+    list (empty and populated), get-found, get-404, signature fields present.
+  No hardware or network required.
+"""
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.exceptions import InvalidSignature
+
+from agent_manifest._revocation import (
+    FileCRL,
+    SignedRevocationRecord,
+    create_crl_router,
+    sign_revocation,
+    verify_revocation_signature,
+)
+from agent_manifest._signing import generate_ed25519
+
+MID = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+MID2 = "018aaaaa-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+
+# ---------------------------------------------------------------------------
+# sign_revocation / verify_revocation_signature
+# ---------------------------------------------------------------------------
+
+
+def test_sign_revocation_returns_record():
+    kp = generate_ed25519()
+    rec = sign_revocation(MID, "key compromise", "security@example.com", kp)
+    assert rec.manifest_id == MID
+    assert rec.reason == "key compromise"
+    assert rec.revoked_by == "security@example.com"
+    assert rec.revocation_signature is not None
+    assert rec.signer_key_id == kp.key_id
+
+
+def test_sign_revocation_sets_revoked_at():
+    kp = generate_ed25519()
+    before = datetime.now(timezone.utc)
+    rec = sign_revocation(MID, "test", "admin", kp)
+    after = datetime.now(timezone.utc)
+    assert before <= rec.revoked_at <= after
+
+
+def test_sign_revocation_roundtrip_verifies():
+    kp = generate_ed25519()
+    rec = sign_revocation(MID, "policy violation", "admin@example.com", kp)
+    verify_revocation_signature(rec, kp.public_bytes)  # must not raise
+
+
+def test_verify_revocation_wrong_key_fails():
+    kp1 = generate_ed25519()
+    kp2 = generate_ed25519()
+    rec = sign_revocation(MID, "test", "admin", kp1)
+    with pytest.raises(InvalidSignature):
+        verify_revocation_signature(rec, kp2.public_bytes)
+
+
+def test_verify_revocation_tampered_manifest_id_fails():
+    kp = generate_ed25519()
+    rec = sign_revocation(MID, "test", "admin", kp)
+    tampered = rec.model_copy(update={"manifest_id": MID2})
+    with pytest.raises(InvalidSignature):
+        verify_revocation_signature(tampered, kp.public_bytes)
+
+
+def test_verify_revocation_tampered_reason_fails():
+    kp = generate_ed25519()
+    rec = sign_revocation(MID, "original reason", "admin", kp)
+    tampered = rec.model_copy(update={"reason": "tampered reason"})
+    with pytest.raises(InvalidSignature):
+        verify_revocation_signature(tampered, kp.public_bytes)
+
+
+def test_verify_revocation_tampered_revoked_by_fails():
+    kp = generate_ed25519()
+    rec = sign_revocation(MID, "test", "admin@example.com", kp)
+    tampered = rec.model_copy(update={"revoked_by": "attacker@evil.com"})
+    with pytest.raises(InvalidSignature):
+        verify_revocation_signature(tampered, kp.public_bytes)
+
+
+def test_verify_revocation_no_signature_fails():
+    kp = generate_ed25519()
+    rec = SignedRevocationRecord(
+        manifest_id=MID,
+        revoked_at=datetime.now(timezone.utc),
+        reason="test",
+        revoked_by="admin",
+        revocation_signature=None,
+    )
+    with pytest.raises(Exception):
+        verify_revocation_signature(rec, kp.public_bytes)
+
+
+# ---------------------------------------------------------------------------
+# FileCRL
+# ---------------------------------------------------------------------------
+
+
+def test_file_crl_empty_on_new_file(tmp_path):
+    crl = FileCRL(tmp_path / "crl.jsonl")
+    assert crl.all_records() == []
+    assert not crl.is_revoked(MID)
+    assert crl.get_record(MID) is None
+
+
+def test_file_crl_handles_nonexistent_path(tmp_path):
+    crl = FileCRL(tmp_path / "does_not_exist.jsonl")
+    assert crl.all_records() == []
+    assert not crl.is_revoked(MID)
+
+
+def test_file_crl_revoke_and_is_revoked(tmp_path):
+    kp = generate_ed25519()
+    crl = FileCRL(tmp_path / "crl.jsonl")
+    rec = sign_revocation(MID, "test", "admin", kp)
+    crl.revoke(rec)
+    assert crl.is_revoked(MID)
+    assert not crl.is_revoked(MID2)
+
+
+def test_file_crl_get_record(tmp_path):
+    kp = generate_ed25519()
+    crl = FileCRL(tmp_path / "crl.jsonl")
+    rec = sign_revocation(MID, "reason", "admin@example.com", kp)
+    crl.revoke(rec)
+    got = crl.get_record(MID)
+    assert got is not None
+    assert got.manifest_id == MID
+    assert got.reason == "reason"
+    assert got.revoked_by == "admin@example.com"
+
+
+def test_file_crl_all_records(tmp_path):
+    kp = generate_ed25519()
+    crl = FileCRL(tmp_path / "crl.jsonl")
+    crl.revoke(sign_revocation(MID, "r1", "admin", kp))
+    crl.revoke(sign_revocation(MID2, "r2", "admin", kp))
+    recs = crl.all_records()
+    assert len(recs) == 2
+    ids = {r.manifest_id for r in recs}
+    assert ids == {MID, MID2}
+
+
+def test_file_crl_persists_to_disk(tmp_path):
+    kp = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl1 = FileCRL(path)
+    crl1.revoke(sign_revocation(MID, "disk test", "admin", kp))
+
+    crl2 = FileCRL(path)
+    assert crl2.is_revoked(MID)
+    got = crl2.get_record(MID)
+    assert got is not None
+    assert got.reason == "disk test"
+
+
+def test_file_crl_reload_multiple_records(tmp_path):
+    kp = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl1 = FileCRL(path)
+    crl1.revoke(sign_revocation(MID, "r1", "admin", kp))
+    crl1.revoke(sign_revocation(MID2, "r2", "admin", kp))
+
+    crl2 = FileCRL(path)
+    assert len(crl2.all_records()) == 2
+    assert crl2.is_revoked(MID)
+    assert crl2.is_revoked(MID2)
+
+
+def test_file_crl_double_revoke_overwrites_in_memory(tmp_path):
+    kp = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl = FileCRL(path)
+    crl.revoke(sign_revocation(MID, "first reason", "admin", kp))
+    crl.revoke(sign_revocation(MID, "second reason", "admin", kp))
+    assert crl.get_record(MID).reason == "second reason"
+    assert len(crl.all_records()) == 1
+
+
+def test_file_crl_signature_survives_roundtrip(tmp_path):
+    kp = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl1 = FileCRL(path)
+    rec = sign_revocation(MID, "sig test", "admin", kp)
+    crl1.revoke(rec)
+
+    crl2 = FileCRL(path)
+    loaded = crl2.get_record(MID)
+    assert loaded is not None
+    verify_revocation_signature(loaded, kp.public_bytes)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# FastAPI CRL router
+# ---------------------------------------------------------------------------
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
+require_fastapi = pytest.mark.skipif(
+    not FASTAPI_AVAILABLE, reason="fastapi not installed"
+)
+
+
+def _make_client(tmp_path, records=None):
+    kp = generate_ed25519()
+    crl = FileCRL(tmp_path / "crl.jsonl")
+    for mid, reason in (records or []):
+        crl.revoke(sign_revocation(mid, reason, "admin", kp))
+    app = FastAPI()
+    app.include_router(create_crl_router(crl))
+    return TestClient(app)
+
+
+@require_fastapi
+def test_crl_list_empty(tmp_path):
+    client = _make_client(tmp_path)
+    r = client.get("/.well-known/agent-manifest/revocation")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@require_fastapi
+def test_crl_list_returns_all_records(tmp_path):
+    client = _make_client(tmp_path, [(MID, "r1"), (MID2, "r2")])
+    r = client.get("/.well-known/agent-manifest/revocation")
+    assert r.status_code == 200
+    ids = {rec["manifest_id"] for rec in r.json()}
+    assert ids == {MID, MID2}
+
+
+@require_fastapi
+def test_crl_list_record_has_required_fields(tmp_path):
+    client = _make_client(tmp_path, [(MID, "key compromise")])
+    r = client.get("/.well-known/agent-manifest/revocation")
+    assert r.status_code == 200
+    rec = r.json()[0]
+    assert "manifest_id" in rec
+    assert "reason" in rec
+    assert "revoked_at" in rec
+    assert "revoked_by" in rec
+    assert "revocation_signature" in rec
+    assert "signer_key_id" in rec
+
+
+@require_fastapi
+def test_crl_get_record_found(tmp_path):
+    client = _make_client(tmp_path, [(MID, "key compromise")])
+    r = client.get(f"/.well-known/agent-manifest/revocation/{MID}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["manifest_id"] == MID
+    assert body["reason"] == "key compromise"
+
+
+@require_fastapi
+def test_crl_get_record_not_found(tmp_path):
+    client = _make_client(tmp_path)
+    r = client.get(f"/.well-known/agent-manifest/revocation/{MID}")
+    assert r.status_code == 404
+    assert r.json()["detail"]["error_code"] == "NOT_REVOKED"
+
+
+@require_fastapi
+def test_crl_get_record_not_found_message_contains_id(tmp_path):
+    client = _make_client(tmp_path)
+    r = client.get(f"/.well-known/agent-manifest/revocation/{MID}")
+    assert MID in r.json()["detail"]["error_message"]
+
+
+@require_fastapi
+def test_crl_get_one_does_not_match_another(tmp_path):
+    client = _make_client(tmp_path, [(MID, "revoked"), (MID2, "also revoked")])
+    r = client.get(f"/.well-known/agent-manifest/revocation/{MID}")
+    assert r.status_code == 200
+    assert r.json()["manifest_id"] == MID
+    assert r.json()["manifest_id"] != MID2
+
+
+@require_fastapi
+def test_crl_router_missing_fastapi(monkeypatch):
+    import builtins
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "fastapi":
+            raise ImportError("fastapi not installed")
+        return original_import(name, *args, **kwargs)
+
+    kp = generate_ed25519()
+    crl = FileCRL(Path("/tmp/unused.jsonl"))
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+    with pytest.raises(ImportError, match="FastAPI"):
+        create_crl_router(crl)

--- a/python/tests/test_revocation.py
+++ b/python/tests/test_revocation.py
@@ -301,7 +301,6 @@ def test_crl_router_missing_fastapi(monkeypatch):
             raise ImportError("fastapi not installed")
         return original_import(name, *args, **kwargs)
 
-    kp = generate_ed25519()
     crl = FileCRL(Path("/tmp/unused.jsonl"))
     monkeypatch.setattr(builtins, "__import__", mock_import)
     with pytest.raises(ImportError, match="FastAPI"):


### PR DESCRIPTION
## Summary

- **`_revocation.py`** (0% → ~100%): unit tests for `sign_revocation` and `verify_revocation_signature` (round-trip, tampered manifest ID, tampered reason, wrong key rejection, missing signature); `FileCRL` via `tmp_path` (revoke, persist-to-disk, reload, double-revoke, signature survives round-trip); FastAPI CRL router via `TestClient` (list empty, list populated, get found, get 404 with correct error code, missing fastapi ImportError path)
- **`_hw_providers.py`** (0% → ~85% on Linux CI): initialization failures via `os.path.exists` monkeypatch; `get_attestation_report()` before extend raises; `verify_manifest_in_report` (pure Python, no mock); `SEVSNPProvider` and `TDXProvider` `extend_manifest_hash` with mocked `fcntl.ioctl` + `builtins.open` (Linux-gated — fcntl unavailable on macOS/Windows); `OPAQUEProvider` with mocked `httpx.post` (all platforms) covering auth header, pre-image encoding, URL trailing-slash stripping, 401/503 error propagation

Hardware integration tests are gated by `NEEDS_SEV_SNP`, `NEEDS_TDX`, `NEEDS_OPAQUE` skipif markers and will not run in CI unless those devices/env vars are present.

Expected coverage after merge: ~86% (up from 74.58%), clearing the 80% threshold.

## Test plan

- [ ] All 278 existing tests continue to pass
- [ ] `test_revocation.py` — all tests pass (no hardware or network required)
- [ ] `test_hw_providers.py` — init/verify/OPAQUE tests pass on all platforms; ioctl tests pass on Linux CI, skipped on macOS/Windows
- [ ] Coverage threshold check passes (`--cov-fail-under=80`)
- [ ] mypy and ruff clean on new test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)