### PR TITLE
docs(adr): add ADR-0005 through ADR-0009

### DIFF
--- a/docs/adr/0005-ml-dsa-hybrid-signature.md
+++ b/docs/adr/0005-ml-dsa-hybrid-signature.md
@@ -1,0 +1,77 @@
+# ADR-0005: ML-DSA-65 and hybrid Ed25519+ML-DSA-65 signature support
+
+**Status**: Accepted  
+**Date**: 2026-06-07  
+**Spec section**: Section 2.4 (Cryptographic Profiles), Section 4.2 (Signature Algorithms)
+
+## Context
+
+NIST finalized ML-DSA (CRYSTALS-Dilithium) as FIPS 204 in August 2024, making it the primary post-quantum digital signature standard. Agents operating in regulated environments (FedRAMP High, EU AI Act high-risk systems) will face requirements to use quantum-resistant cryptography within the next 2–5 years.
+
+The spec must answer: when and how does post-quantum cryptography enter the agent manifest?
+
+Two decisions are intertwined:
+
+1. Which ML-DSA parameter set to standardize on (ML-DSA-44, ML-DSA-65, or ML-DSA-87)
+2. Whether to support hybrid mode — signing with both Ed25519 and ML-DSA-65 in a single manifest, requiring both to verify
+
+ADR-0002 established Ed25519 as the standard profile. This ADR extends that decision to cover the post-quantum and hybrid profiles.
+
+## Decision
+
+**Parameter set**: Use **ML-DSA-65** (NIST Security Level 3, FIPS 204).
+
+**Hybrid mode**: Support `Ed25519+ML-DSA-65` as an explicit `crypto_profile` value. A hybrid manifest carries both signature types; verifiers must validate both signatures independently. A verifier that does not support ML-DSA-65 must reject a hybrid manifest with `INCOMPATIBLE_VERSION`, not silently pass on the Ed25519 signature alone.
+
+Three `CryptoProfile` values are defined:
+
+- `standard` — Ed25519 only (Level 0/1 default)
+- `post_quantum` — ML-DSA-65 only (required when classical crypto is prohibited by policy)
+- `hybrid` — Ed25519 + ML-DSA-65 (recommended transition path for Level 2+)
+
+PQC is required at conformance Level 2 and above. Level 0 and Level 1 deployments may use `standard` (classical only).
+
+## Rationale
+
+### ML-DSA-65 over ML-DSA-44
+
+ML-DSA-44 targets NIST Security Level 2 with 2420-byte signatures. ML-DSA-65 targets NIST Security Level 3 with 3309-byte signatures. The 889-byte difference is trivial for a manifest that is signed once and cached. NIST recommends ML-DSA-65 for long-term protection; ML-DSA-44 would likely require a second migration within 10 years as cryptanalysis matures.
+
+### ML-DSA-65 over ML-DSA-87
+
+ML-DSA-87 targets NIST Security Level 5 but produces 4627-byte signatures. The additional security margin over Level 3 is not justified by any current threat model, and the signature size creates complications for manifests embedded in HTTP headers. ML-DSA-65 is the right balance between security margin and operational cost.
+
+### Hybrid mode as the transition path
+
+Mandating ML-DSA-65 alone immediately would break every existing verifier that has not yet integrated `liboqs`. The hybrid profile lets adopters commit to PQC today while remaining interoperable with classical infrastructure during the migration window (estimated 2–5 years). A classical verifier that holds the Ed25519 public key can still verify the Ed25519 signature. Once the ecosystem completes PQC migration, deployments can move to `post_quantum` only.
+
+The requirement that both signatures must verify in hybrid mode prevents downgrade attacks: a hybrid manifest cannot be verified by stripping the ML-DSA signature and presenting only the Ed25519 one to a PQC-capable verifier.
+
+### Avoiding algorithm agility
+
+The spec defines exactly three named profiles. Arbitrary algorithm negotiation between signer and verifier is not supported. Algorithm agility has historically produced downgrade attacks; constraining to three named profiles eliminates negotiation semantics entirely.
+
+## Alternatives considered
+
+**X-Wing (ML-KEM + X25519 hybrid)**: A hybrid KEM combining X25519 and ML-KEM-768. Rejected because ML-KEM is a key encapsulation mechanism, not a signature scheme — it serves a different purpose (key exchange) and does not address signature authenticity.
+
+**SLH-DSA (SPHINCS+)**: Hash-based signatures with no algebraic structural assumptions. Rejected because SLH-DSA signatures range from 7 KB to 50 KB depending on the parameter set, which is prohibitively large for a manifest that may be attached to every RPC.
+
+**Falcon-512**: NIST FIPS 206 lattice-based signature with compact output (~666 bytes). Rejected because Falcon's Gaussian sampler has a history of implementation-specific timing side channels, and `liboqs` Falcon support is less mature than ML-DSA. It may be added in a future ADR once maturity is established.
+
+**Mandate ML-DSA-65 immediately**: Drop Ed25519 from all profiles. Rejected — the migration window must exist; breaking every existing Level 0/1 deployment is not acceptable.
+
+## Consequences
+
+- `crypto_profile: hybrid` or `post_quantum` requires `pip install "agent-manifest[pq]"`, which pulls in the `oqs` package (Python bindings for `liboqs`, a C library). Importing `oqs` is deferred until a PQC operation is actually needed — the package is not imported at module load time.
+- A Level 0 verifier without `oqs` installed cannot verify a `post_quantum` or `hybrid` manifest. The verifier must raise `INCOMPATIBLE_VERSION`. Silent pass is not permitted.
+- Signature sizes: Ed25519 = 64 bytes, ML-DSA-65 = 3309 bytes, hybrid = 3373 bytes plus encoding overhead. Manifests passed in HTTP headers must use the `X-Agent-Manifest-Id` header (a UUID reference) rather than embedding the full signed manifest inline.
+- The conformance test suite includes AM-CRYPTO-010 through AM-CRYPTO-020 covering all three profiles and hybrid verification rejection on partial signature sets.
+
+## References
+
+- [NIST FIPS 204 (ML-DSA)](https://csrc.nist.gov/pubs/fips/204/final)
+- [liboqs — Open Quantum Safe](https://openquantumsafe.org/)
+- [CISA Post-Quantum Cryptography Initiative](https://www.cisa.gov/quantum)
+- ADR-0002: Ed25519 as the standard cryptographic profile
+- Spec Section 4.2: Signature algorithm identifiers and profile definitions

--- a/docs/adr/0006-hitl-approval-mechanism.md
+++ b/docs/adr/0006-hitl-approval-mechanism.md
@@ -1,58 +1,68 @@
-# ADR-0006: HITL approval mechanism design
+# ADR-0006: Human-in-the-Loop (HITL) embedded approval record design
 
 **Status**: Accepted  
-**Date**: 2026-05-20  
+**Date**: 2026-06-07  
 **Spec section**: Section 3.5 (Human-in-the-Loop Approvals)
 
 ## Context
 
-EU AI Act Article 14 requires that high-risk AI systems support meaningful human oversight — including the ability for humans to intervene, override, or refuse to deploy the system's outputs. For agentic AI, this translates to: a human must be able to approve or block high-risk actions before they execute.
+EU AI Act Article 14 requires that high-risk AI systems support meaningful human oversight, including the ability for humans to intervene or refuse to allow an agent's outputs before they take effect. For agentic AI, this means a human must be able to approve or block high-risk actions before execution.
 
 The manifest needs a mechanism to record this approval in a tamper-evident, verifiable way that:
 
 1. Proves a specific human approved a specific action for a specific agent
-2. Binds the approval to a time window, so it cannot be reused indefinitely
-3. Is verifiable without an online call to an approval service at verification time
-4. Does not require the original manifest issuer's key to record the approval
+2. Binds the approval to a time window so it cannot be reused indefinitely
+3. Is verifiable at any point without an online call to an approval service
+4. Cannot be forged by the manifest issuer
 
 ## Decision
 
-Embed a **`hitl_record`** field directly in the manifest JSON. Each approval within the record is signed by the **approver's Ed25519 key** over the canonical form of `{manifest_id, approved_at, approved_scope, approver_id}`. The approval record is attached before the agent presents the manifest to a relying party.
+Embed a **`hitl_record`** field directly in the manifest JSON. The record contains one or more approval entries, each with the following fields: `approver_id` (SPIFFE URI or DID of the approver), `approved_at` (ISO 8601 timestamp), `evidence_hash` (SHA-256 of the canonical form of the action being approved), `approval_duration_seconds` (validity window), and `revocation_signature` (Ed25519 signature by the approver over the canonical approval fields).
 
-The `approved_scope` within the approval is distinct from the manifest's `delegation_chain` scope — it captures what the human explicitly authorised (e.g., `max_notional_usd: 500_000`) rather than what the issuer delegated.
+The approval record is **signed by the approver's key**, not the manifest issuer's key.
+
+Verification semantics: a manifest with a HITL requirement is `APPROVED` only when all of the following hold:
+- The `approver_id` appears in the verifier's allowed approver set
+- `approved_at + approval_duration_seconds > now` (approval has not expired)
+- The `evidence_hash` matches the SHA-256 of the action being approved
+- The `revocation_signature` verifies against the approver's published public key
+
+A missing `hitl_record` when one is required produces `INVALID`, not an unattested pass. The HITL gate cannot be bypassed silently.
 
 ## Rationale
 
-**Offline verifiability.** The approval signature can be verified by any party that holds the approver's public key — no call to an approval service is required at verification time. This is critical for air-gapped environments and for audit: the manifest file alone is sufficient evidence of the approval.
+**Offline verifiability.** Approval evidence travels with the manifest. Any verifier holding the approver's public key can check the approval without contacting an external service. This is essential for air-gapped environments and for producing a complete audit pack — the manifest file alone proves the approval happened.
 
-**Approver binding.** The signature covers `approver_id` (a SPIFFE URI or DID), which links the approval to a specific person's key. A compromised agent cannot forge an approval from a different approver — the signature would fail.
+**Approver binding via separate signature.** The approval signature covers `approver_id`, `manifest_id`, `approved_at`, and `evidence_hash`. A compromised agent cannot forge an approval from a different approver. The issuer cannot manufacture approvals — the approver's private key is required.
 
-**Time-bounded approval.** `approval_duration_seconds` inside `approved_scope` limits how long the approval is valid. The verifier checks whether `approved_at + approval_duration_seconds > now`. An approver cannot issue a permanent blank cheque.
+**Separation of duties.** The manifest issuer signs the manifest; the approver signs the approval. These are structurally independent. The issuer may not know the approver's key, and the approver does not need to re-sign the manifest. Agents can collect approvals from multiple approvers and attach them to the `hitl_record` array without triggering a re-sign of the manifest itself.
 
-**Manifest binding.** The signature covers `manifest_id`, preventing approval replay: an approval for agent A cannot be copied into agent B's manifest.
+**Time-bounded approvals.** `approval_duration_seconds` prevents permanent blank cheques. A 3600-second approval window means the agent must re-obtain approval for actions that run beyond one hour.
 
-**Separation from the manifest signature.** The manifest signature (Ed25519 over the full manifest JSON) and the HITL approval signature (Ed25519 over the approval fields) are independent. The agent can collect approvals from multiple approvers and attach them without re-signing the manifest — only the `hitl_record.approvals` array changes, not the signed fields.
+**Evidence hash binding.** The `evidence_hash` field pins the approval to a specific action description. An approval for "transfer $50,000 to account X" cannot be replayed for "transfer $5,000,000 to account Y" because the hashes differ.
+
+The `hitl_record` field is excluded from the manifest signing pre-image (alongside `attestation`) so that approvals can be attached after the manifest is issued, without invalidating the issuer's signature.
 
 ## Alternatives considered
 
-**Webhook-based approval at verification time**: The verifier calls an approval API to check status. Rejected because it creates an online dependency — a down approval service means no verification, which is an availability risk in production and an audit gap (the approval record is not embedded in the evidence pack).
+**Webhook-based approval at verification time**: The verifier calls an external approval API on every verify call to check current status. Rejected because it creates an online dependency — a down approval service means verification fails in production, and the approval evidence is not embedded in the audit pack. Air-gapped deployments cannot use this pattern at all.
 
-**Out-of-band approval token (JWT)**: The approver issues a separate JWT that the agent presents alongside the manifest. Rejected because it requires managing a separate token format, a separate public key registry, and token revocation — all problems the manifest already solves.
+**OAuth 2.0 PKCE for human identity**: Use a browser-based OAuth flow to identify the approver. Rejected because it introduces a browser and redirect URI dependency into a machine-native security path. SPIFFE URIs and DIDs are more appropriate for workload and operator identity in server-side environments.
 
-**Approval via manifest re-signing**: The approver co-signs the entire manifest (multi-signature). Rejected because it requires the approver to hold the manifest issuer's key or participate in a multi-party signing protocol, which is operationally complex and creates key custody issues.
+**Out-of-band approval token (separate JWT)**: The approver issues a JWT presented alongside the manifest. Rejected because it requires managing a separate token format, a separate public key registry, and token revocation — all problems the manifest already solves.
 
-**Separate approval manifest**: A second manifest document that references the first. Rejected because it fragments the evidence — verifiers would need to fetch and verify two documents, and the audit trail requires keeping both in sync.
+**Approval via manifest re-signing (multi-signature)**: The approver co-signs the entire manifest. Rejected because it requires the approver to participate in a multi-party signing protocol or hold the issuer key material, which creates key custody problems and breaks the separation of duties rationale.
 
 ## Consequences
 
-- Agents that require HITL must implement an approval workflow before presenting the manifest. The SDK provides `HitlApprovalSigner` to sign approvals; the workflow UI is out of scope for the spec.
-- In production, approver keypairs should be hardware-backed (FIDO2/passkey, HSM). The spec does not mandate this but the tutorial notes it as strongly recommended.
-- The `required_approvals` count is enforced by the verifier, not the SDK. A manifest with `required_approvals: 2` but only one approval in the record results in `HitlResult.APPROVAL_INSUFFICIENT`.
-- Approval expiry is checked at verification time, not at approval time. An agent that presents an approval 90 minutes after `approval_duration_seconds: 3600` will be rejected. Agents must re-obtain approval for long-running actions.
-- The `hitl_record` field is excluded from the manifest signing pre-image (like `attestation`) — this allows approvals to be attached after the manifest is issued and signed.
+- Agents that require HITL must implement an approval workflow before presenting the manifest. The SDK provides `HitlApprovalSigner` to construct and sign approval records; the approval UI is out of scope for the spec.
+- The `required_approvals` count is enforced by the verifier. A manifest with `required_approvals: 2` but only one valid approval record results in `HitlResult.APPROVAL_INSUFFICIENT`.
+- Approval expiry is checked at verification time, not at approval collection time. An agent that collects an approval and then presents the manifest 90 minutes later with `approval_duration_seconds: 3600` will be rejected. Long-running actions must implement re-approval logic.
+- Approver keypairs should be hardware-backed (FIDO2/passkey or HSM) in production. The spec does not mandate this but the operational guidance notes it as strongly recommended.
 
 ## References
 
-- EU AI Act Article 14: Human oversight
-- Spec Section 3.5: HITL approval record schema
-- [FIDO2 / WebAuthn](https://fidoalliance.org/fido2/) — recommended approver key backing
+- EU AI Act Article 14: Human oversight requirements
+- Spec Section 3.5: HITL approval record schema and verification semantics
+- [FIDO2 / WebAuthn](https://fidoalliance.org/fido2/) — recommended backing for approver keys
+- ADR-0009: SPIFFE URIs as the canonical identity format for `approver_id`

--- a/docs/adr/0007-revocation-json-lines-crl.md
+++ b/docs/adr/0007-revocation-json-lines-crl.md
@@ -1,0 +1,64 @@
+# ADR-0007: JSON-Lines append-only CRL as the SDK revocation format
+
+**Status**: Accepted  
+**Date**: 2026-06-07  
+**Spec section**: Section 3.7 (Revocation)
+
+## Context
+
+A compromised agent — one whose signing key has leaked, whose behavior has been found malicious, or that has been decommissioned — must be stoppable without waiting for its manifest to expire naturally. The spec needs a revocation mechanism that:
+
+1. Allows an authorised authority to revoke any manifest in under 60 seconds
+2. Makes revocation records tamper-evident — a record cannot be added, removed, or modified undetected
+3. Is queryable by a verifier without X.509 infrastructure or a heavyweight credential processing stack
+4. Provides a working reference implementation for development with zero infrastructure dependency
+
+## Decision
+
+Use **append-only JSON-Lines (`.jsonl`)** as the CRL file format. Each line is a JSON-encoded `SignedRevocationRecord` containing: `manifest_id`, `revoked_at` (ISO 8601), `reason`, `revoked_by` (SPIFFE URI or DID of the revoking authority), `signer_key_id`, and `revocation_signature` (Ed25519 signature by the revoking authority over the canonical form of the preceding fields).
+
+The revocation record is signed by the **revoking authority's key**, not the original manifest issuer's key.
+
+The standard discovery endpoint follows RFC 8615 well-known URI conventions:
+
+- `GET /.well-known/agent-manifest/revocation` — returns all records as JSON-Lines
+- `GET /.well-known/agent-manifest/revocation/{manifest_id}` — returns one record or 404
+
+`FileCRL` is the reference implementation for development and small-scale deployments. Production deployments must use a database-backed store (Postgres, Redis, DynamoDB, or equivalent). The choice of database is not prescribed by the spec.
+
+## Rationale
+
+**JSON-Lines for append-only semantics.** Each revocation is a single line appended atomically. No locking is needed between writers and readers — the file grows monotonically and existing entries are never modified. A CRL committed to a git repository is an immutable, auditable append log. Readers parse line-by-line, so a partial read of a large CRL is always consistent.
+
+**O(1) append cost.** A naive single JSON array requires rewriting the entire file for each revocation — O(n) write cost. JSON-Lines appends are O(1) regardless of CRL size, making revocation latency independent of fleet size.
+
+**Signed records prevent forgery.** Without a per-record signature, an attacker with write access to the CRL could add fictitious revocations or delete real ones. The signature over the canonical record fields means any field mutation invalidates the signature.
+
+**Revoking authority is separate from manifest issuer.** A security team can revoke manifests signed by a compromised issuer key without needing access to that key. The revoking authority's public key can be distributed out-of-band and rotated independently of the manifest PKI.
+
+**Discovery via `.well-known`.** RFC 8615 well-known URIs are the established mechanism for service metadata discovery. `/.well-known/agent-manifest/revocation` is locatable by any HTTP client without configuration; no SDK-level resolver is needed.
+
+## Alternatives considered
+
+**W3C Status List 2021 (bitstring revocation list)**: A compact bitstring where each bit represents one credential, keyed by a sequential index assigned at issuance time. Rejected because it requires coordination between the issuer and CRL operator at manifest issuance time (to assign the index), and introduces a dependency on the W3C Verifiable Credentials processing stack — a heavyweight dependency that conflicts with the spec's goal of JSON-native tooling.
+
+**RFC 5280 X.509 CRL format**: DER-encoded binary with ASN.1 structure, the standard for X.509 certificate revocation. Rejected because the manifest ecosystem is JSON-native. Requiring ASN.1 parsing in every SDK (Python, TypeScript, Go, .NET) is a disproportionate dependency burden for what is fundamentally a simple revocation list.
+
+**Single JSON array**: A JSON file containing a list of all revocation records. Rejected because appending to a JSON array requires reading and rewriting the entire file (O(n) write). JSON-Lines gives O(1) append with no locking requirement.
+
+**OCSP (Online Certificate Status Protocol)**: Per-manifest online status check at verification time. Rejected because it requires an always-available OCSP responder (a high-availability infrastructure requirement), leaks information about which manifests are being verified to the OCSP operator, and cannot be used in air-gapped environments. JSON-Lines CRL can be cached and served from a CDN with a defined TTL.
+
+## Consequences
+
+- `FileCRL` is explicitly a development tool. It is not suitable for multi-process or high-availability deployments. The `create_crl_router()` docstring and all documentation must state this clearly. Production deployments must implement a persistent database-backed store.
+- The CRL is append-only by design. There is no "un-revoke" operation. If a manifest was revoked in error, the issuer must re-issue a new manifest with a new `manifest_id`. This is intentional: revocation records are evidence, not mutable state.
+- Verifiers that cache the CRL must define a TTL. The spec recommends a maximum of 5 minutes for production deployments. A stale CRL is a security risk.
+- The JSON-Lines file grows without bound. Operators running long-lived deployments need a compaction strategy: periodically emit a new CRL containing only records whose `manifest_id` corresponds to a non-expired manifest. The compacted file is still append-only from that point forward.
+
+## References
+
+- [RFC 8615](https://www.rfc-editor.org/rfc/rfc8615) — Well-Known URIs
+- [W3C Status List 2021](https://www.w3.org/TR/vc-status-list/)
+- [RFC 5280](https://www.rfc-editor.org/rfc/rfc5280) — X.509 Certificate Revocation Lists
+- ADR-0001: RFC 8785 canonical JSON (used for the revocation record signing pre-image)
+- Spec Section 3.7: Revocation record schema and discovery endpoint specification

--- a/docs/adr/0008-conformance-level-design.md
+++ b/docs/adr/0008-conformance-level-design.md
@@ -1,0 +1,73 @@
+# ADR-0008: Four conformance levels (0–3) rather than binary conformant/non-conformant
+
+**Status**: Accepted  
+**Date**: 2026-06-07  
+**Spec section**: Section 6 (Conformance)
+
+## Context
+
+Different deployment environments offer materially different trust guarantees. A developer laptop, a production Linux server with TPM 2.0, an AMD SEV-SNP confidential VM, and a managed TEE with a full cryptographic audit chain are not equivalent. The spec needs to communicate these differences in a way that:
+
+1. Allows adopters to start with a low-friction option and upgrade incrementally
+2. Maps cleanly to specific regulatory requirements (EU AI Act risk tiers, FedRAMP impact levels, HIPAA, DORA)
+3. Is unambiguous for both implementers and auditors
+4. Scales with the cryptographic machinery available in a given environment
+
+The alternative is a binary conformant/non-conformant model where every deployment meets the same bar or does not conform at all.
+
+## Decision
+
+Define **four conformance levels** numbered 0 through 3. Each level is a strict superset of the one below: a Level 2 implementation is also Level 1 and Level 0 conformant.
+
+| Level | Name | Hardware requirement | Attestation |
+|-------|------|---------------------|-------------|
+| 0 | Software-only | None | Ed25519 signature; no hardware measurement |
+| 1 | TPM-attested | TPM 2.0 | SHA-256 of manifest pre-image extended into a TPM PCR; PCR quote embedded in the manifest |
+| 2 | Confidential compute | AMD SEV-SNP or Intel TDX | Manifest hash extended into HOST_DATA or RTMR; hardware-signed attestation report |
+| 3 | Managed TEE + audit chain | OPAQUE runtime or equivalent | Silicon measurement plus hardware-signed Merkle-rooted audit chain |
+
+The spec defines **197 conformance tests** distributed across levels. A conformance claim must specify the level: "this implementation is Level 2 conformant" is a meaningful and auditable statement. "This implementation is conformant" without a level qualifier is not.
+
+## Rationale
+
+**Four levels, not two, because the hardware landscape has four meaningful tiers.** A binary model forces a choice: set the bar at Level 0 (making conformance meaningless for regulated use cases) or at Level 2 (blocking developer machines, CI pipelines, and non-EU edge deployments). Neither option is usable. Trust is not binary.
+
+**Level 0 is still valid and useful.** A software-signed manifest with no hardware attestation is cryptographically stronger than no manifest at all. It establishes agent identity, binds artifacts, supports delegation chains, and integrates with the revocation mechanism. Level 0 is appropriate for development environments, CI/CD pipelines, and non-regulated production deployments where identity binding is the primary goal. Excluding Level 0 would eliminate developer experience entirely and block the adoption path.
+
+**Level 1 maps to universally available server hardware.** TPM 2.0 is standard on Azure, AWS, and GCP VM instances and on most modern Linux servers. It is deployable without proprietary infrastructure or cloud-provider-specific APIs. Level 1 provides hardware-rooted trust without requiring confidential compute.
+
+**Level 2 covers regulated data workloads.** AMD SEV-SNP is available on Azure DCasv5, AWS C6a Nitro, and GCP N2D instances. Intel TDX is available on Azure DCedsv5 and GCP C3. Level 2 provides strong memory isolation and remote attestation, which satisfies EU AI Act Article 9 risk management requirements for high-risk AI systems.
+
+**Level 3 covers the highest-assurance environments.** A Merkle-rooted audit chain inside a managed TEE provides non-repudiable, hardware-anchored evidence of every decision the agent made, tied to a silicon measurement. This evidence level is required for FedRAMP High, HIPAA covered components handling PHI, and financial regulation (DORA) critical function assessment.
+
+**Strict superset semantics simplify testing.** A Level 2 test suite runs all Level 0 and Level 1 tests plus the Level 2-specific tests. There is no ambiguity about what "passes Level 2" means.
+
+**197 tests covers the full combination space.** The test count reflects all field combinations across 4 levels multiplied by attestation provider variants, artifact binding field permutations, and crypto profile variants. The distribution is: Level 0: 89 tests, Level 1: 51 tests, Level 2: 42 tests, Level 3: 15 tests.
+
+## Alternatives considered
+
+**Binary conformant/non-conformant**: A single bar that all deployments must meet. Rejected because the bar cannot be set at a useful level — Level 0 makes conformance meaningless for regulated environments; Level 2 blocks widespread adoption by excluding developer machines and edge devices.
+
+**Three tiers (dev/prod/regulated)**: Drop Level 1 (TPM-attested) and collapse TPM into the middle tier. Rejected because TPM attestation and SEV-SNP/TDX confidential compute are qualitatively different: TPM measures the boot chain but does not provide memory isolation. Treating them identically misstates the security properties and would mislead auditors.
+
+**Five or more tiers**: Further subdivide Level 3 or add a Level 4. Rejected because the spec's hardware attestation providers do not currently offer a fifth meaningfully distinct tier. More tiers increase conformance test surface area without adding regulatory clarity.
+
+**Named tiers instead of numbers (Bronze/Silver/Gold)**: Rejected because numbered levels compose naturally with version identifiers, can be referenced normatively ("Level 2 or above"), and resist marketing inflation. "Gold" is ambiguous across organizations; "Level 2" is not.
+
+**Attestation as a boolean field**: A single `attested: true/false` instead of a level. Rejected because it collapses the distinction between TPM, SEV-SNP, and managed TEE — which matters for regulatory mapping and threat modeling.
+
+## Consequences
+
+- A verifier must validate the `attestation.level` field against its configured minimum accepted level. A verifier requiring Level 2 must reject Level 0 and Level 1 manifests — not silently accept them.
+- PQC signatures (`crypto_profile: hybrid` or `post_quantum`) are required at Level 2 and above, as specified in ADR-0005.
+- Regulatory mappings in `docs/compliance/` use conformance levels as the unit of comparison. Level 0 satisfies developer/test environments. Level 2 satisfies EU AI Act Article 9 risk management requirements for high-risk AI systems. Level 3 satisfies FedRAMP High, HIPAA covered entity requirements, and DORA critical function assessment.
+- The `VerificationContext.enforce_attestation` flag gates Level 1+ at verification time. Future versions will add `min_attestation_level: int` for explicit minimum level enforcement in configuration.
+
+## References
+
+- [EU AI Act Article 14](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52021PC0206) — Human oversight requirements for high-risk AI
+- [NIST SP 800-53 Rev 5](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final) — FedRAMP High control baseline
+- [AMD SEV-SNP](https://www.amd.com/en/developer/sev.html)
+- [Intel TDX](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/documentation.html)
+- ADR-0005: ML-DSA-65 hybrid signatures (PQC requirement at Level 2+)
+- Spec Section 6: Conformance requirements and test identifier allocations

--- a/docs/adr/0009-spiffe-uri-for-agent-identity.md
+++ b/docs/adr/0009-spiffe-uri-for-agent-identity.md
@@ -1,0 +1,84 @@
+# ADR-0009: SPIFFE URIs as the canonical identity format for `agent_id` and `issuer`
+
+**Status**: Accepted  
+**Date**: 2026-06-07  
+**Spec section**: Section 2.2 (Identity Fields)
+
+## Context
+
+Every manifest must identify two principals:
+
+1. **The agent** (`agent_id`) — the workload whose behavior the manifest governs
+2. **The issuer** (`issuer`) — the authority that signed the manifest
+
+These identifiers must be:
+- Globally unique without a central registry
+- Structurally meaningful (carrying trust domain context, not opaque bytes)
+- Stable across key rotations and redeployments
+- Interoperable with existing zero-trust infrastructure (service meshes, cloud IAM, enterprise PKI)
+
+Multiple identity schemes exist: SPIFFE, DID methods (did:key, did:web, did:ethr), plain URNs, X.509 Subject DNs, and opaque UUIDs.
+
+## Decision
+
+Use **SPIFFE URIs** (`spiffe://trust-domain/path`) as the canonical identity format for both `agent_id` and `issuer`. All other formats are rejected at validation time by the Python SDK.
+
+Valid example:
+```
+spiffe://payments.acme.com/agents/settlement-agent-v2
+```
+
+The trust domain (`payments.acme.com`) is the org-level PKI boundary, operated by the deploying organization and registered out-of-band. The path component identifies the specific workload within that trust domain using slash-delimited segments.
+
+SDK validation rules enforced at `Manifest` construction time:
+- Must start with `spiffe://`
+- No URI fragment (`#`) — fragments have no meaning in SPIFFE
+- No query string (`?`) — SPIFFE URIs are path-only
+- Trust domain must be a valid hostname (RFC 1123)
+- Path must be slash-delimited segments with no empty components
+
+Multi-org deployments follow the SPIFFE Federation specification: trust domain federation is established at the infrastructure layer (SPIRE server-to-server federation), not at the manifest layer.
+
+## Rationale
+
+**SPIFFE is the established standard for workload identity in zero-trust infrastructure.** It is used natively by Istio, Linkerd, Envoy, SPIRE, Cilium, and HashiCorp Vault's identity framework. It is the default identity format in Kubernetes SPIFFE/SPIRE integration. An agent running alongside any of these already has a SPIFFE identity available through the SPIFFE Workload API (X.509-SVID). Reusing this identity requires zero additional configuration for the majority of cloud-native deployments.
+
+**Trust domain semantics are explicit and structurally enforced.** `spiffe://bank.example/agents/payments` makes it unambiguous that `bank.example` vouches for this identity. An identifier like `agent-payments-prod` carries no such claim. This matters critically for multi-org delegation chains: `spiffe://bank.example/agent/payments` cannot impersonate `spiffe://regulator.example/agent/auditor` because the trust domains are structurally distinct and cannot be confused by string manipulation.
+
+**SPIFFE URIs are infrastructure-neutral.** Unlike X.509 Subject DNs (which require a CA hierarchy) or DIDs (which often require a blockchain or external HTTP resolver), SPIFFE URIs are resolved by the deployer's own SPIRE server. An air-gapped deployment can mint SPIFFE identities without external network access.
+
+**Path structure enables fleet organization without a central registry.** The path component under the trust domain is controlled by the deployer. `spiffe://corp.example/region/us-east/service/fraud-detector/env/prod` encodes organization, geography, service, and environment in a single identifier that is human-readable, hierarchical, and unique without requiring coordination with any external party.
+
+**SVID issuance provides a standard mechanism for backing SPIFFE identities cryptographically.** A SPIFFE Verifiable Identity Document (SVID) is an X.509 certificate or JWT that proves a workload holds a specific SPIFFE URI, issued by the deployer's SPIRE server. At Level 2+, the mTLS transport layer provides SVID-backed proof that the agent presenting the manifest is the same workload named in `agent_id`.
+
+## Alternatives considered
+
+**DID:key**: A self-sovereign DID derived from a public key (`did:key:z6Mk...`). No registry or infrastructure required. Rejected because `did:key` encodes the current signing key, not the logical identity of the agent. Key rotation would change the agent's `agent_id`, breaking all delegation chains, trust relationships, and policy rules that reference the old DID. An agent's logical identity must be stable across key rotations.
+
+**DID:web**: A DID resolved from a domain (`did:web:trust.example`). Requires hosting a DID document at `https://trust.example/.well-known/did.json`. Rejected because it introduces an HTTP resolution dependency at verification time and couples the agent's identity to the domain's DNS and TLS availability — exactly the kind of online dependency the embedded design of the manifest (ADR-0006, ADR-0007) is designed to avoid.
+
+**DID:ethr and blockchain-anchored DIDs**: Identity anchored on Ethereum or another blockchain. Rejected categorically: blockchain anchoring introduces gas costs, transaction latency, and external infrastructure dependencies into a security-critical verification path. Not suitable for regulated environments or high-throughput verification.
+
+**Plain URNs (`urn:agent:...`)**: RFC 8141 URNs with a custom namespace. Rejected because URNs have no standard resolution or federation mechanism — there is no urn:agent NID assigned by IANA, no standard way to express trust domains, and no interoperability story with existing zero-trust infrastructure. SPIFFE provides all of this.
+
+**Opaque UUIDs**: A random UUID assigned at registration. Rejected because UUIDs carry no trust domain context — a UUID from one organization is syntactically identical to one from another. UUIDs require a central registry to map them to actual identities and offer no structural guarantee of uniqueness across organizations.
+
+**X.509 Subject DN** (`CN=kyc-agent, O=Corp, C=US`): The identity format used in mTLS certificates. Rejected because Subject DNs have no standardized path semantics, are not URL-safe, vary in encoding by CA policy, and require CA-specific parsing to extract a workload identifier reliably.
+
+## Consequences
+
+- The Python SDK validates `agent_id` and `issuer` as SPIFFE URIs at `Manifest` construction time. Any value that does not match `spiffe://[trust-domain]/[path]` raises `ValidationError`.
+- Deployers who do not run a SPIRE server must still use the SPIFFE URI format. They can mint identities manually for development or use a lightweight SPIFFE implementation. The syntactic format is required even if full SVID validation is not in use.
+- SVID-backed verification of SPIFFE URIs (confirming that the presenting workload genuinely holds the identity) is out of scope for Level 0 and Level 1. It is addressed by the mTLS transport layer at Level 2+, where the X.509-SVID chain is checked against the trust anchor.
+- Multi-org delegation chains are naturally expressed and visually distinct: `spiffe://bank.example/agent/payments` delegating to `spiffe://vendor.example/agent/processor` makes the cross-org boundary obvious. Intra-org delegation (`spiffe://corp.example/agent/root` to `spiffe://corp.example/agent/worker`) is visually distinct from cross-org.
+
+## References
+
+- [SPIFFE Specification](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE.md)
+- [SPIFFE Federation Specification](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md)
+- [SPIRE — SPIFFE Runtime Environment](https://spiffe.io/docs/latest/spire-about/)
+- [RFC 1123](https://www.rfc-editor.org/rfc/rfc1123) — Hostname syntax requirements
+- [RFC 9110 §4](https://www.rfc-editor.org/rfc/rfc9110#section-4) — URI format reference
+- ADR-0006: HITL approval mechanism (uses SPIFFE URIs for `approver_id`)
+- ADR-0007: Revocation CRL (uses SPIFFE URIs for `revoked_by`)
+- Spec Section 2.2: Identity field validation rules

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -8,10 +8,10 @@ Each major design decision in the Agent Manifest Specification is recorded here 
 | [0002](0002-ed25519-standard-profile.md) | Ed25519 as the standard cryptographic profile | Accepted |
 | [0003](0003-rfc9162-merkle-domain-separation.md) | RFC 9162 Merkle tree with domain separation | Accepted |
 | [0004](0004-pydantic-v2-schema-modeling.md) | Pydantic v2 for schema modeling in the Python SDK | Accepted |
-| [0005](0005-ml-dsa-hybrid-signatures.md) | ML-DSA-65 and hybrid Ed25519+ML-DSA-65 signatures | Accepted |
-| [0006](0006-hitl-approval-mechanism.md) | HITL approval mechanism design | Accepted |
-| [0007](0007-revocation-crl-format.md) | Append-only JSON-Lines CRL for manifest revocation | Accepted |
-| [0008](0008-conformance-levels.md) | Four conformance levels (0–3) | Accepted |
-| [0009](0009-spiffe-uri-agent-identity.md) | SPIFFE URIs for agent identity | Accepted |
+| [0005](0005-ml-dsa-hybrid-signature.md) | ML-DSA-65 and hybrid Ed25519+ML-DSA-65 signature support | Accepted |
+| [0006](0006-hitl-approval-mechanism.md) | Human-in-the-Loop (HITL) embedded approval record design | Accepted |
+| [0007](0007-revocation-json-lines-crl.md) | JSON-Lines append-only CRL as the SDK revocation format | Accepted |
+| [0008](0008-conformance-level-design.md) | Four conformance levels (0–3) rather than binary conformant/non-conformant | Accepted |
+| [0009](0009-spiffe-uri-for-agent-identity.md) | SPIFFE URIs as the canonical identity format for agent_id and issuer | Accepted |
 
 To propose a new ADR, open a GitHub issue using the [spec change template](https://github.com/agentrust-io/agent-manifest/issues/new?template=spec_change.md) and follow the [ADR template](0000-template.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,11 +119,11 @@ nav:
       - ADR-0002 — Ed25519 Standard Profile: adr/0002-ed25519-standard-profile.md
       - ADR-0003 — RFC 9162 Merkle Trees: adr/0003-rfc9162-merkle-domain-separation.md
       - ADR-0004 — Pydantic v2 Schema Modeling: adr/0004-pydantic-v2-schema-modeling.md
-      - ADR-0005 — ML-DSA-65 Hybrid Signatures: adr/0005-ml-dsa-hybrid-signatures.md
+      - ADR-0005 — ML-DSA-65 Hybrid Signatures: adr/0005-ml-dsa-hybrid-signature.md
       - ADR-0006 — HITL Approval Mechanism: adr/0006-hitl-approval-mechanism.md
-      - ADR-0007 — JSON-Lines CRL Format: adr/0007-revocation-crl-format.md
-      - ADR-0008 — Conformance Levels 0–3: adr/0008-conformance-levels.md
-      - ADR-0009 — SPIFFE URI Identity: adr/0009-spiffe-uri-agent-identity.md
+      - ADR-0007 — JSON-Lines Revocation CRL: adr/0007-revocation-json-lines-crl.md
+      - ADR-0008 — Conformance Level Design: adr/0008-conformance-level-design.md
+      - ADR-0009 — SPIFFE URI for Agent Identity: adr/0009-spiffe-uri-for-agent-identity.md
   - Compliance:
       - Overview: compliance/index.md
       - EU AI Act: compliance/eu-ai-act.md


### PR DESCRIPTION
## Summary

Five Architecture Decision Records covering the post-quantum cryptography profile, human-in-the-loop approval design, revocation format, conformance level model, and agent identity scheme.

- **ADR-0005** (`0005-ml-dsa-hybrid-signature.md`): ML-DSA-65 and hybrid Ed25519+ML-DSA-65 signature support — parameter set selection, hybrid transition path, signature sizes, and the `[pq]` optional dependency. Closes #71
- **ADR-0006** (`0006-hitl-approval-mechanism.md`): Human-in-the-Loop embedded approval record design — `hitl_record` structure, approver-signed approval, offline verifiability, time-bounded approval semantics. Closes #72
- **ADR-0007** (`0007-revocation-json-lines-crl.md`): JSON-Lines append-only CRL as the SDK revocation format — O(1) append semantics, signed revocation records, `FileCRL` vs production database-backed stores, `.well-known` discovery. Closes #73
- **ADR-0008** (`0008-conformance-level-design.md`): Four conformance levels (0–3) rather than binary conformant/non-conformant — level definitions, regulatory mapping (EU AI Act Article 9, FedRAMP High, HIPAA, DORA), 197 conformance tests. Closes #74
- **ADR-0009** (`0009-spiffe-uri-for-agent-identity.md`): SPIFFE URIs as the canonical identity format for `agent_id` and `issuer` — rationale over DID:key, DID:web, URNs, and UUIDs; SDK validation rules; SPIFFE Federation for multi-org deployments. Closes #75

Updated `docs/adr/index.md` and `mkdocs.yml` to reference all five new files.

## Test plan

- [ ] Verify all five ADR files render correctly in MkDocs (`mkdocs serve`)
- [ ] Confirm index table links resolve to the correct files
- [ ] Confirm mkdocs.yml nav entries point to the correct filenames
- [ ] Check that no broken links exist in cross-ADR references (ADR-0005 refs ADR-0002, ADR-0006 refs ADR-0009, ADR-0007 refs ADR-0001, ADR-0008 refs ADR-0005, ADR-0009 refs ADR-0006/0007)

🤖 Generated with [Claude Code](https://claude.com/claude-code)