### PR TITLE
docs(tutorials): add six tutorials covering core SDK features

### DIFF
--- a/docs/tutorials/delegation-chains.md
+++ b/docs/tutorials/delegation-chains.md
@@ -1,0 +1,258 @@
+# A2A delegation chains
+
+Agent-to-agent (A2A) delegation lets a root issuer grant a sub-agent a **scoped subset** of its permissions — cryptographically bound and verifiable at every hop. After completing this tutorial you will be able to:
+
+- Build a two-hop delegation chain: root issuer → delegate → sub-delegate
+- Sign each hop with the delegating principal's key
+- Verify the full chain and detect scope laundering
+- Understand what the verifier rejects at each failure mode
+
+## Prerequisites
+
+```bash
+pip install "agent-manifest[cli]"
+```
+
+## Conceptual model
+
+```
+Root issuer (tools: [search, summarize, write])
+  └─ Delegate agent (tools: [search, summarize])   ← hop 0: scope narrowed
+       └─ Sub-delegate agent (tools: [search])      ← hop 1: narrowed again
+```
+
+Each hop is signed by the **delegating** principal. The sub-agent cannot claim tools the parent did not grant — the verifier enforces this at every hop.
+
+---
+
+## Step 1: Generate keypairs for each principal
+
+```python
+from agent_manifest import generate_ed25519
+
+root_kp = generate_ed25519()        # root issuer
+delegate_kp = generate_ed25519()    # delegate agent
+sub_kp = generate_ed25519()         # sub-delegate agent
+```
+
+---
+
+## Step 2: Build the root manifest
+
+The root manifest declares the full scope the issuer authorises.
+
+```python
+from agent_manifest import Manifest, ArtifactBindings, CryptoProfile
+from agent_manifest._types import ManifestId
+from agent_manifest._signing import Ed25519Signer
+from agent_manifest._delegation import DelegationHopSigner
+from datetime import datetime, timedelta, timezone
+import base64
+
+now = datetime.now(timezone.utc)
+
+root_manifest = Manifest(
+    manifest_id=str(ManifestId.generate()),
+    agent_id="spiffe://trust.example/agent/orchestrator",
+    version="0.1",
+    issued_at=now,
+    expires_at=now + timedelta(hours=8),
+    issuer="spiffe://trust.example/signing-authority",
+    crypto_profile=CryptoProfile.standard,
+    artifacts=ArtifactBindings(),
+    # No delegation_chain on the root — it IS the root
+    delegation_chain=[],
+)
+
+signer = Ed25519Signer(root_kp)
+signed_root = signer.sign(root_manifest.model_dump(mode="json"))
+```
+
+---
+
+## Step 3: Build the delegate hop
+
+The delegate agent creates a manifest that references the root manifest and adds a delegation hop signed by the **root issuer**.
+
+```python
+from agent_manifest._delegation import DelegationHopSigner
+
+hop_signer = DelegationHopSigner(keypair=root_kp)
+
+delegate_manifest_id = str(ManifestId.generate())
+
+# The root issuer signs hop 0 — granting a subset of its tools
+hop0_scope = {
+    "tools": ["search", "summarize"],          # subset of root's [search, summarize, write]
+    "data_classifications": ["public", "internal"],
+    "max_delegation_depth": 2,
+    "approval_required": False,
+}
+
+hop0_sig = hop_signer.sign_hop(
+    hop=0,
+    principal_id="spiffe://trust.example/agent/orchestrator",
+    principal_type="agent",
+    delegated_at=now.isoformat(),
+    scope_grant=hop0_scope,
+    manifest_id=delegate_manifest_id,
+)
+
+delegate_manifest = Manifest(
+    manifest_id=delegate_manifest_id,
+    agent_id="spiffe://trust.example/agent/researcher",
+    version="0.1",
+    issued_at=now,
+    expires_at=now + timedelta(hours=8),
+    issuer="spiffe://trust.example/signing-authority",
+    crypto_profile=CryptoProfile.standard,
+    artifacts=ArtifactBindings(),
+    delegation_chain=[{
+        "hop": 0,
+        "principal_id": "spiffe://trust.example/agent/orchestrator",
+        "principal_type": "agent",
+        "delegated_at": now.isoformat(),
+        "scope_grant": hop0_scope,
+        "delegation_signature": hop0_sig,
+    }],
+)
+
+delegate_signer = Ed25519Signer(delegate_kp)
+signed_delegate = delegate_signer.sign(delegate_manifest.model_dump(mode="json"))
+```
+
+---
+
+## Step 4: Build the sub-delegate hop
+
+The sub-delegate's manifest adds a second hop signed by the **delegate agent** — again narrowing the scope.
+
+```python
+sub_manifest_id = str(ManifestId.generate())
+
+# The delegate agent signs hop 1 — granting only [search] from its [search, summarize]
+hop1_scope = {
+    "tools": ["search"],                        # subset of delegate's [search, summarize]
+    "data_classifications": ["public"],         # narrowed from ["public", "internal"]
+    "max_delegation_depth": 2,
+    "approval_required": False,
+}
+
+delegate_hop_signer = DelegationHopSigner(keypair=delegate_kp)
+hop1_sig = delegate_hop_signer.sign_hop(
+    hop=1,
+    principal_id="spiffe://trust.example/agent/researcher",
+    principal_type="agent",
+    delegated_at=now.isoformat(),
+    scope_grant=hop1_scope,
+    manifest_id=sub_manifest_id,
+)
+
+sub_manifest = Manifest(
+    manifest_id=sub_manifest_id,
+    agent_id="spiffe://trust.example/agent/data-fetcher",
+    version="0.1",
+    issued_at=now,
+    expires_at=now + timedelta(hours=8),
+    issuer="spiffe://trust.example/signing-authority",
+    crypto_profile=CryptoProfile.standard,
+    artifacts=ArtifactBindings(),
+    delegation_chain=[
+        # Carry the full chain forward
+        {
+            "hop": 0,
+            "principal_id": "spiffe://trust.example/agent/orchestrator",
+            "principal_type": "agent",
+            "delegated_at": now.isoformat(),
+            "scope_grant": hop0_scope,
+            "delegation_signature": hop0_sig,
+        },
+        {
+            "hop": 1,
+            "principal_id": "spiffe://trust.example/agent/researcher",
+            "principal_type": "agent",
+            "delegated_at": now.isoformat(),
+            "scope_grant": hop1_scope,
+            "delegation_signature": hop1_sig,
+        },
+    ],
+)
+
+sub_signer = Ed25519Signer(sub_kp)
+signed_sub = sub_signer.sign(sub_manifest.model_dump(mode="json"))
+```
+
+---
+
+## Step 5: Verify the chain
+
+```python
+from agent_manifest._delegation import verify_delegation_chain
+
+# Build a registry of public keys for all principals in the chain
+public_keys = {
+    "spiffe://trust.example/agent/orchestrator": root_kp.public_bytes,
+    "spiffe://trust.example/agent/researcher":   delegate_kp.public_bytes,
+}
+
+# Verify the sub-delegate's chain
+verify_delegation_chain(
+    delegation_chain=signed_sub["delegation_chain"],
+    public_keys=public_keys,
+    manifest_id=sub_manifest_id,
+)
+print("Chain valid")  # reaches here only if all signatures and scopes check out
+```
+
+`verify_delegation_chain` raises on the first failure:
+
+| Error | Cause |
+|-------|-------|
+| `InvalidSignature` | A hop signature is invalid |
+| `ValueError: Scope laundering` | Child claims tools or data classes not granted by parent |
+| `ValueError: depth exceeded` | Chain is deeper than `max_delegation_depth` on hop 0 |
+| `ValueError: wrong hop index` | Hops are not sequential (0, 1, 2, …) |
+
+---
+
+## Failure modes
+
+### Scope laundering (rejected)
+
+```python
+# Attacker tries to claim "write" which was never granted past hop 0
+bad_scope = {
+    "tools": ["search", "write"],   # "write" is NOT in hop 0's grant
+    "max_delegation_depth": 2,
+}
+bad_sig = delegate_hop_signer.sign_hop(
+    hop=1, principal_id="...", principal_type="agent",
+    delegated_at=now.isoformat(), scope_grant=bad_scope,
+    manifest_id=sub_manifest_id,
+)
+# verify_delegation_chain raises:
+# ValueError: Scope laundering at hop 1: child claims tools {'write'} not granted by parent
+```
+
+### Depth exceeded (rejected)
+
+```python
+# Root grants max_delegation_depth=1 but chain has 2 hops
+# verify_delegation_chain raises:
+# ValueError: Delegation chain depth 2 exceeds root max_delegation_depth 1
+```
+
+### Wrong key (rejected)
+
+```python
+# Attacker signs hop 0 with their own key, not the root issuer's key
+# verify_delegation_chain raises: InvalidSignature
+```
+
+---
+
+## What's next
+
+- [Tutorial: Server-side verification](server-side-verification.md) — verify delegation chains at the relying party
+- [Tutorial: HITL approval workflows](hitl-approvals.md) — require human sign-off within a delegation chain
+- [Example: A2A delegation chain manifests](../examples/delegation-chain/README.md)

