### PR TITLE
fix(docs): replace SPIFFE approver_id examples with mailto: URIs (closes #151)

### DIFF
--- a/docs/adr/0006-hitl-approval-mechanism.md
+++ b/docs/adr/0006-hitl-approval-mechanism.md
@@ -17,7 +17,7 @@ The manifest needs a mechanism to record this approval in a tamper-evident, veri
 
 ## Decision
 
-Embed a **`hitl_record`** field directly in the manifest JSON. The record contains one or more approval entries, each with the following fields: `approver_id` (SPIFFE URI or DID of the approver), `approved_at` (ISO 8601 timestamp), `evidence_hash` (SHA-256 of the canonical form of the action being approved), `approval_duration_seconds` (validity window), and `revocation_signature` (Ed25519 signature by the approver over the canonical approval fields).
+Embed a **`hitl_record`** field directly in the manifest JSON. The record contains one or more approval entries, each with the following fields: `approver_id` (human-attributable identity — see Amendment below), `approved_at` (ISO 8601 timestamp), `evidence_hash` (SHA-256 of the canonical form of the action being approved), `approval_duration_seconds` (validity window), and `revocation_signature` (Ed25519 signature by the approver over the canonical approval fields).
 
 The approval record is **signed by the approver's key**, not the manifest issuer's key.
 
@@ -65,4 +65,21 @@ The `hitl_record` field is excluded from the manifest signing pre-image (alongsi
 - EU AI Act Article 14: Human oversight requirements
 - Spec Section 3.5: HITL approval record schema and verification semantics
 - [FIDO2 / WebAuthn](https://fidoalliance.org/fido2/) — recommended backing for approver keys
-- ADR-0009: SPIFFE URIs as the canonical identity format for `approver_id`
+- ADR-0009: SPIFFE URIs as the canonical identity format for machine workload identity (`agent_id`, `issuer`) — does not apply to `approver_id`
+
+---
+
+## Amendment — 2026-06-10: `approver_id` must not use SPIFFE SVIDs
+
+**Resolved by:** issue #40
+
+The original **Decision** section referenced `approver_id` as a "SPIFFE URI or DID of the approver". This was incorrect. Issue #40 clarified:
+
+> `approver_id` MUST be a human-attributable identity. SPIFFE SVIDs MUST NOT be used as `approver_id` values: SPIFFE SVIDs identify machine workloads, not natural persons.
+
+Preferred forms for `approver_id`:
+- Email URI: `mailto:approver@example.com`
+- OIDC subject claim paired with issuer URI
+- W3C DID bound to a hardware authenticator (e.g. FIDO2 passkey)
+
+SPIFFE URIs remain the correct format for `agent_id` and `issuer` (see ADR-0009), but are explicitly prohibited for `approver_id`. The "DID of the approver" language in the original Decision is retained only when the DID is hardware-bound (e.g. `did:key` backed by a FIDO2 authenticator); a software-only DID is discouraged for the same reason SPIFFE is prohibited.

--- a/docs/adr/0009-spiffe-uri-agent-identity.md
+++ b/docs/adr/0009-spiffe-uri-agent-identity.md
@@ -59,6 +59,8 @@ The trust domain (`trust.example` in the example) is operated by the deploying o
 - Multi-org delegation chains are naturally expressed: the root issuer SPIFFE URI and the delegate SPIFFE URI come from different trust domains, making cross-org delegation visually and structurally distinct from intra-org delegation.
 - The trust domain is not verified by the SDK — the spec does not mandate a SPIRE integration. Verification that a SPIFFE URI is authentic (i.e., backed by a real SPIRE certificate) is out of scope for Level 0 and Level 1; it is addressed by the mTLS transport layer at Level 2+.
 
+**Scope note:** This ADR covers `agent_id` and `issuer` (machine workload identities) only. Human approver identity (`hitl_record.approvals[].approver_id`) is explicitly out of scope — SPIFFE SVIDs MUST NOT be used for `approver_id`. See Spec Section 3.5 and ADR-0006 for the approver identity design.
+
 ## References
 
 - [SPIFFE Specification](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE.md)

--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -70,7 +70,7 @@ The `hitl_approval` field records a human approval event:
 {
   "hitl_approval": {
     "approved_at": "2026-06-01T09:15:00Z",
-    "approver_id": "spiffe://trust.example/user/alice",
+    "approver_id": "mailto:alice@example.com",
     "approved_scope": ["execute_payment", "submit_regulatory_filing"],
     "approval_expires_at": "2026-06-01T17:00:00Z",
     "signature": "..."

--- a/docs/tutorials/hitl-approval-workflows.md
+++ b/docs/tutorials/hitl-approval-workflows.md
@@ -103,7 +103,7 @@ approval_sig = approver.sign_approval(
     manifest_id=manifest_id,
     approved_at=approved_at,
     approved_scope=approved_scope,
-    approver_id="spiffe://finance.acme.com/managers/jane-doe",
+    approver_id="mailto:jane.doe@finance.acme.com",
 )
 ```
 
@@ -117,7 +117,7 @@ from agent_manifest._signing import Ed25519Signer
 agent_kp = generate_ed25519()
 
 manifest.hitl_record["approvals"] = [{
-    "approver_id":        "spiffe://finance.acme.com/managers/jane-doe",
+    "approver_id":        "mailto:jane.doe@finance.acme.com",
     "approved_at":        approved_at,
     "approved_scope":     approved_scope,
     "evidence_hash":      evidence_hash,
@@ -189,7 +189,7 @@ expired_sig = approver.sign_approval(
     manifest_id=manifest_id,
     approved_at=approved_at,
     approved_scope=expired_scope,
-    approver_id="spiffe://finance.acme.com/managers/jane-doe",
+    approver_id="mailto:jane.doe@finance.acme.com",
 )
 
 expired_manifest = dict(manifest_dict)
@@ -209,8 +209,8 @@ The verifier checks that the approval signature is cryptographically valid but d
 
 ```python
 AUTHORISED_APPROVERS = {
-    "spiffe://finance.acme.com/managers/jane-doe",
-    "spiffe://finance.acme.com/managers/bob-smith",
+    "mailto:jane.doe@finance.acme.com",
+    "mailto:bob.smith@finance.acme.com",
 }
 
 result = verify_manifest(manifest_dict, VerificationContext(enforce_hitl=True), RevocationStore())

--- a/docs/tutorials/hitl-approvals.md
+++ b/docs/tutorials/hitl-approvals.md
@@ -85,7 +85,7 @@ approval_sig = approver.sign_approval(
     manifest_id=manifest_id,
     approved_at=approved_at,
     approved_scope=approved_scope,
-    approver_id="spiffe://trust.example/human/alice",
+    approver_id="mailto:alice@example.com",
 )
 ```
 
@@ -97,7 +97,7 @@ approval_sig = approver.sign_approval(
 from agent_manifest._signing import Ed25519Signer
 
 manifest.hitl_record["approvals"] = [{
-    "approver_id":          "spiffe://trust.example/human/alice",
+    "approver_id":          "mailto:alice@example.com",
     "approved_at":          approved_at,
     "approved_scope":       approved_scope,
     "approval_method":      "hardware_key",
@@ -169,7 +169,7 @@ old_approval_sig = approver.sign_approval(
     manifest_id=manifest_id,
     approved_at=approved_at,
     approved_scope=old_scope,
-    approver_id="spiffe://trust.example/human/alice",
+    approver_id="mailto:alice@example.com",
 )
 time.sleep(2)
 


### PR DESCRIPTION
## Summary

- Replaces all `spiffe://` human approver identity examples in tutorials and compliance docs with `mailto:` URIs per the clarification in issue #40.
- ADR-0006 (`0006-hitl-approval-mechanism.md`): Decision section updated to say "human-attributable identity (see Amendment)"; amendment section added explaining SPIFFE SVIDs MUST NOT be used for `approver_id`.
- ADR-0009 (`0009-spiffe-uri-agent-identity.md`): Scope clarification added — SPIFFE is for `agent_id` and `issuer` (machine workloads) only; prohibited for `approver_id`.

Files changed:
- `docs/compliance/eu-ai-act.md` (1 example)
- `docs/tutorials/hitl-approval-workflows.md` (5 examples + `AUTHORISED_APPROVERS` set)
- `docs/tutorials/hitl-approvals.md` (3 examples)
- `docs/adr/0006-hitl-approval-mechanism.md` (Decision section + Amendment added)
- `docs/adr/0009-spiffe-uri-agent-identity.md` (Scope note added)

Closes #151.

## Test plan

- [ ] Review doc examples — no `spiffe://` URIs remain in human approver context
- [ ] ADR-0006 amendment matches the normative spec language from issue #40
- [ ] CI passes (docs build, no broken links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)