### PR TITLE
fix: docs workflow and broken relative links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install docs dependencies
         run: |
           pip install -r requirements-docs.txt
-          pip install -e "python/[server,pq]"
+          pip install -e "python/[server]"
 
       - name: Build and deploy to GitHub Pages
         run: mkdocs gh-deploy --force --clean

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -203,7 +203,7 @@ store.revoke(
 
 ## Next steps
 
-- Read the [full specification](../spec/agent-manifest-spec-v0.1.md)
+- Read the [full specification](https://github.com/agentrust-io/agent-manifest/blob/main/spec/agent-manifest-spec-v0.1.md)
 - Browse the [examples](../examples/) for complete manifest JSON for each conformance level
 - For hardware attestation setup on Azure, AWS, or GCP, see the platform-specific notes in Section 3.3.1 of the spec
 - For EU AI Act HITL compliance, see Section 9.1 and the Level 2 example in `examples/`

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,6 @@ Provider auto-selects based on available hardware: `OPAQUE → SEV-SNP → TDX �
 ## Next steps
 
 - [Getting started](getting-started.md) — Level 0 in 15 minutes
-- [Examples](../examples/README.md) — complete manifest JSON for Level 0 and Level 1
+- [Examples](https://github.com/agentrust-io/examples) — complete manifest JSON for Level 0 and Level 1
 - [Specification](https://github.com/agentrust-io/agent-manifest/blob/main/spec/agent-manifest-spec-v0.1.md) — 197 conformance tests across 5 modules
 - [Architecture decisions](adr/index.md) — rationale behind cryptographic design choices

--- a/docs/tutorials/delegation-chains.md
+++ b/docs/tutorials/delegation-chains.md
@@ -255,4 +255,4 @@ bad_sig = delegate_hop_signer.sign_hop(
 
 - [Tutorial: Server-side verification](server-side-verification.md) — verify delegation chains at the relying party
 - [Tutorial: HITL approval workflows](hitl-approvals.md) — require human sign-off within a delegation chain
-- [Example: A2A delegation chain manifests](../examples/delegation-chain/README.md)
+- [Examples repository](https://github.com/agentrust-io/examples)


### PR DESCRIPTION
## Summary

Two real failures that would surface once billing is resolved:

**1. Docs workflow installs `[server,pq]` — fails on Ubuntu**

`pyoqs` (the `pq` extra) requires `liboqs` as a system library, which is not present on GitHub Actions Ubuntu runners. Fixed to `[server]` only. The `oqs` import in `_signing.py` is already guarded with `try/except ImportError` so docs generation works fine without it.

**2. Three broken relative links escape the docs tree**

`mkdocs build --strict` reports these as hard failures:

| File | Was | Now |
|------|-----|-----|
| `docs/index.md` | `../examples/README.md` | `https://github.com/agentrust-io/examples` |
| `docs/getting-started.md` | `../spec/agent-manifest-spec-v0.1.md` | GitHub blob URL |
| `docs/tutorials/delegation-chains.md` | `../examples/delegation-chain/README.md` (doesn't exist) | `https://github.com/agentrust-io/examples` |

## Test plan

- [x] `mkdocs build --strict` → `Documentation built in 5.45 seconds` (0 warnings)
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)