--- a/docs/tutorials/deploy-verifier.md
+++ b/docs/tutorials/deploy-verifier.md
@@ -1,0 +1,270 @@
+# Deploying the verification endpoint
+
+The agent-manifest SDK ships a FastAPI router that you can deploy as a standalone verification service, a sidecar, or embedded in an existing API. After this tutorial you will be able to:
+
+- Package the verifier as a Docker container
+- Configure the manifest store and CRL
+- Expose the `.well-known` discovery endpoint
+- Add health checks and readiness probes
+- Run the complete stack with docker-compose
+
+## Prerequisites
+
+```bash
+pip install "agent-manifest[server]"
+```
+
+---
+
+## Architecture choices
+
+| Deployment mode | When to use |
+|-----------------|-------------|
+| **Sidecar** | Each agent service runs its own verifier alongside it — simplest, no network hop |
+| **Centralized service** | Shared verifier for a fleet — single manifest store, easier CRL management |
+| **Embedded** | Verifier mounted directly in the main application's FastAPI app — fewest moving parts |
+
+This tutorial uses the **embedded** pattern (fewest dependencies) but the Docker and config sections apply to all modes.
+
+---
+
+## Step 1: The application
+
+```python
+# app.py
+import json
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from agent_manifest._verify import RevocationStore, create_router
+from agent_manifest._revocation import FileCRL, create_crl_router
+
+# ── Config ─────────────────────────────────────────────────────────────────
+MANIFEST_DIR = Path("/data/manifests")
+CRL_PATH     = Path("/data/crl.jsonl")
+
+# ── Startup ────────────────────────────────────────────────────────────────
+manifest_store: dict[str, dict] = {}
+revocation_store = RevocationStore()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Load all manifests from disk at startup
+    for path in MANIFEST_DIR.glob("*.json"):
+        m = json.loads(path.read_text())
+        manifest_store[m["manifest_id"]] = m
+
+    # Load the CRL into the revocation store
+    crl = FileCRL(CRL_PATH)
+    for rec in crl.all_records():
+        from agent_manifest._verify import RevocationRecord
+        revocation_store.revoke(RevocationRecord(
+            manifest_id=rec.manifest_id,
+            revoked_at=rec.revoked_at,
+            reason=rec.reason,
+            revoked_by=rec.revoked_by,
+        ))
+
+    yield
+
+app = FastAPI(title="Agent Manifest Verifier", lifespan=lifespan)
+
+# ── Routes ─────────────────────────────────────────────────────────────────
+
+# Verification endpoints: GET /agent/verify, GET /agent/revocation-status
+app.include_router(create_router(manifest_store, revocation_store), prefix="/agent")
+
+# CRL discovery endpoints: GET /.well-known/agent-manifest/revocation[/{id}]
+crl_live = FileCRL(CRL_PATH)
+app.include_router(create_crl_router(crl_live))
+
+# ── Health ─────────────────────────────────────────────────────────────────
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok", "manifests": len(manifest_store)}
+
+@app.get("/readyz")
+def readyz():
+    if not manifest_store:
+        return {"status": "no manifests loaded"}, 503
+    return {"status": "ready"}
+```
+
+---
+
+## Step 2: Dockerfile
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir "agent-manifest[server]" uvicorn[standard]
+
+COPY app.py .
+
+# Manifest store and CRL live in /data — mount as a volume
+RUN mkdir /data
+
+EXPOSE 8080
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+```bash
+docker build -t agent-manifest-verifier .
+```
+
+---
+
+## Step 3: docker-compose
+
+```yaml
+# docker-compose.yml
+services:
+  verifier:
+    image: agent-manifest-verifier
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./manifests:/data/manifests:ro   # manifest JSON files
+      - ./crl.jsonl:/data/crl.jsonl      # CRL file (writable)
+    environment:
+      UVICORN_WORKERS: "2"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Example: an agent service that verifies itself at startup
+  kyc-agent:
+    image: your-kyc-agent:latest
+    environment:
+      VERIFIER_URL: "http://verifier:8080"
+      MANIFEST_ID:  "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+    depends_on:
+      verifier:
+        condition: service_healthy
+```
+
+```bash
+docker-compose up
+
+# Verify the kyc-agent manifest
+curl "http://localhost:8080/agent/verify?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+# Browse the CRL
+curl "http://localhost:8080/.well-known/agent-manifest/revocation"
+```
+
+---
+
+## Step 4: Environment variable configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MANIFEST_DIR` | `/data/manifests` | Directory containing manifest JSON files |
+| `CRL_PATH` | `/data/crl.jsonl` | Path to the CRL JSON-Lines file |
+| `UVICORN_WORKERS` | `1` | Number of uvicorn worker processes |
+| `UVICORN_LOG_LEVEL` | `info` | Logging level |
+
+Update `app.py` to read these from the environment:
+
+```python
+import os
+
+MANIFEST_DIR = Path(os.getenv("MANIFEST_DIR", "/data/manifests"))
+CRL_PATH     = Path(os.getenv("CRL_PATH", "/data/crl.jsonl"))
+```
+
+---
+
+## Step 5: Kubernetes deployment
+
+```yaml
+# k8s/verifier-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-manifest-verifier
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: agent-manifest-verifier
+  template:
+    metadata:
+      labels:
+        app: agent-manifest-verifier
+    spec:
+      containers:
+        - name: verifier
+          image: agent-manifest-verifier:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: MANIFEST_DIR
+              value: /data/manifests
+            - name: CRL_PATH
+              value: /data/crl.jsonl
+          volumeMounts:
+            - name: manifests
+              mountPath: /data/manifests
+              readOnly: true
+            - name: crl
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+      volumes:
+        - name: manifests
+          configMap:
+            name: agent-manifests
+        - name: crl
+          persistentVolumeClaim:
+            claimName: crl-pvc
+```
+
+---
+
+## Step 6: Hot-reloading manifests
+
+The startup `lifespan` loads manifests once. In production you will add new agents without restarting. Two approaches:
+
+**Option A: Reload endpoint** (simplest)
+
+```python
+@app.post("/admin/reload", include_in_schema=False)
+async def reload_manifests():
+    manifest_store.clear()
+    for path in MANIFEST_DIR.glob("*.json"):
+        m = json.loads(path.read_text())
+        manifest_store[m["manifest_id"]] = m
+    return {"loaded": len(manifest_store)}
+```
+
+Protect this endpoint with network policy or an API key.
+
+**Option B: Shared database** (recommended for fleets)
+
+Replace `manifest_store: dict` with a database-backed store. On each request the verifier reads from the database — no reload needed, and multiple replicas stay consistent.
+
+---
+
+## What's next
+
+- [Tutorial: Revocation and key rotation](revocation.md) — update the CRL in the running verifier
+- [Operations: Monitoring the verification endpoint](../operations/monitoring.md) — metrics and alerting
+- [Operations: Key rotation runbook](../operations/key-rotation.md)

