### PR TITLE
fix: mypy unused-ignore on Linux for fcntl.ioctl

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -69,6 +69,10 @@ python_version = "3.11"
 strict = true
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "agent_manifest._hw_providers"
+warn_unused_ignores = false
+
 [tool.coverage.run]
 source = ["src/agent_manifest"]
 omit = ["src/agent_manifest/cli.py"]


### PR DESCRIPTION
## Summary

Follow-up to #145. `fcntl.ioctl` exists in Linux stubs so `# type: ignore[attr-defined]` is correct on Windows but flagged as `unused-ignore` on Linux (the CI runner). `strict = true` enables `warn_unused_ignores`, which made it a hard error.

Fix: add a `[[tool.mypy.overrides]]` for `agent_manifest._hw_providers` with `warn_unused_ignores = false`. The `type: ignore` comment stays to protect Windows builds; the override stops the Linux CI from rejecting it.

```
src/agent_manifest/_hw_providers.py:92: error: Unused "type: ignore" comment  [unused-ignore]
src/agent_manifest/_hw_providers.py:188: error: Unused "type: ignore" comment  [unused-ignore]
Found 2 errors in 1 file (checked 14 source files)
```

After:
```
Success: no issues found in 14 source files
```

## Test plan
- [x] `mypy src/agent_manifest` → Success (local)
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)