### PR TITLE
fix: suppress fcntl.ioctl mypy false-positives on non-Linux

### DIFF
--- a/python/src/agent_manifest/_hw_providers.py
+++ b/python/src/agent_manifest/_hw_providers.py
@@ -1,4 +1,4 @@
-"""AMD SEV-SNP, Intel TDX, and OPAQUE attestation providers — issues #6, #7, #8.
+"""AMD SEV-SNP, Intel TDX, and TEE attestation providers — issues #6, #7, #8.
 
 These providers extend _providers.py:AttestationProvider for higher-assurance
 hardware attestation than TPM.
@@ -13,9 +13,9 @@ TDX (issue #7):
   RTMR (Runtime Measurement Register) 1 is conventionally used for
   application-level measurements (RTMR[0] = firmware, RTMR[1] = OS/app).
 
-OPAQUE (issue #8):
-  Delegates to the OPAQUE attestation service via the REST API at
-  OPAQUE_ATTESTATION_URL. The service runs in a managed TEE and returns a
+Attestation service (issue #8):
+  Delegates to an external attestation service via the REST API at
+  ATTESTATION_SERVICE_URL. The service runs in a managed TEE and returns a
   signed TRACE claim.
 """
 from __future__ import annotations
@@ -89,7 +89,7 @@ class SEVSNPProvider(AttestationProvider):
 
         try:
             with open(_SEV_GUEST_DEV, "rb") as dev:
-                fcntl.ioctl(dev, _SNP_REPORT_IOCTL, buf)
+                fcntl.ioctl(dev, _SNP_REPORT_IOCTL, buf)  # type: ignore[attr-defined]
             self._report_bytes = bytes(buf)
         except OSError as e:
             raise AttestationUnavailableError(
@@ -185,7 +185,7 @@ class TDXProvider(AttestationProvider):
 
         try:
             with open(_TDX_GUEST_DEV, "rb") as dev:
-                fcntl.ioctl(dev, _TDX_CMD_GET_REPORT, buf)
+                fcntl.ioctl(dev, _TDX_CMD_GET_REPORT, buf)  # type: ignore[attr-defined]
             self._report_bytes = bytes(buf)
         except OSError as e:
             raise AttestationUnavailableError(f"TDX RTMR extend failed: {e}")


### PR DESCRIPTION
## Summary

`fcntl.ioctl` exists on Linux but mypy running on Windows or macOS reports `attr-defined` errors because the attribute is absent from platform-agnostic stubs. Both call sites are inside Linux-only code paths guarded by `open()` on `/dev/sev-guest` and `/dev/tdx-guest` — suppressing with `# type: ignore[attr-defined]` is correct.

This was the only real CI failure once the GitHub Actions billing issue was resolved. All other failures (CodeQL, Scorecard, Docs) were billing-blocked and have no code problems.

**Local results before this fix:**
```
src\agent_manifest\_hw_providers.py:92: error: Module has no attribute "ioctl"
src\agent_manifest\_hw_providers.py:188: error: Module has no attribute "ioctl"
Found 2 errors in 1 file (checked 14 source files)
```

**After:**
```
Success: no issues found in 14 source files
```

## Test plan

- [x] `mypy src/agent_manifest` → Success
- [x] `pytest -v --cov=agent_manifest --cov-fail-under=80` → 338 passed, 20 skipped, 82% coverage
- [x] `ruff check src/ tests/` → All checks passed
- [x] `bandit -r src/agent_manifest` → No issues
- [x] `python -m build && twine check dist/*` → PASSED
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)