--- a/docs/tutorials/hardware-attestation.md
+++ b/docs/tutorials/hardware-attestation.md
@@ -1,0 +1,233 @@
+# Hardware attestation (SEV-SNP, TDX, OPAQUE)
+
+Hardware attestation binds the manifest to a cryptographic measurement from silicon — proving the agent is running inside a specific, unmodified trusted execution environment. After this tutorial you will be able to:
+
+- Choose the right provider for your infrastructure
+- Extend the manifest hash into hardware (SEV-SNP, TDX, OPAQUE)
+- Read and verify the attestation report
+- Use the auto-provider when the environment is unknown at build time
+
+## Prerequisites
+
+```bash
+pip install agent-manifest              # for OPAQUE (HTTP only)
+pip install "agent-manifest[server]"    # adds httpx for OPAQUE
+```
+
+Hardware providers require the appropriate VM type — see the table below.
+
+---
+
+## Conformance levels and providers
+
+| Level | Provider | Infrastructure |
+|-------|----------|---------------|
+| 0 | *(none — software signing only)* | Any |
+| 1 | `TPMProvider` | Linux host with TPM 2.0 |
+| 2 | `SEVSNPProvider` | AMD EPYC (Milan+): Azure DCasv5, AWS C6a Nitro, GCP N2D |
+| 2 | `TDXProvider` | Intel Xeon (Sapphire Rapids+): Azure DCedsv5, GCP C3 |
+| 3 | `OPAQUEProvider` | Any — delegates to OPAQUE's managed TEE |
+
+Level 2 provides the strongest locally-verifiable hardware guarantee. Level 3 adds an audit chain signed inside the TEE by OPAQUE's infrastructure.
+
+---
+
+## AMD SEV-SNP (Level 2)
+
+### Requirements
+
+- AMD EPYC Milan or Genoa CPU with SEV-SNP enabled in BIOS
+- Linux kernel 5.19+ with `CONFIG_AMD_MEM_ENCRYPT=y`
+- Running inside an SEV-SNP VM
+- `/dev/sev-guest` readable by the process (typically requires `CAP_SYS_ADMIN` or a udev rule)
+
+### Usage
+
+```python
+import json
+from agent_manifest._hw_providers import SEVSNPProvider
+from agent_manifest._providers import AttestationUnavailableError
+
+try:
+    provider = SEVSNPProvider()
+except AttestationUnavailableError as e:
+    print(f"SEV-SNP not available: {e}")
+    raise SystemExit(1)
+
+# Load the manifest you want to attest
+with open("manifest.json") as f:
+    manifest = json.load(f)
+
+# Extends SHA-256(manifest_pre_image) into HOST_DATA
+provider.extend_manifest_hash(manifest)
+
+# Read the hardware attestation report
+report = provider.get_attestation_report()
+print(f"Platform:      {report.platform}")          # "amd-sev-snp"
+print(f"Manifest hash: {report.manifest_hash}")     # "sha256:..."
+print(f"Measurement:   {report.raw['measurement']}")  # 48-byte PCR hex
+
+# Confirm the report binds to this manifest
+assert provider.verify_manifest_in_report(report, manifest)
+```
+
+### What is in the report
+
+| Field | Description |
+|-------|-------------|
+| `raw.host_data` | 64 bytes: first 32 = SHA-256 of manifest pre-image, last 32 = zeros |
+| `raw.measurement` | 48-byte platform measurement (covers firmware + kernel) |
+| `raw.vmpl` | VMPL level (0 = highest privilege) |
+
+---
+
+## Intel TDX (Level 2)
+
+### Requirements
+
+- Intel 4th Gen Xeon (Sapphire Rapids) or later with TDX enabled
+- Linux kernel 6.2+ with TDX guest driver (`/dev/tdx-guest`)
+- Running inside an Intel TDX Trust Domain
+
+### Usage
+
+```python
+from agent_manifest._hw_providers import TDXProvider
+
+# rtmr_index=1 is the conventional application measurement register
+provider = TDXProvider(rtmr_index=1)
+
+provider.extend_manifest_hash(manifest)
+report = provider.get_attestation_report()
+
+print(f"Platform:    {report.platform}")        # "intel-tdx"
+print(f"RTMR index:  {report.raw['rtmr_index']}")  # 1
+print(f"Report data: {report.raw['report_data']}")  # 64-byte hex
+
+assert provider.verify_manifest_in_report(report, manifest)
+```
+
+### RTMR index guidance
+
+| RTMR | Conventional use |
+|------|-----------------|
+| 0 | TD-measured (firmware and boot) — do not use |
+| 1 | OS and application-level measurements — use this |
+| 2 | Available for software use |
+| 3 | Available for software use |
+
+---
+
+## OPAQUE managed runtime (Level 3)
+
+OPAQUE runs the attestation inside its own TEE and returns a signed TRACE claim. No local hardware is required — OPAQUE handles the silicon-level measurement on your behalf.
+
+### Requirements
+
+- `OPAQUE_ATTESTATION_URL` environment variable pointing to the OPAQUE attestation service
+- Optionally `OPAQUE_API_KEY` for authenticated access
+- `httpx` installed (`pip install "agent-manifest[server]"`)
+
+### Usage
+
+```python
+import os
+from agent_manifest._hw_providers import OPAQUEProvider
+
+os.environ["OPAQUE_ATTESTATION_URL"] = "https://attest.opaque.co"
+# os.environ["OPAQUE_API_KEY"] = "your-key"   # if required
+
+provider = OPAQUEProvider()
+provider.extend_manifest_hash(manifest)
+
+report = provider.get_attestation_report()
+print(f"Platform: {report.platform}")   # "opaque"
+print(f"Manifest hash: {report.manifest_hash}")
+print(f"TRACE claim: {report.raw}")     # eat_profile, iat, audit_chain_root, ...
+
+assert provider.verify_manifest_in_report(report, manifest)
+```
+
+### What the TRACE claim contains
+
+```json
+{
+  "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
+  "iat": 1749120000,
+  "manifest_hash": "sha256:e3b0c44...",
+  "audit_chain_root": "sha256:a1b2c3...",
+  "tee_platform": "amd-sev-snp",
+  "attestation_report_hash": "sha256:..."
+}
+```
+
+The `audit_chain_root` anchors every decision the agent made to a Merkle chain held inside the OPAQUE TEE — this is the Level 3 guarantee.
+
+---
+
+## Auto-provider: pick the best available hardware
+
+Use `_auto_provider.py` when the environment is not known at build time — it tries each provider in order and falls back to software-only.
+
+```python
+from agent_manifest._auto_provider import SoftwareProvider
+
+# Falls back gracefully: OPAQUE → TDX → SEV-SNP → TPM → software
+provider = SoftwareProvider()
+provider.extend_manifest_hash(manifest)
+report = provider.get_attestation_report()
+
+print(f"Attested on: {report.platform}")
+# "amd-sev-snp" in an SEV-SNP VM
+# "intel-tdx"   in a TDX Trust Domain
+# "tpm"         on a Linux host with TPM
+# "software"    everywhere else
+```
+
+---
+
+## Testing without hardware
+
+All providers raise `AttestationUnavailableError` if the hardware is absent. In tests, mock the provider:
+
+```python
+from unittest.mock import patch, MagicMock
+from agent_manifest._providers import AttestationReport
+
+mock_report = AttestationReport(
+    platform="amd-sev-snp",
+    manifest_hash="sha256:" + "aa" * 32,
+    raw={"measurement": "bb" * 48, "host_data": "cc" * 64, "vmpl": 0},
+)
+
+with patch("agent_manifest._hw_providers.SEVSNPProvider.extend_manifest_hash"), \
+     patch("agent_manifest._hw_providers.SEVSNPProvider.get_attestation_report",
+           return_value=mock_report):
+    # your test code
+    pass
+```
+
+Or gate the test on hardware availability:
+
+```python
+import os, pytest
+
+NEEDS_SEV_SNP = pytest.mark.skipif(
+    not os.path.exists("/dev/sev-guest"),
+    reason="requires AMD SEV-SNP hardware",
+)
+
+@NEEDS_SEV_SNP
+def test_sev_snp_roundtrip():
+    provider = SEVSNPProvider()
+    provider.extend_manifest_hash(manifest)
+    report = provider.get_attestation_report()
+    assert provider.verify_manifest_in_report(report, manifest)
+```
+
+---
+
+## What's next
+
+- [Tutorial: Deploying the verification endpoint](deploy-verifier.md) — run the verifier in production alongside your hardware-attested agents
+- [Tutorial: Server-side verification](server-side-verification.md) — enforce minimum attestation level with `enforce_attestation=True`

