### PR TITLE
fix(security): remediate 9 MEDIUM issues

### DIFF
--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -97,9 +97,11 @@ def verify_delegation_chain(
         return
 
     root_max_depth = delegation_chain[0]["scope_grant"].get("max_delegation_depth", 3)
-    if len(delegation_chain) > root_max_depth:
+    # DELEG-002: max_delegation_depth counts sub-delegation levels below the root,
+    # so a chain of (root + N delegates) has depth N. Allow length <= max_depth + 1.
+    if len(delegation_chain) > root_max_depth + 1:
         raise ValueError(
-            f"Delegation chain depth {len(delegation_chain)} exceeds "
+            f"Delegation chain depth {len(delegation_chain) - 1} exceeds "
             f"root max_delegation_depth {root_max_depth}"
         )
 
@@ -239,9 +241,25 @@ def verify_hitl_approval(
 
     Raises:
         InvalidSignature: If the approval signature is invalid.
-        ValueError: If required fields are missing.
+        ValueError: If required fields are missing or the approval has expired.
     """
     import base64
+    from datetime import datetime, timezone, timedelta
+
+    # HITL-003: enforce approval expiry before verifying signature
+    duration = approval.get("approved_scope", {}).get("approval_duration_seconds", 0)
+    if duration:
+        approved_at_str = approval.get("approved_at", "")
+        try:
+            approved_at = datetime.fromisoformat(approved_at_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError) as e:
+            raise ValueError(f"HITL approval has invalid approved_at: {e}") from e
+        if datetime.now(timezone.utc) > approved_at + timedelta(seconds=duration):
+            raise ValueError(
+                f"HITL approval expired: approved_at={approved_at_str}, "
+                f"duration={duration}s"
+            )
+
     pre = _approval_pre_image(
         manifest_id=manifest_id,
         approved_at=approval["approved_at"],

--- a/python/src/agent_manifest/_hw_providers.py
+++ b/python/src/agent_manifest/_hw_providers.py
@@ -54,11 +54,20 @@ class SEVSNPProvider(AttestationProvider):
         AttestationUnavailableError: If /dev/sev-guest is not accessible.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, require_vcek_verification: bool = False) -> None:
         if not os.path.exists(_SEV_GUEST_DEV):
             raise AttestationUnavailableError(
                 f"AMD SEV-SNP not available: {_SEV_GUEST_DEV} not found. "
                 "Requires an SEV-SNP VM (Azure DCasv5, AWS C6a Nitro, GCP N2D Confidential)."
+            )
+        # HW-008: if VCEK chain verification is required, raise eagerly so callers
+        # cannot silently rely on an unverified attestation report.
+        if require_vcek_verification:
+            raise AttestationUnavailableError(
+                "VCEK certificate chain verification is not yet implemented. "
+                "Fetch the VCEK cert from AMD KDS and verify it against the AMD root CA "
+                "before trusting the SNP attestation report. "
+                "Pass require_vcek_verification=False only in development."
             )
         self._manifest_hash: Optional[str] = None
         self._report_bytes: Optional[bytes] = None
@@ -102,6 +111,10 @@ class SEVSNPProvider(AttestationProvider):
                 "host_data": self._report_bytes[0x140:0x180].hex(),  # HOST_DATA at offset 0x140
                 "measurement": measurement_hex,
                 "vmpl": 0,
+                # HW-008: VCEK chain not verified — the ioctl response does not embed
+                # the cert chain. Callers who need full attestation must fetch the VCEK
+                # from AMD KDS using chip_id + tcb_version and verify independently.
+                "vcek_cert_chain_verified": False,
             },
         )
 

--- a/python/src/agent_manifest/_providers.py
+++ b/python/src/agent_manifest/_providers.py
@@ -100,13 +100,21 @@ def _detect_nitro() -> bool:
     return os.path.exists(_NITRO_NSM_DEV)
 
 
-def _require_tpm2_tools() -> None:
-    if shutil.which("tpm2_extend") is None:
+def _require_tpm2_tools() -> tuple[str, str]:
+    """Return absolute paths (tpm2_extend, tpm2_pcrread) or raise.
+
+    HW-007: resolve to absolute paths at call time so PATH changes after
+    import cannot inject a malicious binary.
+    """
+    extend = shutil.which("tpm2_extend")
+    pcrread = shutil.which("tpm2_pcrread")
+    if extend is None or pcrread is None:
         raise AttestationUnavailableError(
             "tpm2-tools not found. Install with: apt-get install tpm2-tools "
             "or yum install tpm2-tools. "
             "For CI, use swtpm: https://github.com/stefanberger/swtpm"
         )
+    return extend, pcrread
 
 
 class TPMProvider(AttestationProvider):
@@ -154,13 +162,13 @@ class TPMProvider(AttestationProvider):
         Raises:
             AttestationUnavailableError: If tpm2_extend fails.
         """
-        _require_tpm2_tools()
+        extend_path, _ = _require_tpm2_tools()
         pre = self.manifest_pre_image(manifest_json)
         digest = hashlib.sha256(pre).hexdigest()
         self._last_manifest_hash = f"sha256:{digest}"
 
         result = subprocess.run(
-            ["tpm2_extend", f"-i{self._pcr}", "-g=sha256", f"-d={digest}"],
+            [extend_path, f"-i{self._pcr}", "-g=sha256", f"-d={digest}"],
             capture_output=True,
             text=True,
         )
@@ -175,11 +183,11 @@ class TPMProvider(AttestationProvider):
         Raises:
             AttestationUnavailableError: If tpm2_pcrread or tpm2_quote fails.
         """
-        _require_tpm2_tools()
+        _, pcrread_path = _require_tpm2_tools()
 
         # Read PCR values
         result = subprocess.run(
-            ["tpm2_pcrread", f"sha256:{self._pcr}"],
+            [pcrread_path, f"sha256:{self._pcr}"],
             capture_output=True,
             text=True,
         )

--- a/python/src/agent_manifest/_revocation.py
+++ b/python/src/agent_manifest/_revocation.py
@@ -88,7 +88,7 @@ def verify_revocation_signature(
     """
     import base64
     from cryptography.exceptions import InvalidSignature
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    from ._signing import Ed25519Verifier as _Ed25519Verifier
 
     # CRL-001: null/empty signature must raise InvalidSignature, not ValueError
     if not record.revocation_signature:
@@ -114,8 +114,8 @@ def verify_revocation_signature(
         raise InvalidSignature(
             f"Ed25519 signature must be 64 bytes, got {len(sig_bytes)}"
         )
-    pub = Ed25519PublicKey.from_public_bytes(signer_public_key)
-    pub.verify(sig_bytes, pre_image)
+    # CRYPTO-007: use Ed25519Verifier so small-order key check is enforced
+    _Ed25519Verifier(signer_public_key)._pub.verify(sig_bytes, pre_image)
 
 
 # ---------------------------------------------------------------------------

--- a/python/src/agent_manifest/_signing.py
+++ b/python/src/agent_manifest/_signing.py
@@ -86,7 +86,7 @@ def _b64url_decode(s: str) -> bytes:
     # CRYPTO-006: reject standard base64 (+/) — only URL-safe chars allowed
     if not _B64URL_RE.match(s):
         raise ValueError(
-            f"Invalid base64url: contains non-URL-safe characters (use - and _ not + and /)"
+            "Invalid base64url: contains non-URL-safe characters (use - and _ not + and /)"
         )
     pad = 4 - len(s) % 4
     return base64.urlsafe_b64decode(s + ("=" * pad if pad != 4 else ""))

--- a/python/src/agent_manifest/_signing.py
+++ b/python/src/agent_manifest/_signing.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -78,7 +79,15 @@ def _b64url_encode(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
 
 
+_B64URL_RE = re.compile(r"^[A-Za-z0-9\-_]*$")
+
+
 def _b64url_decode(s: str) -> bytes:
+    # CRYPTO-006: reject standard base64 (+/) — only URL-safe chars allowed
+    if not _B64URL_RE.match(s):
+        raise ValueError(
+            f"Invalid base64url: contains non-URL-safe characters (use - and _ not + and /)"
+        )
     pad = 4 - len(s) % 4
     return base64.urlsafe_b64decode(s + ("=" * pad if pad != 4 else ""))
 
@@ -106,6 +115,19 @@ def signing_pre_image(manifest_dict: dict[str, Any]) -> bytes:
 # ---------------------------------------------------------------------------
 # Ed25519
 # ---------------------------------------------------------------------------
+
+# CRYPTO-005: all 8 low-order (torsion) points of the Ed25519 curve — cofactor 8.
+# A key equal to any of these allows signature forgery; reject at load time.
+_SMALL_ORDER_POINTS: frozenset[bytes] = frozenset({
+    bytes.fromhex("0000000000000000000000000000000000000000000000000000000000000000"),
+    bytes.fromhex("0100000000000000000000000000000000000000000000000000000000000000"),
+    bytes.fromhex("26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc05"),
+    bytes.fromhex("c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a"),
+    bytes.fromhex("0000000000000000000000000000000000000000000000000000000000000080"),
+    bytes.fromhex("ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f"),
+    bytes.fromhex("26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc85"),
+    bytes.fromhex("c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa"),
+})
 
 
 @dataclass(frozen=True)
@@ -176,12 +198,12 @@ class Ed25519Verifier:
     """Verifies Ed25519 signatures using OpenSSL's cofactorless equation."""
 
     def __init__(self, public_key_bytes: bytes) -> None:
-        # Cryptography <44 rejected small-order/torsion keys in from_public_bytes.
-        # >=44 moved that check to verify() time, so we enforce it here (CRYPTO-007).
-        if len(public_key_bytes) != 32 or public_key_bytes == bytes(32):
+        # CRYPTO-005: reject all 8 torsion (small-order) subgroup elements.
+        # cryptography >=44 moved this check to verify() time — enforce it here.
+        if len(public_key_bytes) != 32 or public_key_bytes in _SMALL_ORDER_POINTS:
             raise ValueError(
-                "Invalid Ed25519 public key: all-zero bytes are a small-order "
-                "subgroup element and MUST be rejected."
+                "Invalid Ed25519 public key: key is a small-order subgroup element "
+                "(torsion point) and MUST be rejected."
             )
         self._pub: Ed25519PublicKey = Ed25519PublicKey.from_public_bytes(
             public_key_bytes
@@ -196,11 +218,16 @@ class Ed25519Verifier:
         """Verify *signature_value* over *manifest_dict*'s signed fields.
 
         Raises:
-            cryptography.exceptions.InvalidSignature: Verification failed.
-            ValueError: Signature bytes are malformed / wrong length.
+            cryptography.exceptions.InvalidSignature: Verification failed or wrong length.
+            ValueError: Signature string contains non-URL-safe base64 characters.
         """
         pre_image = signing_pre_image(manifest_dict)
         sig_bytes = _b64url_decode(signature_value)
+        # SIGN-001: reject before passing to OpenSSL — avoids undefined-length inputs
+        if len(sig_bytes) != 64:
+            raise InvalidSignature(
+                f"Ed25519 signature must be 64 bytes, got {len(sig_bytes)}"
+            )
         self._pub.verify(sig_bytes, pre_image)  # raises InvalidSignature on failure
 
 

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -401,6 +401,25 @@ def verify_manifest(
                 ))
             fields.hitl_record = HitlResult.APPROVED if all_ok else HitlResult.EXPIRED
 
+    # --- Attestation block verification (HW-010)
+    # Check that manifest_hash_in_report matches the computed manifest hash.
+    attestation_block = manifest.get("attestation") or {}
+    if attestation_block:
+        reported_hash = attestation_block.get("manifest_hash_in_report", "")
+        if reported_hash:
+            from ._canonicalize import canonicalize as _canonicalize
+            import hashlib as _hashlib
+            subset = {k: v for k, v in manifest.items() if k != "attestation"}
+            expected_attest_hash = "sha256:" + _hashlib.sha256(_canonicalize(subset)).hexdigest()
+            if hmac.compare_digest(reported_hash, expected_attest_hash):
+                result.attestation_verified = True
+            elif context.enforce_attestation:
+                mismatches.append(MismatchDetail(
+                    field="attestation",
+                    expected_hash=expected_attest_hash,
+                    actual_hash=reported_hash,
+                ))
+
     # --- Final result
     result.mismatch_details = mismatches
     if mismatches:

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -1,5 +1,5 @@
 """Tests for A2A delegation chain and HITL approval signing — issues #12 and #13."""
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from cryptography.exceptions import InvalidSignature
@@ -106,11 +106,13 @@ def test_scope_laundering_detected():
         )
 
 def test_depth_exceeded_raises():
+    # max_delegation_depth=1 means root + at most 1 sub-delegate (chain length <= 2).
+    # A chain of 3 hops has depth 2, which exceeds max_delegation_depth=1.
     narrow_scope = {**SCOPE, "max_delegation_depth": 1}
     chain = [
         {"hop": i, "principal_id": f"spiffe://x/{i}", "principal_type": "agent",
          "delegated_at": NOW, "scope_grant": narrow_scope, "delegation_signature": "sig"}
-        for i in range(2)  # depth 2 > max 1
+        for i in range(3)  # length 3, depth 2 > max_delegation_depth 1
     ]
     with pytest.raises(ValueError, match="max_delegation_depth"):
         verify_delegation_chain(chain, {}, MID)
@@ -195,3 +197,38 @@ def test_approval_scope_change_fails():
                 "approval_signature": sig}
     with pytest.raises(InvalidSignature):
         verify_hitl_approval(approval, MID, kp.public_bytes)
+
+
+def test_approval_expired_raises():
+    """Approval past its duration must raise ValueError before signature check."""
+    kp = generate_ed25519()
+    past_time = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat().replace("+00:00", "Z")
+    short_scope = {**APPROVAL_SCOPE, "approval_duration_seconds": 3600}  # 1h ago = expired
+    sig = HitlApprovalSigner(kp).sign_approval(
+        manifest_id=MID, approved_at=past_time,
+        approved_scope=short_scope, approver_id="did:web:ciso",
+    )
+    approval = {
+        "manifest_id": MID, "approved_at": past_time,
+        "approved_scope": short_scope, "approver_id": "did:web:ciso",
+        "approval_signature": sig,
+    }
+    with pytest.raises(ValueError, match="expired"):
+        verify_hitl_approval(approval, MID, kp.public_bytes)
+
+
+def test_approval_no_duration_does_not_expire():
+    """Approval with no duration limit must not raise expiry error."""
+    kp = generate_ed25519()
+    past_time = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat().replace("+00:00", "Z")
+    no_expiry_scope = {**APPROVAL_SCOPE, "approval_duration_seconds": 0}
+    sig = HitlApprovalSigner(kp).sign_approval(
+        manifest_id=MID, approved_at=past_time,
+        approved_scope=no_expiry_scope, approver_id="did:web:ciso",
+    )
+    approval = {
+        "manifest_id": MID, "approved_at": past_time,
+        "approved_scope": no_expiry_scope, "approver_id": "did:web:ciso",
+        "approval_signature": sig,
+    }
+    verify_hitl_approval(approval, MID, kp.public_bytes)  # must not raise

--- a/python/tests/test_signing.py
+++ b/python/tests/test_signing.py
@@ -9,6 +9,8 @@ from agent_manifest._signing import (
     SIGNED_FIELDS,
     Ed25519Signer,
     Ed25519Verifier,
+    _SMALL_ORDER_POINTS,
+    _b64url_decode,
     generate_ed25519,
     signing_pre_image,
 )
@@ -156,10 +158,37 @@ def test_ed25519_signed_fields_list_correct():
 
 
 def test_ed25519_small_order_key_rejected():
-    """OpenSSL rejects keys on small-order (torsion) subgroup at load time."""
-    # All-zero raw key bytes are rejected by OpenSSL
-    with pytest.raises((ValueError, Exception)):
+    with pytest.raises(ValueError):
         Ed25519Verifier(bytes(32))
+
+
+def test_ed25519_all_small_order_points_rejected():
+    """All 8 torsion subgroup elements must be rejected at key load time."""
+    for point in _SMALL_ORDER_POINTS:
+        with pytest.raises(ValueError):
+            Ed25519Verifier(point)
+
+
+def test_ed25519_truncated_sig_raises_invalid_signature():
+    kp = generate_ed25519()
+    verifier = Ed25519Verifier(kp.public_bytes)
+    with pytest.raises(InvalidSignature):
+        verifier.verify(SAMPLE_MANIFEST, "abc")  # decodes to <64 bytes
+
+
+def test_b64url_decode_rejects_plus():
+    with pytest.raises(ValueError, match="non-URL-safe"):
+        _b64url_decode("abc+def")
+
+
+def test_b64url_decode_rejects_slash():
+    with pytest.raises(ValueError, match="non-URL-safe"):
+        _b64url_decode("abc/def")
+
+
+def test_b64url_decode_accepts_valid():
+    result = _b64url_decode("SGVsbG8")  # "Hello"
+    assert result == b"Hello"
 
 
 def test_ed25519_public_key_roundtrip_b64url():

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -238,3 +238,45 @@ def test_revocation_store_get_record():
     s.revoke(rec)
     assert s.get_record("test-id") == rec
     assert s.get_record("other") is None
+
+
+# ---------------------------------------------------------------------------
+# Attestation verification (HW-010)
+# ---------------------------------------------------------------------------
+
+
+def _manifest_hash(manifest: dict) -> str:
+    import hashlib
+    from agent_manifest._canonicalize import canonicalize
+    subset = {k: v for k, v in manifest.items() if k != "attestation"}
+    return "sha256:" + hashlib.sha256(canonicalize(subset)).hexdigest()
+
+
+def test_attestation_verified_true_when_hash_matches():
+    m = base_manifest()
+    m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": _manifest_hash(m)}
+    result = verify_manifest(m, base_context(), store())
+    assert result.attestation_verified is True
+
+
+def test_attestation_verified_false_when_no_attestation():
+    result = verify_manifest(base_manifest(), base_context(), store())
+    assert result.attestation_verified is False
+
+
+def test_attestation_hash_mismatch_with_enforce_raises_mismatch():
+    m = base_manifest()
+    m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": "sha256:" + "00" * 32}
+    ctx = base_context(enforce_attestation=True)
+    result = verify_manifest(m, ctx, store())
+    assert result.attestation_verified is False
+    assert result.result == OverallResult.MISMATCH
+    assert any(d.field == "attestation" for d in result.mismatch_details)
+
+
+def test_attestation_hash_mismatch_without_enforce_is_valid():
+    m = base_manifest()
+    m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": "sha256:" + "00" * 32}
+    result = verify_manifest(m, base_context(), store())
+    assert result.attestation_verified is False
+    assert result.result == OverallResult.VALID


### PR DESCRIPTION
## Summary

- **CRYPTO-005/SIGN-002 (#120)**: `Ed25519Verifier` now rejects all 8 torsion subgroup (small-order) points at key load time, not just the all-zero identity. Added `_SMALL_ORDER_POINTS` frozenset with the complete Ed25519 cofactor-8 torsion group.
- **CRYPTO-007 (#121)**: `verify_revocation_signature` routes through `Ed25519Verifier` instead of raw `Ed25519PublicKey.from_public_bytes`, so the small-order key check applies to revocation signer keys.
- **SIGN-001 (#122)**: `Ed25519Verifier.verify()` checks `len(sig_bytes) == 64` before passing to OpenSSL, raising `InvalidSignature` on wrong-length inputs.
- **HW-007 (#123)**: `TPMProvider` resolves `tpm2_extend`/`tpm2_pcrread` to absolute paths via `shutil.which` and passes those to `subprocess`, preventing PATH-hijacking.
- **HW-010 (#124)**: `verify_manifest()` sets `attestation_verified=True` when `manifest_hash_in_report` matches the computed manifest hash; adds mismatch detail when `enforce_attestation=True`.
- **DELEG-002 (#125)**: Delegation depth check was off-by-one; corrected to `len > max_delegation_depth + 1` (depth counts sub-delegation levels below root, not total hops).
- **HITL-003 (#126)**: `verify_hitl_approval()` checks approval expiry before verifying the signature, raising `ValueError` if the approval window has passed.
- **HW-008 (#128)**: `SEVSNPProvider` gains `require_vcek_verification=False` parameter (raises eagerly if `True`) and sets `vcek_cert_chain_verified=False` in the raw report so the unverified gap is explicit.
- **CRYPTO-006 (#129)**: `_b64url_decode()` rejects strings containing `+` or `/` (standard base64) before decoding.

## Test plan

- [ ] 323 tests pass, 35 skipped (no hardware/OQS)
- [ ] `bandit -ll` clean on all modified files
- [ ] New tests for each fix: small-order points, expiry, depth, attestation_verified, b64url validation
- [ ] `test_depth_exceeded_raises` updated for corrected depth semantics
- [ ] CI passes on all 5 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)