### PR TITLE
fix: author email, spec byline, adopters attribution for oss launch

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,7 +8,7 @@ To add your organization, open a PR editing this file. Include: organization nam
 
 | Organization | Use case |
 |---|---|
-| Opaque Systems | Reference implementation and OPAQUE attestation provider integration |
+| Opaque Systems | Founding contributor — developed the initial specification and reference SDK |
 
 ## Community evaluations
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts 
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "Apache-2.0"}
-authors = [{name = "Imran Siddique", email = "imran.siddique@opaque.co"}]
+authors = [{name = "Imran Siddique", email = "maintainers@agentrust.io"}]
 keywords = [
   "ai-agents", "attestation", "governance", "tee", "confidential-computing",
   "mcp", "agent-manifest", "trust", "hardware-attestation", "pydantic",

--- a/spec/agent-manifest-spec-v0.1.md
+++ b/spec/agent-manifest-spec-v0.1.md
@@ -4,7 +4,7 @@
 |---|---|
 | Version | 0.1 — Draft for Review |
 | Subtitle | A cryptographic identity and provenance standard for AI agents |
-| Authors | Imran Siddique (OPAQUE Systems, CPO) |
+| Authors | Imran Siddique (AgentTrust) |
 | Status | Draft v0.1 — Proposed Open Standard |
 | Date | June 2026 |
 | Relationship | Extends: OWASP ASI 2026 \| Aligns: CoSAI WS1, EU AI Act Art. 14/15 |
@@ -1437,7 +1437,7 @@ This specification builds on architectural work developed across the Agent Gover
 
 ---
 
-*Agent Manifest Specification v0.1 — OPAQUE Systems — June 2026*
+*Agent Manifest Specification v0.1 — Opaque Systems — June 2026*
 
 
 ### D. RFC 8785 Canonical JSON Test Vector <!-- CHANGED: closes #25 -->


### PR DESCRIPTION
## Summary
- `python/pyproject.toml`: change author email from personal Opaque address to `maintainers@agentrust.io` — current value is baked into every published PyPI sdist
- `spec/agent-manifest-spec-v0.1.md`: byline changed from `Imran Siddique (OPAQUE Systems, CPO)` to `Imran Siddique (AgentTrust)`; normalized inconsistent `OPAQUE Systems` (all-caps) to `Opaque Systems` in the header block
- `ADOPTERS.md`: reframe Opaque Systems from "Reference implementation" to "Founding contributor — developed the initial specification and reference SDK"

## What was NOT changed (needs a decision)
The spec body contains multiple substantive technical references to "OPAQUE's attestation service", "OPAQUE Confidential Runtime", and "OPAQUE revocation service" (lines 86, 108, 110, 552, 560, 577-578). These describe the actual protocol architecture, not cosmetic attribution. Changing them requires deciding whether the spec is vendor-neutral or explicitly Opaque-anchored. Flagging for a separate decision.

## Test plan
- [ ] `grep "imran.siddique@opaque.co" python/pyproject.toml` returns nothing
- [ ] Spec byline shows AgentTrust
- [ ] ADOPTERS.md no longer positions Opaque as sole reference implementation