--- a/docs/tutorials/hitl-approvals.md
+++ b/docs/tutorials/hitl-approvals.md
@@ -1,0 +1,215 @@
+# HITL approval workflows
+
+Human-in-the-loop (HITL) approval lets an agent record that a human explicitly authorised a high-risk action — and cryptographically binds that approval to the manifest. After this tutorial you will be able to:
+
+- Create a manifest that requires human approval
+- Record a signed approval from a human approver
+- Verify that the approval is present, unexpired, and cryptographically valid
+- Understand what triggers `HITL_MISSING` and `HITL_EXPIRED`
+
+## Prerequisites
+
+```bash
+pip install agent-manifest
+```
+
+## Why sign the approval?
+
+A plain timestamp field can be forged. The HITL approval is signed by the **approver's key** over the canonical form of `{manifest_id, approved_at, approved_scope, approver_id}`. This proves:
+
+1. The named approver actually saw this exact manifest
+2. The approval was given at a specific time
+3. The approval covers a specific scope — not a blank cheque
+
+---
+
+## Step 1: Generate keypairs
+
+```python
+from agent_manifest import generate_ed25519
+
+agent_kp = generate_ed25519()     # the agent's signing key
+approver_kp = generate_ed25519()  # the human approver's key (use FIDO2 in production)
+```
+
+---
+
+## Step 2: Build a manifest that requires approval
+
+Set `hitl_record.required = True` and leave `approvals` empty — the agent will fill this in after getting human sign-off.
+
+```python
+from agent_manifest import Manifest, ArtifactBindings, CryptoProfile
+from agent_manifest._types import ManifestId
+from datetime import datetime, timedelta, timezone
+
+now = datetime.now(timezone.utc)
+manifest_id = str(ManifestId.generate())
+
+manifest = Manifest(
+    manifest_id=manifest_id,
+    agent_id="spiffe://trust.example/agent/trading/prod",
+    version="0.1",
+    issued_at=now,
+    expires_at=now + timedelta(hours=4),
+    issuer="spiffe://trust.example/signing-authority",
+    crypto_profile=CryptoProfile.standard,
+    artifacts=ArtifactBindings(),
+    hitl_record={
+        "required": True,
+        "required_approvals": 1,
+        "approvals": [],          # filled in below
+    },
+)
+```
+
+---
+
+## Step 3: Get human approval and sign it
+
+In production this happens through an approval workflow (Slack bot, web UI, etc.). Here it is expressed as code:
+
+```python
+from agent_manifest._delegation import HitlApprovalSigner
+
+approver = HitlApprovalSigner(keypair=approver_kp)
+approved_at = datetime.now(timezone.utc).isoformat()
+
+approved_scope = {
+    "action": "execute_trade",
+    "max_notional_usd": 500_000,
+    "approval_duration_seconds": 3600,   # approval is valid for 1 hour
+}
+
+approval_sig = approver.sign_approval(
+    manifest_id=manifest_id,
+    approved_at=approved_at,
+    approved_scope=approved_scope,
+    approver_id="spiffe://trust.example/human/alice",
+)
+```
+
+---
+
+## Step 4: Attach the approval to the manifest
+
+```python
+from agent_manifest._signing import Ed25519Signer
+
+manifest.hitl_record["approvals"] = [{
+    "approver_id":          "spiffe://trust.example/human/alice",
+    "approved_at":          approved_at,
+    "approved_scope":       approved_scope,
+    "approval_method":      "hardware_key",
+    "approval_signature":   approval_sig,
+    "approver_key_id":      approver_kp.key_id,
+}]
+
+signer = Ed25519Signer(agent_kp)
+signed_manifest = signer.sign(manifest.model_dump(mode="json"))
+```
+
+---
+
+## Step 5: Verify the approval
+
+```python
+from agent_manifest._delegation import verify_hitl_approval
+
+approval = signed_manifest["hitl_record"]["approvals"][0]
+
+verify_hitl_approval(
+    approval=approval,
+    manifest_id=manifest_id,
+    approver_public_key=approver_kp.public_bytes,
+)
+print("HITL approval is valid")
+```
+
+To verify using the full manifest verifier:
+
+```python
+from agent_manifest._verify import (
+    OverallResult, RevocationStore, VerificationContext, verify_manifest
+)
+
+ctx = VerificationContext(enforce_hitl=True)
+result = verify_manifest(signed_manifest, ctx, RevocationStore())
+
+assert result.fields_verified.hitl_record.value == "APPROVED"
+assert result.result == OverallResult.VALID
+```
+
+---
+
+## Failure modes
+
+### Missing approval (`HITL_MISSING`)
+
+```python
+# Manifest requires HITL but approvals list is empty
+manifest_no_approval = {
+    **signed_manifest,
+    "hitl_record": {"required": True, "required_approvals": 1, "approvals": []},
+}
+ctx = VerificationContext(enforce_hitl=True)
+result = verify_manifest(manifest_no_approval, ctx, RevocationStore())
+# result.fields_verified.hitl_record == HitlResult.MISSING
+# result.result == OverallResult.MISMATCH  (when enforce_hitl=True)
+```
+
+### Expired approval (`HITL_EXPIRED`)
+
+```python
+import time
+
+# The approval_duration_seconds has elapsed
+old_scope = {**approved_scope, "approval_duration_seconds": 1}  # 1 second
+old_approval_sig = approver.sign_approval(
+    manifest_id=manifest_id,
+    approved_at=approved_at,
+    approved_scope=old_scope,
+    approver_id="spiffe://trust.example/human/alice",
+)
+time.sleep(2)
+
+manifest_expired = dict(signed_manifest)
+manifest_expired["hitl_record"]["approvals"][0]["approved_scope"] = old_scope
+manifest_expired["hitl_record"]["approvals"][0]["approval_signature"] = old_approval_sig
+
+result = verify_manifest(manifest_expired, VerificationContext(), RevocationStore())
+# result.fields_verified.hitl_record == HitlResult.EXPIRED
+```
+
+### Tampered approval (signature mismatch)
+
+```python
+from cryptography.exceptions import InvalidSignature
+
+tampered = dict(approval)
+tampered["approved_scope"] = {**approved_scope, "max_notional_usd": 10_000_000}
+
+try:
+    verify_hitl_approval(tampered, manifest_id, approver_kp.public_bytes)
+except InvalidSignature:
+    print("Approval signature invalid — scope was tampered")
+```
+
+---
+
+## Production guidance
+
+| Concern | Recommendation |
+|---------|----------------|
+| Approver key storage | FIDO2 hardware key or HSM — software keys are only for development |
+| Approval UI | Generate the `approved_scope` dict from your UI, sign on the server with the approver's key after authentication |
+| Multiple approvers | Set `required_approvals: 2` and add two entries to `approvals` |
+| Approval duration | Keep short (1–4 hours); for long-running jobs, re-approve rather than extending |
+| Audit | Store each `approval_signature` in your audit log with the approver's public key |
+
+---
+
+## What's next
+
+- [Tutorial: Revocation and key rotation](revocation.md) — revoke a manifest if the approver's key is compromised
+- [Tutorial: Server-side verification](server-side-verification.md) — enforce HITL at the relying party with `enforce_hitl=True`

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,23 @@
+# Tutorials
+
+Step-by-step guides for specific agent-manifest features. Each tutorial is self-contained and includes runnable code.
+
+If you are new to agent-manifest, start with [Getting Started](../getting-started.md) first — it covers creating and signing your first manifest in 15 minutes.
+
+---
+
+## Development
+
+| Tutorial | What you'll build |
+|----------|-------------------|
+| [Server-side manifest verification](server-side-verification.md) | A FastAPI service that verifies incoming agent manifests and gates requests |
+| [A2A delegation chains](delegation-chains.md) | A two-hop delegation chain with scope narrowing and chain verification |
+| [HITL approval workflows](hitl-approvals.md) | A manifest with a cryptographically signed human approval record |
+| [Revocation and key rotation](revocation.md) | A signed revocation record, a live CRL endpoint, and a key rotation procedure |
+| [Hardware attestation](hardware-attestation.md) | Hardware-bound attestation on SEV-SNP, TDX, and OPAQUE |
+
+## Operations
+
+| Tutorial | What you'll build |
+|----------|-------------------|
+| [Deploying the verification endpoint](deploy-verifier.md) | A containerised verifier with health checks, CRL, and Kubernetes deployment |

