### PR TITLE
docs(tutorials): add five how-to guides

### DIFF
--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -15,3 +15,7 @@ Each major design decision in the Agent Manifest Specification is recorded here 
 | [0009](0009-spiffe-uri-agent-identity.md) | SPIFFE URIs for agent identity | Accepted |
 
 To propose a new ADR, open a GitHub issue using the [spec change template](https://github.com/agentrust-io/agent-manifest/issues/new?template=spec_change.md) and follow the [ADR template](0000-template.md).
+
+---
+
+For practical implementation guidance that corresponds to these decisions, see the [tutorials](../tutorials/index.md): [HITL approval workflows](../tutorials/hitl-approval-workflows.md) (ADR-0006), [revocation and key rotation](../tutorials/revocation-and-key-rotation.md) (ADR-0007), [hardware attestation](../tutorials/hardware-attestation.md) (ADR-0008), and [server-side verification](../tutorials/server-side-verification.md).

--- a/docs/tutorials/deploying-the-verification-endpoint.md
+++ b/docs/tutorials/deploying-the-verification-endpoint.md
@@ -1,0 +1,204 @@
+# Deploying the Verification Endpoint
+
+The agent-manifest SDK ships a FastAPI router that you can deploy as a standalone verification service, a sidecar, or embedded in an existing API. After this tutorial you will be able to:
+
+- Package the verifier as a Docker container
+- Configure the manifest store and CRL
+- Expose the `.well-known` discovery endpoint (RFC 8615)
+- Add health checks and Kubernetes readiness probes
+- Run the complete stack with docker-compose
+
+## Prerequisites
+
+```bash
+pip install "agent-manifest[server]"
+```
+
+---
+
+## Architecture options
+
+| Deployment mode | When to use |
+|-----------------|-------------|
+| **Sidecar** | Each agent service runs its own verifier alongside it — no network hop, lowest latency |
+| **Centralized service** | Shared verifier for a fleet — single manifest store, easier CRL management |
+| **Embedded in API gateway** | Verifier mounted directly in the main application — fewest moving parts |
+
+This tutorial packages the verifier as a standalone container, which works for all three modes.
+
+---
+
+## Container packaging
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY pyproject.toml .
+RUN pip install "agent-manifest[server]"
+COPY verifier.py .
+CMD ["uvicorn", "verifier:app", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+```bash
+docker build -t agent-manifest-verifier .
+```
+
+---
+
+## The full server (`verifier.py`)
+
+```python
+from fastapi import FastAPI
+from agent_manifest._verify import create_router, RevocationStore
+from agent_manifest._revocation import create_crl_router, FileCRL
+import os
+
+app = FastAPI(title="Agent Manifest Verifier")
+
+manifest_store: dict = {}
+crl = FileCRL(os.getenv("CRL_PATH", "/data/revocations.jsonl"))
+revocation_store = RevocationStore()
+
+app.include_router(create_router(manifest_store, revocation_store), prefix="/agent")
+app.include_router(create_crl_router(crl))
+
+
+@app.get("/.well-known/agent-manifest")
+async def discovery():
+    """RFC 8615 discovery document."""
+    return {
+        "revocation": "/.well-known/agent-manifest/revocation",
+        "verify": "/agent/verify",
+    }
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+```
+
+This mounts the following endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/agent/verify?manifest_id=...` | Returns a `VerificationResult` |
+| `GET` | `/agent/revocation-status?manifest_id=...` | Returns revocation record or 404 |
+| `GET` | `/.well-known/agent-manifest/revocation` | Full CRL as JSON array |
+| `GET` | `/.well-known/agent-manifest/revocation/{id}` | Single CRL entry or 404 |
+| `GET` | `/.well-known/agent-manifest` | Discovery document |
+| `GET` | `/health` | Liveness probe |
+
+!!! note
+    `RevocationStore` in this example is in-memory. For production, replace it with a database-backed store that is shared across replicas and persists across restarts.
+
+---
+
+## docker-compose setup
+
+```yaml
+# examples/docker-compose-verifier.yml
+version: "3.9"
+services:
+  verifier:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/data
+    environment:
+      CRL_PATH: /data/revocations.jsonl
+
+  agent-service:
+    image: python:3.12-slim
+    command: ["echo", "Replace with your agent service"]
+```
+
+```bash
+# Create the data directory and a blank CRL file
+mkdir -p data && touch data/revocations.jsonl
+
+docker-compose -f examples/docker-compose-verifier.yml up
+
+# Verify a manifest
+curl "http://localhost:8080/agent/verify?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+# Browse the CRL
+curl "http://localhost:8080/.well-known/agent-manifest/revocation"
+```
+
+---
+
+## Environment variables reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CRL_PATH` | `/data/revocations.jsonl` | Path to the JSON-Lines CRL file |
+| `LOG_LEVEL` | `info` | Uvicorn log level (`debug`, `info`, `warning`, `error`) |
+| `UVICORN_WORKERS` | `1` | Number of uvicorn worker processes |
+
+Read them in `verifier.py`:
+
+```python
+import os
+from pathlib import Path
+
+CRL_PATH = Path(os.getenv("CRL_PATH", "/data/revocations.jsonl"))
+LOG_LEVEL = os.getenv("LOG_LEVEL", "info")
+```
+
+---
+
+## Health checks and readiness
+
+The `/health` endpoint returns `{"status": "ok"}` as soon as the process starts — use it for Kubernetes liveness probes. If you want a readiness gate that waits until manifests are loaded, add a separate `/ready` endpoint:
+
+```python
+@app.get("/ready")
+async def ready():
+    if not manifest_store:
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            status_code=503,
+            content={"status": "no manifests loaded"},
+        )
+    return {"status": "ready", "manifests": len(manifest_store)}
+```
+
+Kubernetes probe configuration:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 3
+  periodSeconds: 5
+```
+
+---
+
+## `.well-known/agent-manifest` discovery
+
+The discovery endpoint follows [RFC 8615](https://www.rfc-editor.org/rfc/rfc8615) (well-known URIs). Clients can `GET /.well-known/agent-manifest` to discover the verification and revocation URLs without hardcoding them.
+
+```bash
+curl http://localhost:8080/.well-known/agent-manifest
+# {"revocation":"/.well-known/agent-manifest/revocation","verify":"/agent/verify"}
+```
+
+Agents bootstrapping in a new environment should use the discovery document rather than assuming fixed paths.
+
+---
+
+## What's next
+
+- [Tutorial: Revocation and key rotation](revocation-and-key-rotation.md) — update the CRL in the running verifier
+- [Operations: Monitoring](../operations/monitoring.md) — metrics and alerting for the verification endpoint
+- [Operations: Key rotation runbook](../operations/key-rotation.md)

--- a/docs/tutorials/hardware-attestation.md
+++ b/docs/tutorials/hardware-attestation.md
@@ -1,45 +1,50 @@
-# Hardware attestation (SEV-SNP, TDX, OPAQUE)
+# Hardware Attestation (SEV-SNP, TDX, OPAQUE)
 
 Hardware attestation binds the manifest to a cryptographic measurement from silicon — proving the agent is running inside a specific, unmodified trusted execution environment. After this tutorial you will be able to:
 
-- Choose the right provider for your infrastructure
-- Extend the manifest hash into hardware (SEV-SNP, TDX, OPAQUE)
+- Choose the right attestation provider for your infrastructure
+- Extend the manifest hash into hardware using `SEVSNPProvider`, `TDXProvider`, or `OPAQUEProvider`
 - Read and verify the attestation report
-- Use the auto-provider when the environment is unknown at build time
+- Use the auto-provider when the environment is not known at build time
+- Write tests that work without hardware
 
 ## Prerequisites
 
 ```bash
-pip install agent-manifest              # for OPAQUE (HTTP only)
-pip install "agent-manifest[server]"    # adds httpx for OPAQUE
+pip install agent-manifest              # core SDK
+pip install "agent-manifest[server]"   # adds httpx for OPAQUEProvider
 ```
 
-Hardware providers require the appropriate VM type — see the table below.
+Hardware providers require the VM types listed in the table below. The `SoftwareProvider` fallback works everywhere.
 
 ---
 
-## Conformance levels and providers
+## Conformance levels
 
-| Level | Provider | Infrastructure |
-|-------|----------|---------------|
-| 0 | *(none — software signing only)* | Any |
+| Level | Provider | Infrastructure requirement |
+|-------|----------|--------------------------|
+| 0 | *(none)* | Any — software signing only |
 | 1 | `TPMProvider` | Linux host with TPM 2.0 |
 | 2 | `SEVSNPProvider` | AMD EPYC (Milan+): Azure DCasv5, AWS C6a Nitro, GCP N2D |
 | 2 | `TDXProvider` | Intel Xeon (Sapphire Rapids+): Azure DCedsv5, GCP C3 |
 | 3 | `OPAQUEProvider` | Any — delegates to OPAQUE's managed TEE |
 
-Level 2 provides the strongest locally-verifiable hardware guarantee. Level 3 adds an audit chain signed inside the TEE by OPAQUE's infrastructure.
+Level 2 provides the strongest locally-verifiable hardware guarantee. Level 3 adds a hardware-signed audit chain managed by OPAQUE inside their TEE.
 
 ---
 
 ## AMD SEV-SNP (Level 2)
 
-### Requirements
+### Prerequisites
 
 - AMD EPYC Milan or Genoa CPU with SEV-SNP enabled in BIOS
 - Linux kernel 5.19+ with `CONFIG_AMD_MEM_ENCRYPT=y`
-- Running inside an SEV-SNP VM
-- `/dev/sev-guest` readable by the process (typically requires `CAP_SYS_ADMIN` or a udev rule)
+- Running inside an SEV-SNP VM (Azure DCasv5, AWS C6a Nitro, or GCP N2D Confidential)
+- `/dev/sev-guest` readable by the process (requires `CAP_SYS_ADMIN` or a dedicated udev rule)
+
+### How it works
+
+`SEVSNPProvider.extend_manifest_hash()` computes `SHA-256(manifest_pre_image)` and places the 32-byte digest in the first half of the `HOST_DATA` field of the SNP attestation report. `HOST_DATA` is 64 bytes reserved for user-defined binding data. Verifiers check that `HOST_DATA[:32]` matches the expected manifest hash.
 
 ### Usage
 
@@ -54,55 +59,59 @@ except AttestationUnavailableError as e:
     print(f"SEV-SNP not available: {e}")
     raise SystemExit(1)
 
-# Load the manifest you want to attest
 with open("manifest.json") as f:
     manifest = json.load(f)
 
 # Extends SHA-256(manifest_pre_image) into HOST_DATA
 provider.extend_manifest_hash(manifest)
 
-# Read the hardware attestation report
+# Read the attestation report
 report = provider.get_attestation_report()
-print(f"Platform:      {report.platform}")          # "amd-sev-snp"
-print(f"Manifest hash: {report.manifest_hash}")     # "sha256:..."
-print(f"Measurement:   {report.raw['measurement']}")  # 48-byte PCR hex
+print(f"Platform:      {report.platform}")             # "amd-sev-snp"
+print(f"Manifest hash: {report.manifest_hash}")        # "sha256:..."
+print(f"Measurement:   {report.raw['measurement']}")   # 48-byte hex
 
 # Confirm the report binds to this manifest
 assert provider.verify_manifest_in_report(report, manifest)
 ```
 
-### What is in the report
+### What the report contains
 
 | Field | Description |
 |-------|-------------|
-| `raw.host_data` | 64 bytes: first 32 = SHA-256 of manifest pre-image, last 32 = zeros |
-| `raw.measurement` | 48-byte platform measurement (covers firmware + kernel) |
-| `raw.vmpl` | VMPL level (0 = highest privilege) |
+| `raw['host_data']` | 64 bytes: first 32 = SHA-256 of manifest pre-image, last 32 = zeros |
+| `raw['measurement']` | 48-byte platform measurement covering firmware and kernel |
+| `raw['vmpl']` | VMPL level (0 = highest privilege) |
+| `raw['vcek_cert_chain_verified']` | Always `False` in the SDK — fetch the VCEK from AMD KDS to verify independently |
 
 ---
 
 ## Intel TDX (Level 2)
 
-### Requirements
+### Prerequisites
 
 - Intel 4th Gen Xeon (Sapphire Rapids) or later with TDX enabled
 - Linux kernel 6.2+ with TDX guest driver (`/dev/tdx-guest`)
-- Running inside an Intel TDX Trust Domain
+- Running inside an Intel TDX Trust Domain (Azure DCedsv5 or GCP C3 Confidential)
+
+### How it works
+
+`TDXProvider.extend_manifest_hash()` places `SHA-256(manifest_pre_image)` in the `REPORTDATA` field of the TD report. RTMR[1] is the conventional application-level measurement register — RTMR[0] is owned by firmware.
 
 ### Usage
 
 ```python
 from agent_manifest._hw_providers import TDXProvider
 
-# rtmr_index=1 is the conventional application measurement register
+# rtmr_index=1 is the conventional choice for application measurements
 provider = TDXProvider(rtmr_index=1)
 
 provider.extend_manifest_hash(manifest)
 report = provider.get_attestation_report()
 
-print(f"Platform:    {report.platform}")        # "intel-tdx"
-print(f"RTMR index:  {report.raw['rtmr_index']}")  # 1
-print(f"Report data: {report.raw['report_data']}")  # 64-byte hex
+print(f"Platform:    {report.platform}")             # "intel-tdx"
+print(f"RTMR index:  {report.raw['rtmr_index']}")   # 1
+print(f"Report data: {report.raw['report_data']}")   # 64-byte hex
 
 assert provider.verify_manifest_in_report(report, manifest)
 ```
@@ -113,19 +122,19 @@ assert provider.verify_manifest_in_report(report, manifest)
 |------|-----------------|
 | 0 | TD-measured (firmware and boot) — do not use |
 | 1 | OS and application-level measurements — use this |
-| 2 | Available for software use |
-| 3 | Available for software use |
+| 2 | Available for additional software measurements |
+| 3 | Available for additional software measurements |
 
 ---
 
-## OPAQUE managed runtime (Level 3)
+## OPAQUE Managed TEE (Level 3)
 
-OPAQUE runs the attestation inside its own TEE and returns a signed TRACE claim. No local hardware is required — OPAQUE handles the silicon-level measurement on your behalf.
+OPAQUE runs attestation inside its own managed TEE and returns a signed TRACE claim. No local hardware is required.
 
-### Requirements
+### Prerequisites
 
-- `OPAQUE_ATTESTATION_URL` environment variable pointing to the OPAQUE attestation service
-- Optionally `OPAQUE_API_KEY` for authenticated access
+- Set `OPAQUE_ATTESTATION_URL` to the OPAQUE attestation service base URL (must be `https://`)
+- Optionally set `OPAQUE_API_KEY` for authenticated access
 - `httpx` installed (`pip install "agent-manifest[server]"`)
 
 ### Usage
@@ -135,15 +144,15 @@ import os
 from agent_manifest._hw_providers import OPAQUEProvider
 
 os.environ["OPAQUE_ATTESTATION_URL"] = "https://attest.opaque.co"
-# os.environ["OPAQUE_API_KEY"] = "your-key"   # if required
+# os.environ["OPAQUE_API_KEY"] = "your-key"  # if required
 
 provider = OPAQUEProvider()
 provider.extend_manifest_hash(manifest)
 
 report = provider.get_attestation_report()
-print(f"Platform: {report.platform}")   # "opaque"
+print(f"Platform:      {report.platform}")      # "opaque"
 print(f"Manifest hash: {report.manifest_hash}")
-print(f"TRACE claim: {report.raw}")     # eat_profile, iat, audit_chain_root, ...
+print(f"TRACE claim:   {report.raw}")
 
 assert provider.verify_manifest_in_report(report, manifest)
 ```
@@ -161,22 +170,40 @@ assert provider.verify_manifest_in_report(report, manifest)
 }
 ```
 
-The `audit_chain_root` anchors every decision the agent made to a Merkle chain held inside the OPAQUE TEE — this is the Level 3 guarantee.
+The `audit_chain_root` anchors every decision the agent made to a Merkle chain held inside the OPAQUE TEE. This is the Level 3 guarantee — the signing key never leaves the TEE.
 
 ---
 
-## Auto-provider: pick the best available hardware
+## Choosing the right level
 
-Use `_auto_provider.py` when the environment is not known at build time — it tries each provider in order and falls back to software-only.
+| Use case | Recommended level | Provider |
+|----------|------------------|---------|
+| Development and local testing | 0 | `SoftwareProvider` |
+| Enterprise internal deployment | 1 | `TPMProvider` |
+| EU AI Act Art. 15 (cybersecurity) | 2 | `SEVSNPProvider` or `TDXProvider` |
+| Financial services, regulated workloads | 2+ | `SEVSNPProvider` / `TDXProvider` |
+| Full audit chain, OPAQUE-managed trust | 3 | `OPAQUEProvider` |
+| Unknown environment, pick best available | any | `select_provider(level=N)` |
+
+---
+
+## Auto-detection
+
+Use `select_provider()` when the environment is not known at build time. It probes in order: OPAQUE (if env var set) then SEV-SNP then TDX then TPM then software-only.
 
 ```python
-from agent_manifest._auto_provider import SoftwareProvider
+from agent_manifest._auto_provider import select_provider
+from agent_manifest._providers import AttestationUnavailableError
 
-# Falls back gracefully: OPAQUE → TDX → SEV-SNP → TPM → software
-provider = SoftwareProvider()
+# Raises AttestationUnavailableError if level=1 and no hardware is available
+try:
+    provider = select_provider(level=1)
+except AttestationUnavailableError:
+    # Fallback to Level 0 in development
+    provider = select_provider(level=0)
+
 provider.extend_manifest_hash(manifest)
 report = provider.get_attestation_report()
-
 print(f"Attested on: {report.platform}")
 # "amd-sev-snp" in an SEV-SNP VM
 # "intel-tdx"   in a TDX Trust Domain
@@ -186,38 +213,59 @@ print(f"Attested on: {report.platform}")
 
 ---
 
-## Testing without hardware
+## Mocked examples for developers without hardware
 
-All providers raise `AttestationUnavailableError` if the hardware is absent. In tests, mock the provider:
+All providers raise `AttestationUnavailableError` if the hardware device is absent. In tests, mock the provider rather than skipping tests entirely.
 
 ```python
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from agent_manifest._providers import AttestationReport
 
 mock_report = AttestationReport(
     platform="amd-sev-snp",
     manifest_hash="sha256:" + "aa" * 32,
-    raw={"measurement": "bb" * 48, "host_data": "cc" * 64, "vmpl": 0},
+    raw={
+        "host_data": "cc" * 64,
+        "measurement": "bb" * 48,
+        "vmpl": 0,
+        "vcek_cert_chain_verified": False,
+    },
 )
 
-with patch("agent_manifest._hw_providers.SEVSNPProvider.extend_manifest_hash"), \
-     patch("agent_manifest._hw_providers.SEVSNPProvider.get_attestation_report",
-           return_value=mock_report):
-    # your test code
+with patch(
+    "agent_manifest._hw_providers.SEVSNPProvider.extend_manifest_hash"
+), patch(
+    "agent_manifest._hw_providers.SEVSNPProvider.get_attestation_report",
+    return_value=mock_report,
+):
+    # your test code here
     pass
 ```
 
-Or gate the test on hardware availability:
+`SoftwareProvider` is useful for unit tests that exercise the attestation flow without mocking:
 
 ```python
-import os, pytest
+from agent_manifest._auto_provider import SoftwareProvider
 
-NEEDS_SEV_SNP = pytest.mark.skipif(
+provider = SoftwareProvider()
+provider.extend_manifest_hash(manifest)
+report = provider.get_attestation_report()
+# report.platform == "software"
+# Note: "software" measurement is not accepted for Level 1+ conformance
+```
+
+Gate hardware-only tests with a skip marker:
+
+```python
+import os
+import pytest
+
+needs_sev_snp = pytest.mark.skipif(
     not os.path.exists("/dev/sev-guest"),
     reason="requires AMD SEV-SNP hardware",
 )
 
-@NEEDS_SEV_SNP
+@needs_sev_snp
 def test_sev_snp_roundtrip():
     provider = SEVSNPProvider()
     provider.extend_manifest_hash(manifest)
@@ -229,5 +277,5 @@ def test_sev_snp_roundtrip():
 
 ## What's next
 
-- [Tutorial: Deploying the verification endpoint](deploy-verifier.md) — run the verifier in production alongside your hardware-attested agents
+- [Tutorial: Deploying the verification endpoint](deploying-the-verification-endpoint.md) — run the verifier in production alongside hardware-attested agents
 - [Tutorial: Server-side verification](server-side-verification.md) — enforce minimum attestation level with `enforce_attestation=True`

--- a/docs/tutorials/hitl-approval-workflows.md
+++ b/docs/tutorials/hitl-approval-workflows.md
@@ -1,0 +1,244 @@
+# HITL Approval Workflows
+
+Human-in-the-loop (HITL) approval lets an agent record that a human explicitly authorised a high-risk action and cryptographically binds that authorisation to the manifest. The EU AI Act Article 14 requires "appropriate human oversight measures" for high-risk AI systems; a signed HITL record is one concrete way to demonstrate compliance.
+
+After this tutorial you will be able to:
+
+- Configure a manifest to require human approval
+- Build and attach a signed `HITLRecord` to a manifest
+- Verify that the approval is present, unexpired, and from an authorised approver
+- Understand what triggers `HitlResult.MISSING` and `HitlResult.EXPIRED`
+
+## Prerequisites
+
+```bash
+pip install agent-manifest
+```
+
+---
+
+## Why HITL belongs in the manifest
+
+A plain timestamp field in a database can be backdated or deleted. The HITL record in an agent manifest is different:
+
+1. The approver signs over `{manifest_id, approved_at, approved_scope, approver_id}` with their own key
+2. That signature is embedded in the manifest
+3. The manifest itself is then signed by the agent's key
+
+Removing or altering the approval breaks both signatures. Verifiers can reject the manifest without contacting any external system.
+
+---
+
+## Step 1: Configure `required_approvals`
+
+Set `hitl_record.required = True` when building the manifest. Leave `approvals` empty — it is filled in after the human signs off.
+
+```python
+from agent_manifest import Manifest, ArtifactBindings, CryptoProfile
+from agent_manifest._types import ManifestId
+from datetime import datetime, timedelta, timezone
+
+now = datetime.now(timezone.utc)
+manifest_id = str(ManifestId.generate())
+
+manifest = Manifest(
+    manifest_id=manifest_id,
+    agent_id="spiffe://finance.acme.com/agent/trading/prod",
+    version="0.1",
+    issued_at=now,
+    expires_at=now + timedelta(hours=4),
+    issuer="spiffe://finance.acme.com/signing-authority",
+    crypto_profile=CryptoProfile.standard,
+    artifacts=ArtifactBindings(),
+    hitl_record={
+        "required": True,
+        "required_approvals": 1,
+        "approvals": [],   # filled in after human approval
+    },
+)
+```
+
+---
+
+## Step 2: Build the evidence hash
+
+The `evidence_hash` field binds the approval to a specific action or dataset, not just to the manifest. Compute it by hashing the action description in a stable, reproducible way.
+
+```python
+import hashlib
+import json
+
+action = {
+    "action": "execute_trade",
+    "amount_usd": 500000,
+    "symbol": "AAPL",
+}
+evidence_hash = "sha256:" + hashlib.sha256(
+    json.dumps(action, sort_keys=True).encode()
+).hexdigest()
+```
+
+---
+
+## Step 3: Get human approval and sign it
+
+In production this step happens through an approval workflow — a Slack bot, web UI, or dedicated approval service. The approver authenticates with their FIDO2 key, reviews the action, and the system signs on their behalf.
+
+```python
+from agent_manifest import generate_ed25519
+from agent_manifest._delegation import HitlApprovalSigner
+
+# In production: load the approver's key from their FIDO2 or HSM session
+approver_kp = generate_ed25519()
+
+approved_at = datetime.now(timezone.utc).isoformat()
+approved_scope = {
+    "action": "execute_trade",
+    "max_notional_usd": 500_000,
+    "approval_duration_seconds": 3600,  # approval valid for 1 hour
+}
+
+approver = HitlApprovalSigner(keypair=approver_kp)
+approval_sig = approver.sign_approval(
+    manifest_id=manifest_id,
+    approved_at=approved_at,
+    approved_scope=approved_scope,
+    approver_id="spiffe://finance.acme.com/managers/jane-doe",
+)
+```
+
+---
+
+## Step 4: Attach the approval and sign the manifest
+
+```python
+from agent_manifest._signing import Ed25519Signer
+
+agent_kp = generate_ed25519()
+
+manifest.hitl_record["approvals"] = [{
+    "approver_id":        "spiffe://finance.acme.com/managers/jane-doe",
+    "approved_at":        approved_at,
+    "approved_scope":     approved_scope,
+    "evidence_hash":      evidence_hash,
+    "approval_method":    "hardware_key",
+    "approval_signature": approval_sig,
+    "approver_key_id":    approver_kp.key_id,
+}]
+
+signer = Ed25519Signer(agent_kp)
+manifest_dict = manifest.model_dump(mode="json", by_alias=True)
+manifest_dict["signature"] = signer.sign(manifest_dict)
+```
+
+---
+
+## Step 5: Verify HITL with `verify_manifest()`
+
+Pass `enforce_hitl=True` in the `VerificationContext` so the verifier treats a missing or expired approval as a hard failure.
+
+```python
+from agent_manifest._verify import (
+    HitlResult,
+    OverallResult,
+    RevocationStore,
+    VerificationContext,
+    verify_manifest,
+)
+
+ctx = VerificationContext(enforce_hitl=True)
+result = verify_manifest(manifest_dict, ctx, RevocationStore())
+
+assert result.fields_verified.hitl_record == HitlResult.APPROVED
+assert result.result == OverallResult.VALID
+print(f"HITL status: {result.fields_verified.hitl_record}")  # APPROVED
+```
+
+---
+
+## Failure modes
+
+### Missing approval
+
+When `required = True` but `approvals` is empty and `enforce_hitl=True`, the result is `MISMATCH` with `HitlResult.MISSING`:
+
+```python
+no_approval_manifest = dict(manifest_dict)
+no_approval_manifest["hitl_record"] = {
+    "required": True,
+    "required_approvals": 1,
+    "approvals": [],
+}
+
+ctx = VerificationContext(enforce_hitl=True)
+result = verify_manifest(no_approval_manifest, ctx, RevocationStore())
+
+assert result.fields_verified.hitl_record == HitlResult.MISSING
+assert result.result == OverallResult.MISMATCH
+```
+
+### Expired approval
+
+When `approval_duration_seconds` has elapsed since `approved_at`, the verifier sets `HitlResult.EXPIRED`. This always propagates to `MISMATCH` regardless of `enforce_hitl`:
+
+```python
+import time
+
+expired_scope = {**approved_scope, "approval_duration_seconds": 1}
+expired_sig = approver.sign_approval(
+    manifest_id=manifest_id,
+    approved_at=approved_at,
+    approved_scope=expired_scope,
+    approver_id="spiffe://finance.acme.com/managers/jane-doe",
+)
+
+expired_manifest = dict(manifest_dict)
+expired_manifest["hitl_record"]["approvals"][0]["approved_scope"] = expired_scope
+expired_manifest["hitl_record"]["approvals"][0]["approval_signature"] = expired_sig
+
+time.sleep(2)  # wait for the 1-second approval to expire
+
+result = verify_manifest(expired_manifest, VerificationContext(), RevocationStore())
+assert result.fields_verified.hitl_record == HitlResult.EXPIRED
+assert result.result == OverallResult.MISMATCH
+```
+
+### Approval from an unauthorised approver
+
+The verifier checks that the approval signature is cryptographically valid but does not enforce which `approver_id` values are acceptable — that is your policy. After calling `verify_manifest`, check the `approver_id` against your authorised set:
+
+```python
+AUTHORISED_APPROVERS = {
+    "spiffe://finance.acme.com/managers/jane-doe",
+    "spiffe://finance.acme.com/managers/bob-smith",
+}
+
+result = verify_manifest(manifest_dict, VerificationContext(enforce_hitl=True), RevocationStore())
+
+if result.fields_verified.hitl_record == HitlResult.APPROVED:
+    for approval in manifest_dict["hitl_record"]["approvals"]:
+        if approval["approver_id"] not in AUTHORISED_APPROVERS:
+            raise PermissionError(
+                f"Approval from unauthorised approver: {approval['approver_id']}"
+            )
+```
+
+---
+
+## Production guidance
+
+| Concern | Recommendation |
+|---------|----------------|
+| Approver key storage | FIDO2 hardware key or HSM; software keys are for development only |
+| Approval UI | Hash the `approved_scope` dict from your UI before presenting it to the approver for signing |
+| Multiple approvers | Set `required_approvals: 2` and add two entries to `approvals` |
+| Approval duration | 1-4 hours; require re-approval for long-running jobs rather than extending the window |
+| Audit trail | Log each `approval_signature` and `approver_key_id` in your SIEM alongside the manifest ID |
+| EU AI Act Art. 14 | Document that `approved_scope` maps to the specific AI system output that was reviewed |
+
+---
+
+## What's next
+
+- [Tutorial: Revocation and key rotation](revocation-and-key-rotation.md) — revoke a manifest if an approver's key is compromised
+- [Tutorial: Server-side verification](server-side-verification.md) — enforce HITL at the relying party

--- a/docs/tutorials/revocation-and-key-rotation.md
+++ b/docs/tutorials/revocation-and-key-rotation.md
@@ -1,0 +1,239 @@
+# Revocation and Key Rotation
+
+Revocation stops a compromised or decommissioned agent in under a minute. Any holder of the revoking authority's key can revoke a manifest without the original signing key. After this tutorial you will be able to:
+
+- Issue a signed revocation record and append it to a CRL
+- Stand up the `.well-known` CRL endpoint with FastAPI
+- Configure a verifier to check the CRL before accepting a manifest
+- Execute a zero-downtime key rotation after a compromise
+
+## Prerequisites
+
+```bash
+pip install "agent-manifest[server]"
+```
+
+---
+
+## Why revocation matters
+
+A manifest is signed at issue time. If the signing key is later compromised, all previously issued manifests remain technically valid — their signatures still verify. Revocation provides the out-of-band mechanism to mark those manifests as untrusted without waiting for their `expires_at` to pass.
+
+The CRL (Certificate Revocation List) is an append-only JSON-Lines file. Each line is a `SignedRevocationRecord` — the record itself is signed by the revoking authority's key, binding the revocation to a specific manifest ID and authority identity. Verifiers query the CRL before accepting any manifest.
+
+---
+
+## Part 1: Revoke a manifest programmatically
+
+```python
+from agent_manifest._revocation import sign_revocation, FileCRL
+from agent_manifest._signing import generate_ed25519
+
+# The revoking authority keypair — keep this separate from the signing key
+revocation_kp = generate_ed25519()
+
+# The manifest ID to revoke (UUID v7 from your manifest store)
+manifest_id = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+record = sign_revocation(
+    manifest_id=manifest_id,
+    reason="Key compromise detected in incident-2026-06-07",
+    revoked_by="spiffe://security.acme.com/incident-response",
+    keypair=revocation_kp,
+)
+
+crl = FileCRL("revocations.jsonl")
+crl.revoke(record)
+
+print(f"Revoked: {record.manifest_id}")
+print(f"At:      {record.revoked_at}")
+print(f"Sig:     {record.revocation_signature[:32]}...")
+```
+
+`FileCRL` is append-only — records are never deleted. It is suitable for development and small deployments. For production, replace it with a database-backed store and serve the CRL from there.
+
+---
+
+## Part 2: Stand up the CRL endpoint with FastAPI
+
+The `.well-known/agent-manifest/revocation` endpoint lets any verifier check revocation status over HTTP without access to the CRL file directly.
+
+```python
+from fastapi import FastAPI
+from agent_manifest._revocation import create_crl_router, FileCRL
+
+app = FastAPI()
+crl = FileCRL("revocations.jsonl")
+app.include_router(create_crl_router(crl))
+
+# Mounts:
+# GET /.well-known/agent-manifest/revocation
+#     Returns all revocation records as a JSON array
+# GET /.well-known/agent-manifest/revocation/{manifest_id}
+#     Returns one record, or 404 if not revoked
+```
+
+```bash
+uvicorn myapp:app --reload
+
+# Check if a manifest is revoked
+curl http://localhost:8000/.well-known/agent-manifest/revocation/018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c
+# 200 with the signed revocation record if revoked
+# 404 with {"error_code": "NOT_REVOKED", ...} if clean
+```
+
+---
+
+## Part 3: Configure a verifier to check the CRL
+
+Wire `FileCRL` into a `RevocationStore` so `verify_manifest()` checks revocation on every call.
+
+```python
+import json
+from agent_manifest._verify import (
+    OverallResult,
+    RevocationRecord,
+    RevocationStore,
+    VerificationContext,
+    verify_manifest,
+)
+from agent_manifest._revocation import FileCRL
+
+# Load the CRL once at startup
+crl = FileCRL("revocations.jsonl")
+store = RevocationStore()
+for rec in crl.all_records():
+    store.revoke(RevocationRecord(
+        manifest_id=rec.manifest_id,
+        revoked_at=rec.revoked_at,
+        reason=rec.reason,
+        revoked_by=rec.revoked_by,
+    ))
+
+# Verify a manifest against the loaded CRL
+with open("manifest.json") as f:
+    manifest = json.load(f)
+
+result = verify_manifest(manifest, VerificationContext(), store)
+
+if result.result == OverallResult.REVOKED:
+    raise PermissionError(f"Manifest {result.manifest_id} is revoked")
+elif result.result == OverallResult.VALID:
+    print("Manifest is valid")
+```
+
+---
+
+## Part 4: Key rotation after a compromise
+
+Use this procedure when a signing key is compromised, expiring, or changing ownership. The goal is to revoke all manifests signed by the old key and replace them with manifests signed by a new key, with a brief overlap window to avoid dropped requests.
+
+### Step 1: Generate the new keypair
+
+```python
+from agent_manifest._signing import generate_ed25519
+
+new_kp = generate_ed25519()
+# Store new_kp.private_b64url() securely — this is the new signing key
+```
+
+### Step 2: Re-sign all active manifests with the new key
+
+```python
+import json
+from pathlib import Path
+from agent_manifest._signing import Ed25519Signer
+
+signer = Ed25519Signer(new_kp)
+
+for manifest_path in Path("manifests/").glob("*.json"):
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    manifest.pop("signature", None)  # strip the old signature
+    manifest["signature"] = signer.sign(manifest)
+
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+```
+
+### Step 3: Revoke every manifest signed by the old key
+
+```python
+old_manifest_ids = [
+    "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+    "018aaaaa-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+]
+
+for mid in old_manifest_ids:
+    rec = sign_revocation(
+        manifest_id=mid,
+        reason="key rotation — old signing key decommissioned 2026-06-07",
+        revoked_by="spiffe://security.acme.com/incident-response",
+        keypair=revocation_kp,
+    )
+    crl.revoke(rec)
+```
+
+### Step 4: Overlap window and decommission
+
+Run both the old and new manifests in parallel for five minutes to allow any in-flight requests to drain. Once verifiers have updated their CRL cache, decommission the old private key:
+
+```
+t=0   Generate new key, begin re-signing manifests
+t=2m  New manifests deployed and live
+t=5m  Revoke old manifests in CRL
+t=7m  All verifiers have fetched the updated CRL
+t=10m Shred old private key material; audit the deletion
+```
+
+---
+
+## End-to-end incident response example
+
+```python
+# 1. Detect: CI log exposes signing key
+compromised_manifest_id = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+# 2. Revoke immediately
+record = sign_revocation(
+    manifest_id=compromised_manifest_id,
+    reason="signing key exposed in CI log — incident-2026-06-07",
+    revoked_by="spiffe://security.acme.com/incident-response",
+    keypair=revocation_kp,
+)
+crl.revoke(record)
+
+# 3. Confirm the old manifest is now rejected
+store = RevocationStore()
+store.revoke(RevocationRecord(
+    manifest_id=record.manifest_id,
+    revoked_at=record.revoked_at,
+    reason=record.reason,
+    revoked_by=record.revoked_by,
+))
+
+with open("old-manifest.json") as f:
+    old_manifest = json.load(f)
+
+result = verify_manifest(old_manifest, VerificationContext(), store)
+assert result.result == OverallResult.REVOKED
+print("Old manifest correctly rejected")
+```
+
+---
+
+## Notes on `FileCRL` in production
+
+`FileCRL` uses a file lock and an in-memory cache. It is safe for a single process on a single host. For multi-replica or multi-host deployments:
+
+- Replace it with a database-backed store (Postgres, Redis, etc.)
+- Distribute the CRL via the `.well-known` HTTP endpoint rather than sharing a file
+- Set a short TTL on the HTTP response so verifiers pick up revocations quickly
+
+---
+
+## What's next
+
+- [Tutorial: Deploying the verification endpoint](deploying-the-verification-endpoint.md) — host the CRL and verify endpoints in production
+- [Operations: Key rotation runbook](../operations/key-rotation.md) — step-by-step runbook for incident response

--- a/docs/tutorials/server-side-verification.md
+++ b/docs/tutorials/server-side-verification.md
@@ -1,11 +1,12 @@
-# Server-side manifest verification
+# Server-Side Manifest Verification
 
-This tutorial covers the **relying-party side**: the service that receives requests from agents and needs to decide whether to trust them. After completing it you will be able to:
+This tutorial covers the relying-party side: a service that receives requests from agents and needs to decide whether to trust them. After completing it you will be able to:
 
 - Verify an agent manifest programmatically in any Python service
-- Mount a FastAPI verification router that exposes `/verify` and `/revocation-status` endpoints
+- Mount a FastAPI verification router exposing `/verify` and `/revocation-status` endpoints
 - Gate requests with HTTP middleware using the manifest result
-- Understand every field of `VerificationResult` and what to act on
+- Read every field of `VerificationResult` and know what to act on
+- Configure CRL checking via `RevocationStore` or `FileCRL`
 
 ## Prerequisites
 
@@ -13,29 +14,26 @@ This tutorial covers the **relying-party side**: the service that receives reque
 pip install "agent-manifest[server]"
 ```
 
-This installs the SDK plus FastAPI and its dependencies.
+---
 
-## How verification works
+## What verification checks
 
-The verifier checks six things in order, stopping at the first failure:
+The verifier checks six things in order, stopping at the first hard failure:
 
-1. **Revocation** — is this manifest ID in the revocation list?
+1. **Revocation** — is this manifest ID in the revocation store?
 2. **Expiry** — is `expires_at` in the past?
 3. **Artifact hashes** — do the hashes in the manifest match what is actually running?
-4. **Delegation chain** — is every hop in the chain signed by its parent?
-5. **HITL record** — if human approval was required, is a valid one present?
+4. **Delegation chain** — is every hop signed by its parent?
+5. **HITL record** — if approval was required, is a valid, unexpired one present?
 6. **Attestation** — if `enforce_attestation=True`, was hardware attestation verified?
-
-The result is a `VerificationResult` with an `OverallResult` enum and per-field detail.
 
 ---
 
-## Pattern 1: Programmatic verification
+## Programmatic verification in middleware
 
-Use this when you control the call site and want to act on the result in code.
+Use this pattern when you control the call site and want to act on the result in application code.
 
 ```python
-import json
 from agent_manifest._verify import (
     OverallResult,
     RevocationStore,
@@ -43,34 +41,19 @@ from agent_manifest._verify import (
     verify_manifest,
 )
 
-# Build once at startup — share across requests
+# Build once at startup, share across requests
 revocation_store = RevocationStore()
+ctx = VerificationContext(enforce_attestation=True, enforce_hitl=False)
 
-def check_agent(manifest_path: str) -> None:
-    with open(manifest_path) as f:
-        manifest = json.load(f)
+result = verify_manifest(manifest_dict, ctx, revocation_store)
 
-    ctx = VerificationContext()          # default: no enforcement overrides
-    result = verify_manifest(manifest, ctx, revocation_store)
-
-    if result.result == OverallResult.VALID:
-        print(f"[VALID] {result.manifest_id} verified at {result.verified_at}")
-    elif result.result == OverallResult.REVOKED:
-        raise PermissionError(f"Manifest {result.manifest_id} has been revoked")
-    elif result.result == OverallResult.EXPIRED:
-        raise PermissionError("Manifest has expired — agent must re-issue")
-    elif result.result == OverallResult.MISMATCH:
-        # Show which artifacts have drifted
-        for d in result.mismatch_details:
-            print(f"  [MISMATCH] {d.field}: expected {d.expected_hash}, got {d.actual_hash}")
-        raise PermissionError("Artifact integrity check failed")
-    else:
-        raise PermissionError(f"Verification failed: {result.result}")
+if result.result != OverallResult.VALID:
+    raise PermissionError(f"Agent manifest invalid: {result.result}")
 ```
 
 ### Supplying runtime artifact hashes
 
-If you have access to the agent's running artifacts, pass them in `VerificationContext`. The verifier compares these against the hashes in the manifest.
+Pass hashes for any artifacts you can observe at runtime. Fields left as `None` in the context are skipped and return `FieldResult.NOT_BOUND`, not a mismatch.
 
 ```python
 import hashlib
@@ -80,54 +63,33 @@ with open("system_prompt.txt") as f:
 
 ctx = VerificationContext(
     system_prompt_hash="sha256:" + hashlib.sha256(prompt_text.encode()).hexdigest(),
-    model_version="gpt-4o-2024-08-06",   # or a content hash for local models
+    model_version="claude-sonnet-4-5-20251022",
     tool_catalog_hash="sha256:e3b0c44...",
+    enforce_hitl=True,
+    enforce_attestation=False,
 )
-result = verify_manifest(manifest, ctx, revocation_store)
-```
-
-Fields that are `None` in the context are skipped — `FieldResult.NOT_BOUND` is returned for them, not a mismatch.
-
-### Enforcement flags
-
-```python
-ctx = VerificationContext(
-    enforce_hitl=True,         # MISMATCH if hitl_record is required but missing
-    enforce_attestation=True,  # ATTESTATION_UNAVAILABLE if no hardware attestation
-    min_slsa_level=2,          # reserved for future SLSA gate
-)
+result = verify_manifest(manifest_dict, ctx, revocation_store)
 ```
 
 ---
 
-## Pattern 2: FastAPI router
+## Mounting verification endpoints with FastAPI
 
-Use this when you want to expose verification as an HTTP service — for example, a sidecar that other services can query.
+Use this when you want to expose verification as an HTTP service, for example a sidecar that other services query.
 
 ```python
 from fastapi import FastAPI
-from agent_manifest._verify import RevocationStore, create_router
-
-# Load manifests from your store at startup
-manifest_store: dict[str, dict] = {}
-
-with open("kyc-agent-manifest.json") as f:
-    import json
-    m = json.load(f)
-    manifest_store[m["manifest_id"]] = m
-
-revocation_store = RevocationStore()
+from agent_manifest._verify import create_router, RevocationStore
 
 app = FastAPI()
+manifest_store: dict = {}   # manifest_id -> manifest dict
+revocation_store = RevocationStore()
+
 app.include_router(create_router(manifest_store, revocation_store), prefix="/agent")
+
+# GET /agent/verify?manifest_id=...&enforce_hitl=true
+# GET /agent/revocation-status?manifest_id=...
 ```
-
-This mounts two endpoints:
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/agent/verify?manifest_id=<id>` | Returns a `VerificationResult` |
-| `GET` | `/agent/revocation-status?manifest_id=<id>` | Returns the revocation record or 404 |
 
 **Verify a manifest:**
 
@@ -139,8 +101,9 @@ curl "http://localhost:8000/agent/verify?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1
 {
   "verification_id": "a1b2c3d4-...",
   "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
-  "verified_at": "2026-06-05T12:00:00Z",
+  "verified_at": "2026-06-07T10:00:00Z",
   "result": "VALID",
+  "signature_verified": false,
   "attestation_verified": false,
   "fields_verified": {
     "system_prompt": "NOT_BOUND",
@@ -154,9 +117,7 @@ curl "http://localhost:8000/agent/verify?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1
     "delegation_chain": "NOT_PRESENT",
     "hitl_record": "NOT_REQUIRED"
   },
-  "mismatch_details": [],
-  "evidence_pack": null,
-  "verification_signature": null
+  "mismatch_details": []
 }
 ```
 
@@ -168,12 +129,52 @@ curl "http://localhost:8000/agent/verify?manifest_id=<id>&enforce_hitl=true&enfo
 
 ---
 
-## Pattern 3: HTTP middleware
+## Configuring minimum attestation level
 
-Use this to gate every inbound request — the agent attaches its manifest ID in a header and the middleware verifies it before routing to your handler.
+`VerificationContext.enforce_attestation=True` requires that `attestation_verified` is `True` in the result. Manifests without hardware attestation return `ATTESTATION_UNAVAILABLE`.
+
+In production, reject any result where `attestation_verified` is `False`:
 
 ```python
-import json
+ctx = VerificationContext(enforce_attestation=True)
+result = verify_manifest(manifest_dict, ctx, revocation_store)
+
+if not result.attestation_verified:
+    raise PermissionError(
+        "Production requires hardware attestation (Level 2+). "
+        "Use SEVSNPProvider, TDXProvider, or OPAQUEProvider."
+    )
+```
+
+---
+
+## Reading `VerificationResult` and acting on each outcome
+
+| `result` value | Meaning | Recommended action |
+|---------------|---------|-------------------|
+| `VALID` | All checks passed | Allow the request |
+| `REVOKED` | Manifest is in the revocation list | Block immediately; open an incident |
+| `EXPIRED` | `expires_at` is in the past | Block; agent must re-issue the manifest |
+| `MISMATCH` | One or more artifact hashes differ | Block; agent may have drifted or been tampered with |
+| `ATTESTATION_UNAVAILABLE` | `enforce_attestation` set but no attestation present | Block in prod, warn in dev |
+| `INCOMPLETE` | `strict_artifact_verification` set and bound fields lack runtime hashes | Block |
+| `INCOMPATIBLE_VERSION` | Manifest spec version not supported | Upgrade the SDK |
+
+Inspect `mismatch_details` to identify which artifacts failed:
+
+```python
+if result.result == OverallResult.MISMATCH:
+    for detail in result.mismatch_details:
+        print(f"  [{detail.field}] expected={detail.expected_hash} got={detail.actual_hash}")
+```
+
+---
+
+## FastAPI middleware that gates requests on manifest ID
+
+Use the `X-Agent-Manifest-ID` header to identify the calling agent. The middleware verifies the manifest before routing to your handler.
+
+```python
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from agent_manifest._verify import (
@@ -184,7 +185,7 @@ from agent_manifest._verify import (
 )
 
 app = FastAPI()
-manifest_store: dict[str, dict] = {}
+manifest_store: dict = {}
 revocation_store = RevocationStore()
 
 MANIFEST_ID_HEADER = "x-agent-manifest-id"
@@ -204,63 +205,47 @@ async def verify_agent_manifest(request: Request, call_next):
         if result.result != OverallResult.VALID:
             return JSONResponse(
                 status_code=403,
-                content={"detail": result.result, "mismatch_details": [
-                    d.model_dump() for d in result.mismatch_details
-                ]},
+                content={
+                    "detail": result.result,
+                    "mismatch_details": [d.model_dump() for d in result.mismatch_details],
+                },
             )
     return await call_next(request)
 
 @app.post("/execute")
 async def execute(request: Request):
-    # Reaches here only if the manifest verified — or no manifest was provided
     return {"status": "ok"}
 ```
 
 ---
 
-## Reading the VerificationResult
+## Configuring CRL checking
 
-| Field | Type | Meaning |
-|-------|------|---------|
-| `result` | `OverallResult` | Top-level verdict — see table below |
-| `attestation_verified` | `bool` | `True` if hardware attestation was confirmed |
-| `fields_verified` | `FieldsVerified` | Per-artifact status (MATCH / MISMATCH / NOT_BOUND / EXPIRED) |
-| `mismatch_details` | `list[MismatchDetail]` | One entry per failed artifact, with expected and actual hashes |
-| `evidence_pack` | `EvidencePack` | Signed evidence bundle (populated in future releases) |
-| `verification_id` | `str` | UUID for this specific verification event — use in audit logs |
+Wire `FileCRL` into the `RevocationStore` at startup so every `verify_manifest()` call checks revocation.
 
-**OverallResult values:**
+```python
+from pathlib import Path
+from agent_manifest._revocation import FileCRL
+from agent_manifest._verify import RevocationRecord, RevocationStore
 
-| Value | Meaning | Action |
-|-------|---------|--------|
-| `VALID` | All checks passed | Allow the request |
-| `REVOKED` | Manifest is in the revocation list | Block immediately — possible incident |
-| `EXPIRED` | `expires_at` is in the past | Block — agent must re-issue manifest |
-| `MISMATCH` | One or more artifact hashes differ | Block — agent may have drifted or been tampered |
-| `ATTESTATION_UNAVAILABLE` | `enforce_attestation` was set but no attestation present | Block in prod, warn in dev |
-| `INCOMPLETE` | Required fields are missing from the manifest | Block |
-| `INCOMPATIBLE_VERSION` | Manifest spec version not supported | Upgrade the SDK |
+crl = FileCRL(Path("/data/revocations.jsonl"))
+revocation_store = RevocationStore()
 
----
-
-## Running the complete example
-
-```bash
-# Terminal 1 — start the verification service
-uvicorn myservice:app --reload
-
-# Terminal 2 — verify a manifest
-curl "http://localhost:8000/agent/verify?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
-
-# Check revocation status
-curl "http://localhost:8000/agent/revocation-status?manifest_id=018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
-# 404 if not revoked
+for rec in crl.all_records():
+    revocation_store.revoke(RevocationRecord(
+        manifest_id=rec.manifest_id,
+        revoked_at=rec.revoked_at,
+        reason=rec.reason,
+        revoked_by=rec.revoked_by,
+    ))
 ```
+
+`RevocationStore` is in-memory. For a long-running service, reload the CRL periodically or replace it with a database-backed store.
 
 ---
 
 ## What's next
 
 - [Tutorial: A2A delegation chains](delegation-chains.md) — verify multi-hop delegation manifests
-- [Tutorial: Revocation and key rotation](revocation.md) — revoke a manifest and update the CRL
-- [Tutorial: Deploying the verification endpoint](deploy-verifier.md) — containerize and run in production
+- [Tutorial: Revocation and key rotation](revocation-and-key-rotation.md) — revoke a manifest and update the CRL
+- [Tutorial: Deploying the verification endpoint](deploying-the-verification-endpoint.md) — containerise and run in production

--- a/examples/docker-compose-verifier.yml
+++ b/examples/docker-compose-verifier.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+  verifier:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/data
+    environment:
+      CRL_PATH: /data/revocations.jsonl
+
+  agent-service:
+    image: python:3.12-slim
+    command: ["echo", "Replace with your agent service"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,9 @@ nav:
       - Revocation and key rotation: tutorials/revocation.md
       - Hardware attestation: tutorials/hardware-attestation.md
       - Deploying the verifier: tutorials/deploy-verifier.md
+      - HITL approval workflows (how-to): tutorials/hitl-approval-workflows.md
+      - Revocation and key rotation (how-to): tutorials/revocation-and-key-rotation.md
+      - Deploying the verification endpoint: tutorials/deploying-the-verification-endpoint.md
   - Integrations:
       - Overview: integrations/index.md
       - LangChain: integrations/langchain.md


### PR DESCRIPTION
## Summary

- Adds five how-to tutorial documents covering the most-requested SDK workflows
- Updates `mkdocs.yml` to include the new tutorials in the nav
- Adds cross-reference note in `docs/adr/index.md` linking ADRs to their corresponding tutorials
- Adds `examples/docker-compose-verifier.yml` for the deployment tutorial

## Tutorials added

| File | Issue |
|------|-------|
| `docs/tutorials/hitl-approval-workflows.md` | closes #65 |
| `docs/tutorials/revocation-and-key-rotation.md` | closes #66 |
| `docs/tutorials/hardware-attestation.md` | closes #67 |
| `docs/tutorials/server-side-verification.md` | closes #68 |
| `docs/tutorials/deploying-the-verification-endpoint.md` | closes #69 |

closes #65, closes #66, closes #67, closes #68, closes #69

## Test plan

- [ ] `mkdocs serve` renders all five tutorials without broken links
- [ ] Code examples reference actual class names and method signatures from the SDK (`SEVSNPProvider`, `TDXProvider`, `OPAQUEProvider`, `FileCRL`, `sign_revocation`, `verify_manifest`, `VerificationContext`, `RevocationStore`, `create_router`, `create_crl_router`)
- [ ] `HitlResult.MISSING` and `HitlResult.EXPIRED` failure mode examples are accurate per `_verify.py` logic
- [ ] `examples/docker-compose-verifier.yml` parses correctly with `docker-compose config`

Generated with [Claude Code](https://claude.com/claude-code)