### PR TITLE
fix(providers): correct auto-select docstring and error message for OPAQUE opt-in

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -80,11 +80,11 @@ print(sig_block["key_id"])      # sha256:<hex>
 ```python
 from agent_manifest._auto_provider import select_provider
 
-# auto-selects: OPAQUE → SEV-SNP → TDX → TPM → Software
+# auto-selects: SEV-SNP → TDX → TPM → software  (OPAQUE is explicit opt-in via OPAQUE_ATTESTATION_URL)
 provider = select_provider(level=1)   # Level 1+ requires hardware
 provider.extend_manifest_hash(manifest_dict)
 report = provider.get_attestation_report()
-# report.platform: "amd-sev-snp" | "intel-tdx" | "tpm" | "opaque"
+# report.platform: "amd-sev-snp" | "intel-tdx" | "tpm" | "opaque" | "software"
 ```
 
 | Provider | Hardware | Level | Install |

--- a/python/src/agent_manifest/_auto_provider.py
+++ b/python/src/agent_manifest/_auto_provider.py
@@ -1,11 +1,13 @@
 """provider='auto' attestation backend selection.
 
-Selection order (first available wins):
-  1. OPAQUEProvider  — if OPAQUE_ATTESTATION_URL env var is set
-  2. SEVSNPProvider  — if /dev/sev-guest exists
-  3. TDXProvider     — if /dev/tdx-guest exists
-  4. TPMProvider     — if tpm2_extend is in PATH
-  5. SoftwareProvider — fallback, Level 0 only (no hardware attestation)
+Auto-selection order (first locally-verifiable silicon wins):
+  1. SEVSNPProvider  — if /dev/sev-guest exists
+  2. TDXProvider     — if /dev/tdx-guest exists
+  3. TPMProvider     — if tpm2_extend is in PATH
+  4. SoftwareProvider — fallback, Level 0 only (no hardware attestation)
+
+OPAQUEProvider is explicit opt-in: selected only when OPAQUE_ATTESTATION_URL
+is set. It is never auto-detected.
 
 The SoftwareProvider is never selected automatically for Level 1+ contexts.
 Callers that require Level 1+ MUST explicitly check provider.level >= 1.
@@ -53,7 +55,7 @@ def select_provider(level: int = 0) -> AttestationProvider:
         AttestationUnavailableError: If *level* > 0 and no hardware provider
             is available.
     """
-    # OPAQUE managed runtime
+    # OPAQUE managed runtime — explicit opt-in only, not auto-detected
     if os.environ.get("OPAQUE_ATTESTATION_URL"):
         from ._hw_providers import OPAQUEProvider
         return cast(AttestationProvider, OPAQUEProvider())
@@ -76,8 +78,8 @@ def select_provider(level: int = 0) -> AttestationProvider:
     if level >= 1:
         raise AttestationUnavailableError(
             "No hardware attestation provider available. "
-            "Level 1+ conformance requires TPM 2.0, AMD SEV-SNP, Intel TDX, "
-            "or the OPAQUE managed runtime. "
+            "Level 1+ conformance requires TPM 2.0, AMD SEV-SNP, or Intel TDX. "
+            "To use the OPAQUE managed runtime, set OPAQUE_ATTESTATION_URL. "
             "For development use, set level=0 explicitly."
         )
     return SoftwareProvider()


### PR DESCRIPTION
## Summary

- `_auto_provider.py` module docstring: reorders the selection list to `SEV-SNP → TDX → TPM → software`; adds explicit note that `OPAQUEProvider` is never auto-detected (env var required)
- Inline comment on the OPAQUE block: clarifies it is explicit opt-in only
- Error message: removes "or the OPAQUE managed runtime" from the hardware list; adds a separate sentence pointing to `OPAQUE_ATTESTATION_URL`
- `python/README.md`: updates the `# auto-selects` comment and adds `"software"` to the `report.platform` list (was missing)

The code logic was already correct — OPAQUE only fires when `OPAQUE_ATTESTATION_URL` is set. This aligns the comments and error messages with that behavior and with the root README updated in #143.

## Test plan

- [ ] `python -c "from agent_manifest._auto_provider import select_provider; help(select_provider)"` — confirm docstring reads correctly
- [ ] Unset `OPAQUE_ATTESTATION_URL`, run `select_provider()` — confirm OPAQUE is not selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)