--- a/docs/tutorials/revocation.md
+++ b/docs/tutorials/revocation.md
@@ -1,0 +1,232 @@
+# Revocation and key rotation
+
+Revocation lets you stop a compromised or decommissioned agent in under a minute. After this tutorial you will be able to:
+
+- Issue a signed revocation record for any manifest
+- Serve a CRL (Certificate Revocation List) at the standard `.well-known` endpoint
+- Configure a verifier to check the CRL before accepting a manifest
+- Execute a zero-downtime key rotation
+
+## Prerequisites
+
+```bash
+pip install "agent-manifest[server]"
+```
+
+---
+
+## How revocation works
+
+Revocation is separate from signing. Anyone with the **revoking authority's key** can revoke a manifest — it does not require the original signing key. Each revocation record is signed over `{manifest_id, revoked_at, reason, revoked_by}` to prevent forgery.
+
+The CRL is an append-only JSON-Lines file. Each line is one `SignedRevocationRecord`. The verifier fetches or reads the CRL at verification time and rejects any manifest whose `manifest_id` appears in it.
+
+---
+
+## Part 1: Revoke a manifest
+
+### Step 1: Issue the revocation
+
+```python
+from agent_manifest._revocation import sign_revocation, verify_revocation_signature, FileCRL
+from agent_manifest import generate_ed25519
+from pathlib import Path
+
+# The revoking authority keypair — store this separately from the signing key
+revocation_kp = generate_ed25519()
+
+# The manifest ID you want to revoke (UUID v7 from your manifest)
+manifest_id = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+record = sign_revocation(
+    manifest_id=manifest_id,
+    reason="key compromise — signing key leaked in CI log",
+    revoked_by="security@example.com",
+    keypair=revocation_kp,
+)
+
+print(f"Revoked {record.manifest_id} at {record.revoked_at}")
+print(f"Signature: {record.revocation_signature[:32]}...")
+```
+
+Or via the CLI:
+
+```bash
+manifest revoke \
+  --manifest-id 018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c \
+  --reason "key compromise" \
+  --revoked-by security@example.com \
+  --key keys/revocation-private.hex \
+  --crl crl.jsonl
+```
+
+### Step 2: Append to the CRL
+
+```python
+crl = FileCRL(Path("crl.jsonl"))
+crl.revoke(record)
+
+# Verify it was written
+assert crl.is_revoked(manifest_id)
+print(f"CRL now contains {len(crl.all_records())} record(s)")
+```
+
+### Step 3: Verify the revocation signature
+
+Before trusting a CRL entry, verify its signature with the revoking authority's public key:
+
+```python
+verify_revocation_signature(record, revocation_kp.public_bytes)
+# Raises cryptography.exceptions.InvalidSignature if tampered
+```
+
+---
+
+## Part 2: Serve the CRL
+
+Stand up the `.well-known/agent-manifest/revocation` endpoint so verifiers can query it.
+
+```python
+from fastapi import FastAPI
+from agent_manifest._revocation import FileCRL, create_crl_router
+from pathlib import Path
+
+crl = FileCRL(Path("crl.jsonl"))
+app = FastAPI()
+app.include_router(create_crl_router(crl))
+```
+
+This mounts:
+
+| Method | Path | Returns |
+|--------|------|---------|
+| `GET` | `/.well-known/agent-manifest/revocation` | All revocation records as JSON array |
+| `GET` | `/.well-known/agent-manifest/revocation/{manifest_id}` | Single record, or 404 if not revoked |
+
+```bash
+# Check if a manifest is revoked
+curl http://localhost:8000/.well-known/agent-manifest/revocation/018f4a3b-...
+# 200 with the revocation record if revoked
+# 404 with {"detail": {"error_code": "NOT_REVOKED", ...}} if clean
+```
+
+---
+
+## Part 3: Verify against the CRL
+
+### In-process (using FileCRL)
+
+```python
+from agent_manifest._verify import RevocationStore, VerificationContext, verify_manifest, OverallResult
+from agent_manifest._revocation import FileCRL
+from pathlib import Path
+import json
+
+# Load the CRL once at startup
+crl = FileCRL(Path("crl.jsonl"))
+
+# Wrap it so the verify engine can query it
+store = RevocationStore()
+for rec in crl.all_records():
+    from agent_manifest._verify import RevocationRecord
+    store.revoke(RevocationRecord(
+        manifest_id=rec.manifest_id,
+        revoked_at=rec.revoked_at,
+        reason=rec.reason,
+        revoked_by=rec.revoked_by,
+    ))
+
+with open("manifest.json") as f:
+    manifest = json.load(f)
+
+result = verify_manifest(manifest, VerificationContext(), store)
+
+if result.result == OverallResult.REVOKED:
+    print("Manifest has been revoked — request blocked")
+elif result.result == OverallResult.VALID:
+    print("Manifest is valid")
+```
+
+---
+
+## Part 4: Key rotation
+
+Use this procedure when a signing key is compromised, expiring, or changing ownership.
+
+### Step 1: Generate the new keypair
+
+```python
+new_kp = generate_ed25519()
+# Save new_kp.private_hex and new_kp.public_hex securely
+```
+
+Or via CLI:
+```bash
+manifest keygen -d keys/new/
+```
+
+### Step 2: Re-sign all active manifests with the new key
+
+```python
+import json
+from agent_manifest._signing import Ed25519Signer
+from pathlib import Path
+
+signer = Ed25519Signer(new_kp)
+
+for manifest_path in Path("manifests/").glob("*.json"):
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    # Strip the old signature before re-signing
+    manifest.pop("signature", None)
+    resigned = signer.sign(manifest)
+
+    with open(manifest_path, "w") as f:
+        json.dump(resigned, f, indent=2)
+```
+
+### Step 3: Revoke every manifest signed by the old key
+
+```python
+old_key_manifests = [
+    "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+    "018aaaaa-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+]
+
+for mid in old_key_manifests:
+    rec = sign_revocation(
+        manifest_id=mid,
+        reason="key rotation — old signing key decommissioned",
+        revoked_by="security@example.com",
+        keypair=revocation_kp,
+    )
+    crl.revoke(rec)
+```
+
+### Step 4: Overlap window
+
+Verifiers that cached the old manifests will see them as revoked and request a fresh one. Run both keys in parallel for 5 minutes if you need zero downtime, then decommission the old private key.
+
+### Step 5: Decommission the old key
+
+Delete or shred the old private key material. Audit the deletion.
+
+---
+
+## Overlap timing reference
+
+```
+t=0   Generate new key, begin re-signing manifests
+t=2m  New manifests deployed to agents
+t=5m  Revoke old manifests in CRL
+t=7m  Old key is no longer accepted by any verifier
+t=10m Decommission old private key
+```
+
+---
+
+## What's next
+
+- [Tutorial: Deploying the verification endpoint](deploy-verifier.md) — host the CRL and verify endpoints in production
+- [Operations: Key rotation runbook](../operations/key-rotation.md) — step-by-step runbook for incident response

--- a/docs/tutorials/server-side-verification.md
+++ b/docs/tutorials/server-side-verification.md
@@ -1,0 +1,266 @@
+# Server-side manifest verification
+
+This tutorial covers the **relying-party side**: the service that receives requests from agents and needs to decide whether to trust them. After completing it you will be able to:
+
+- Verify an agent manifest programmatically in any Python service
+- Mount a FastAPI verification router that exposes `/verify` and `/revocation-status` endpoints
+- Gate requests with HTTP middleware using the manifest result
+- Understand every field of `VerificationResult` and what to act on
+
+## Prerequisites
+
+```bash
+pip install "agent-manifest[server]"
+```
+
+This installs the SDK plus FastAPI and its dependencies.
+
+## How verification works
+
+The verifier checks six things in order, stopping at the first failure:
+
+1. **Revocation** — is this manifest ID in the revocation list?
+2. **Expiry** — is `expires_at` in the past?
+3. **Artifact hashes** — do the hashes in the manifest match what is actually running?
+4. **Delegation chain** — is every hop in the chain signed by its parent?
+5. **HITL record** — if human approval was required, is a valid one present?
+6. **Attestation** — if `enforce_attestation=True`, was hardware attestation verified?
+
+The result is a `VerificationResult` with an `OverallResult` enum and per-field detail.
+
+---
+
+## Pattern 1: Programmatic verification
+
+Use this when you control the call site and want to act on the result in code.
+
+```python
+import json
+from agent_manifest._verify import (
+    OverallResult,
+    RevocationStore,
+    VerificationContext,
+    verify_manifest,
+)
+
+# Build once at startup — share across requests
+revocation_store = RevocationStore()
+
+def check_agent(manifest_path: str) -> None:
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    ctx = VerificationContext()          # default: no enforcement overrides
+    result = verify_manifest(manifest, ctx, revocation_store)
+
+    if result.result == OverallResult.VALID:
+        print(f"[VALID] {result.manifest_id} verified at {result.verified_at}")
+    elif result.result == OverallResult.REVOKED:
+        raise PermissionError(f"Manifest {result.manifest_id} has been revoked")
+    elif result.result == OverallResult.EXPIRED:
+        raise PermissionError("Manifest has expired — agent must re-issue")
+    elif result.result == OverallResult.MISMATCH:
+        # Show which artifacts have drifted
+        for d in result.mismatch_details:
+            print(f"  [MISMATCH] {d.field}: expected {d.expected_hash}, got {d.actual_hash}")
+        raise PermissionError("Artifact integrity check failed")
+    else:
+        raise PermissionError(f"Verification failed: {result.result}")
+```
+
+### Supplying runtime artifact hashes
+
+If you have access to the agent's running artifacts, pass them in `VerificationContext`. The verifier compares these against the hashes in the manifest.
+
+```python
+import hashlib
+
+with open("system_prompt.txt") as f:
+    prompt_text = f.read()
+
+ctx = VerificationContext(
+    system_prompt_hash="sha256:" + hashlib.sha256(prompt_text.encode()).hexdigest(),
+    model_version="gpt-4o-2024-08-06",   # or a content hash for local models
+    tool_catalog_hash="sha256:e3b0c44...",
+)
+result = verify_manifest(manifest, ctx, revocation_store)
+```
+
+Fields that are `None` in the context are skipped — `FieldResult.NOT_BOUND` is returned for them, not a mismatch.
+
+### Enforcement flags
+
+```python
+ctx = VerificationContext(
+    enforce_hitl=True,         # MISMATCH if hitl_record is required but missing
+    enforce_attestation=True,  # ATTESTATION_UNAVAILABLE if no hardware attestation
+    min_slsa_level=2,          # reserved for future SLSA gate
+)
+```
+
+---
+
+## Pattern 2: FastAPI router
+
+Use this when you want to expose verification as an HTTP service — for example, a sidecar that other services can query.
+
+```python
+from fastapi import FastAPI
+from agent_manifest._verify import RevocationStore, create_router
+
+# Load manifests from your store at startup
+manifest_store: dict[str, dict] = {}
+
+with open("kyc-agent-manifest.json") as f:
+    import json
+    m = json.load(f)
+    manifest_store[m["manifest_id"]] = m
+
+revocation_store = RevocationStore()
+
+app = FastAPI()
+app.include_router(create_router(manifest_store, revocation_store), prefix="/agent")
+```
+
+This mounts two endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/agent/verify?manifest_id=<id>` | Returns a `VerificationResult` |
+| `GET` | `/agent/revocation-status?manifest_id=<id>` | Returns the revocation record or 404 |
+
+**Verify a manifest:**
+
+```bash
+curl "http://localhost:8000/agent/verify?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+```
+
+```json
+{
+  "verification_id": "a1b2c3d4-...",
+  "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+  "verified_at": "2026-06-05T12:00:00Z",
+  "result": "VALID",
+  "attestation_verified": false,
+  "fields_verified": {
+    "system_prompt": "NOT_BOUND",
+    "policy_bundle": "NOT_BOUND",
+    "tool_manifest": "NOT_BOUND",
+    "model_identity": "NOT_BOUND",
+    "rag_corpus": "NOT_BOUND",
+    "memory_baseline": "NOT_BOUND",
+    "decision_trace": "NOT_BOUND",
+    "supply_chain": "NOT_BOUND",
+    "delegation_chain": "NOT_PRESENT",
+    "hitl_record": "NOT_REQUIRED"
+  },
+  "mismatch_details": [],
+  "evidence_pack": null,
+  "verification_signature": null
+}
+```
+
+**Enforce HITL and attestation via query params:**
+
+```bash
+curl "http://localhost:8000/agent/verify?manifest_id=<id>&enforce_hitl=true&enforce_attestation=true"
+```
+
+---
+
+## Pattern 3: HTTP middleware
+
+Use this to gate every inbound request — the agent attaches its manifest ID in a header and the middleware verifies it before routing to your handler.
+
+```python
+import json
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from agent_manifest._verify import (
+    OverallResult,
+    RevocationStore,
+    VerificationContext,
+    verify_manifest,
+)
+
+app = FastAPI()
+manifest_store: dict[str, dict] = {}
+revocation_store = RevocationStore()
+
+MANIFEST_ID_HEADER = "x-agent-manifest-id"
+
+@app.middleware("http")
+async def verify_agent_manifest(request: Request, call_next):
+    manifest_id = request.headers.get(MANIFEST_ID_HEADER)
+    if manifest_id:
+        manifest = manifest_store.get(manifest_id)
+        if manifest is None:
+            return JSONResponse(
+                status_code=403,
+                content={"detail": f"Unknown manifest: {manifest_id}"},
+            )
+        ctx = VerificationContext()
+        result = verify_manifest(manifest, ctx, revocation_store)
+        if result.result != OverallResult.VALID:
+            return JSONResponse(
+                status_code=403,
+                content={"detail": result.result, "mismatch_details": [
+                    d.model_dump() for d in result.mismatch_details
+                ]},
+            )
+    return await call_next(request)
+
+@app.post("/execute")
+async def execute(request: Request):
+    # Reaches here only if the manifest verified — or no manifest was provided
+    return {"status": "ok"}
+```
+
+---
+
+## Reading the VerificationResult
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `result` | `OverallResult` | Top-level verdict — see table below |
+| `attestation_verified` | `bool` | `True` if hardware attestation was confirmed |
+| `fields_verified` | `FieldsVerified` | Per-artifact status (MATCH / MISMATCH / NOT_BOUND / EXPIRED) |
+| `mismatch_details` | `list[MismatchDetail]` | One entry per failed artifact, with expected and actual hashes |
+| `evidence_pack` | `EvidencePack` | Signed evidence bundle (populated in future releases) |
+| `verification_id` | `str` | UUID for this specific verification event — use in audit logs |
+
+**OverallResult values:**
+
+| Value | Meaning | Action |
+|-------|---------|--------|
+| `VALID` | All checks passed | Allow the request |
+| `REVOKED` | Manifest is in the revocation list | Block immediately — possible incident |
+| `EXPIRED` | `expires_at` is in the past | Block — agent must re-issue manifest |
+| `MISMATCH` | One or more artifact hashes differ | Block — agent may have drifted or been tampered |
+| `ATTESTATION_UNAVAILABLE` | `enforce_attestation` was set but no attestation present | Block in prod, warn in dev |
+| `INCOMPLETE` | Required fields are missing from the manifest | Block |
+| `INCOMPATIBLE_VERSION` | Manifest spec version not supported | Upgrade the SDK |
+
+---
+
+## Running the complete example
+
+```bash
+# Terminal 1 — start the verification service
+uvicorn myservice:app --reload
+
+# Terminal 2 — verify a manifest
+curl "http://localhost:8000/agent/verify?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+# Check revocation status
+curl "http://localhost:8000/agent/revocation-status?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+# 404 if not revoked
+```
+
+---
+
+## What's next
+
+- [Tutorial: A2A delegation chains](delegation-chains.md) — verify multi-hop delegation manifests
+- [Tutorial: Revocation and key rotation](revocation.md) — revoke a manifest and update the CRL
+- [Tutorial: Deploying the verification endpoint](deploy-verifier.md) — containerize and run in production

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,14 @@ extra_css:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Tutorials:
+      - Overview: tutorials/index.md
+      - Server-side verification: tutorials/server-side-verification.md
+      - A2A delegation chains: tutorials/delegation-chains.md
+      - HITL approval workflows: tutorials/hitl-approvals.md
+      - Revocation and key rotation: tutorials/revocation.md
+      - Hardware attestation: tutorials/hardware-attestation.md
+      - Deploying the verifier: tutorials/deploy-verifier.md
   - Architecture:
       - Decision Records: adr/index.md
       - ADR-0001 — RFC 8785 Canonical JSON: adr/0001-rfc8785-canonical-json.md


### PR DESCRIPTION
## Summary

Adds a `docs/tutorials/` section to the MkDocs site with six tutorials, closing issues #64–#69. Each tutorial is self-contained with runnable Python code and CLI examples.

| Tutorial | Issue | What it covers |
|----------|-------|----------------|
| Server-side verification | #68 | `verify_manifest()`, FastAPI router, HTTP middleware, `VerificationResult` reference |
| A2A delegation chains | #64 | `DelegationHopSigner`, `verify_delegation_chain`, scope laundering and depth failure modes |
| HITL approval workflows | #65 | `HitlApprovalSigner`, signed approval attachment, `MISSING`/`EXPIRED` failure modes |
| Revocation and key rotation | #66 | `sign_revocation`, `FileCRL`, CRL endpoint, zero-downtime key rotation |
| Hardware attestation | #67 | `SEVSNPProvider`, `TDXProvider`, `OPAQUEProvider`, auto-provider, mocking without hardware |
| Deploying the verifier | #69 | Dockerfile, docker-compose, Kubernetes, health probes, hot-reload |

Also adds `docs/tutorials/index.md` as a landing page and wires all tutorials into `mkdocs.yml` under a new **Tutorials** nav tab.

## Test plan

- [ ] MkDocs build passes (`mkdocs build --strict`)
- [ ] All internal cross-links resolve
- [ ] Code examples match the current SDK API (no undefined symbols)
- [ ] Issues #64–#69 closed on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)