### PR TITLE
spec: enumerate signing coverage per top-level field, detach hitl_record.approvals

### DIFF
--- a/docs/adr/0006-hitl-approval-mechanism.md
+++ b/docs/adr/0006-hitl-approval-mechanism.md
@@ -83,3 +83,20 @@ Preferred forms for `approver_id`:
 - W3C DID bound to a hardware authenticator (e.g. FIDO2 passkey)
 
 SPIFFE URIs remain the correct format for `agent_id` and `issuer` (see ADR-0009), but are explicitly prohibited for `approver_id`. The "DID of the approver" language in the original Decision is retained only when the DID is hardware-bound (e.g. `did:key` backed by a FIDO2 authenticator); a software-only DID is discouraged for the same reason SPIFFE is prohibited.
+
+---
+
+## Amendment  -  2026-06-11: `hitl_record` is signed with `approvals` normalized, not wholly excluded
+
+**Resolved by:** issue #156
+
+The original Decision section stated that "the `hitl_record` field is excluded from the manifest signing pre-image (alongside `attestation`)". This conflicted with spec Section 3.6, which listed `hitl_record` in the fixed `signed_fields` list. Issue #156 flagged the contradiction and the security gap in the wholly-excluded reading: if `hitl_record` is entirely outside the pre-image, an attacker can strip or weaken the HITL *requirement* itself (`required`, risk-tier metadata, `escalation_policy`, `hitl_runtime`) without invalidating the issuer signature.
+
+Resolution: `hitl_record` IS part of the signing pre-image, with one normalization rule. When computing the pre-image, `hitl_record.approvals` is normalized to an empty array (`[]`). All other `hitl_record` fields are covered by the issuer signature.
+
+This preserves both original design goals:
+
+- **Post-issuance approval attachment.** Because `approvals` is normalized out of the pre-image, approvals can be collected and attached after the manifest is issued without re-signing, exactly as the original Decision intended. Each approval remains independently authenticated by its `approval_signature`.
+- **Tamper-evident HITL requirement.** The requirement that approvals exist (and under what conditions) is bound by the issuer signature and cannot be silently removed.
+
+Verifiers MUST apply the identical normalization before checking the issuer signature. Spec Section 3.6 now contains the normative signing coverage table and the normalization rule; the "excluded alongside `attestation`" sentence in the Decision section above is superseded by this amendment.

--- a/spec/agent-manifest-spec-v0.1.md
+++ b/spec/agent-manifest-spec-v0.1.md
@@ -729,16 +729,46 @@ Each `approval_signature` is produced by the approver's hardware-backed key (FID
   "key_id": "<key identifier>  -- REQUIRED",
   "key_type": "software | hsm | tee-sealed  -- REQUIRED",
   "signed_at": "<ISO 8601 UTC>  -- REQUIRED",
-  "signed_fields": ["manifest_id", "agent_id", "version", "issued_at", "expires_at", "issuer", "crypto_profile", "artifacts", "delegation_chain", "hitl_record"],
+  "signed_fields": ["@context", "@type", "manifest_id", "previous_manifest_id", "agent_id", "version", "min_verifier_version", "issued_at", "expires_at", "issuer", "crypto_profile", "artifacts", "delegation_chain", "hitl_record", "prior_transparency_log_entry", "log_retention", "data_scope", "operational_lifecycle"],
   "signature_value": "<base64url-encoded signature over RFC 8785 canonical JSON>  -- CONDITIONALLY REQUIRED: REQUIRED when algorithm is Ed25519 or ML-DSA-65",
   "classical_signature": "<base64url-encoded Ed25519 signature>  -- CONDITIONALLY REQUIRED: REQUIRED when algorithm is hybrid-Ed25519-ML-DSA-65",
   "pq_signature": "<base64url-encoded ML-DSA-65 signature>  -- CONDITIONALLY REQUIRED: REQUIRED when algorithm is hybrid-Ed25519-ML-DSA-65"
 }
 ```
 
-**`signed_fields`** is a fixed normative list and MUST NOT be varied by implementations. It covers all top-level fields except `attestation` (appended post-signing by hardware), `signature` (the signing object itself), and `transparency_log_entry` (populated after log submission). This ensures that identity fields including `expires_at`, `manifest_id`, and `issued_at` are covered by the signature and cannot be modified without invalidating it.
+**`signed_fields`** is a fixed normative list and MUST NOT be varied by implementations. <!-- CHANGED: closes #156: replaced contradictory prose with an exhaustive signing coverage table; added hitl_record.approvals normalization rule --> The following table enumerates every top-level manifest field and states whether it is part of the signing pre-image. A field marked "Signed" that is absent from the manifest (an omitted OPTIONAL or CONDITIONALLY REQUIRED field) is simply omitted from the pre-image per the null-omission rule in section 2.3; it MUST NOT be serialized as `null`.
 
-**Canonical serialization**: The signature covers the RFC 8785 canonical JSON serialization of the named `signed_fields`. See section 2.3 for the complete canonicalization specification.
+**Signing coverage table (normative)**
+
+| Top-level field | In signing pre-image | Notes |
+|---|---|---|
+| `@context` | Signed | Treated as an ordinary JSON string field (section 2.3). Binding it prevents post-signing context substitution. |
+| `@type` | Signed | Treated as an ordinary JSON string field (section 2.3). |
+| `manifest_id` | Signed | |
+| `previous_manifest_id` | Signed | Binds re-issuance audit chain continuity. |
+| `agent_id` | Signed | |
+| `version` | Signed | |
+| `min_verifier_version` | Signed | Prevents post-signing downgrade of the required verifier version. |
+| `issued_at` | Signed | |
+| `expires_at` | Signed | |
+| `issuer` | Signed | |
+| `crypto_profile` | Signed | |
+| `artifacts` | Signed | |
+| `attestation` | NOT signed | Appended post-signing by hardware (section 3.3). |
+| `delegation_chain` | Signed | |
+| `hitl_record` | Signed, with `approvals` normalized to `[]` | See the normalization rule below. The HITL requirement itself is tamper-evident; approvals attach post-issuance. |
+| `prior_transparency_log_entry` | Signed | Known at issuance time: it references the previous manifest's log entry (section 2.2). Binds the key rotation chain. |
+| `log_retention` | Signed | Prevents post-signing weakening of the declared retention policy (section 8.1). |
+| `data_scope` | Signed | Prevents post-signing alteration of declared GDPR processing scope (section 9.3). |
+| `operational_lifecycle` | Signed | Prevents post-signing alteration of Art. 13 lifecycle disclosures (section 9.4). |
+| `signature` | NOT signed | The signing object itself. |
+| `transparency_log_entry` | NOT signed | Populated after log submission (see ordering rules below). |
+
+Every top-level field defined by this specification appears in exactly one row of this table. A future spec version that introduces a new top-level field MUST add it to this table.
+
+**`hitl_record.approvals` normalization rule (normative)**: When computing the manifest signing pre-image, the value of `hitl_record.approvals` MUST be normalized to an empty array (`[]`). All other `hitl_record` fields, including `required`, `escalation_policy`, `hitl_runtime`, and any risk-tier metadata, are covered by the issuer signature as-is. This makes the HITL *requirement* tamper-evident (an attacker cannot strip or weaken it without invalidating the issuer signature) while allowing approvals to be attached after the manifest is issued, without re-signing. Approval entries are individually authenticated by their own `approval_signature` and verified separately per section 3.5; they are NOT covered by the issuer signature. Verifiers MUST apply the identical normalization before checking the issuer signature. See ADR-0006 (as amended 2026-06-11).
+
+**Canonical serialization**: The signature covers the RFC 8785 canonical JSON serialization of the named `signed_fields`, after applying the `hitl_record.approvals` normalization rule above. See section 2.3 for the complete canonicalization specification.
 
 **Ed25519 validation rules** <!-- CHANGED: CRYPTO-007 -->: Ed25519 implementations MUST use the cofactorless verification equation (`[S]B == R + [k]A`). Implementations MUST reject non-canonically encoded points (i.e., reject if the encoding does not round-trip through point decoding). Implementations MUST NOT use batch verification unless the batch verifier enforces the same cofactorless equation with canonical encoding checks. Implementations SHOULD use hedged signing (per draft-irtf-cfrg-det-sigs-with-noise) when signing keys reside in hardware signers subject to fault injection.
 
@@ -885,7 +915,7 @@ All canonical JSON serialization in this specification uses **RFC 8785 (JSON Can
 
 | Use | Input |
 |-----|-------|
-| Manifest signature pre-image | Fields in `signed_fields` — excludes `attestation`, `signature`, `transparency_log_entry` |
+| Manifest signature pre-image | Fields in `signed_fields` (excludes `attestation`, `signature`, `transparency_log_entry`), with `hitl_record.approvals` normalized to `[]` per section 3.6 |
 | `manifest_hash_in_report` pre-image | Full draft manifest JSON before attestation block appended |
 | Memory snapshot hash | Memory baseline JSON object |
 | Evidence pack hash | Evidence pack JSON envelope |
@@ -1015,7 +1045,7 @@ An evidence pack is a JSON document with the following structure:
 
 A `VALID` result means all of the following are true:
 
-- The manifest signature is valid under RFC 8785 canonicalization and the manifest is present in the transparency log
+- The manifest signature is valid under RFC 8785 canonicalization and the manifest is present in the transparency log. Before checking the issuer signature, the verifier MUST apply the `hitl_record.approvals` normalization rule from section 3.6 (replace `hitl_record.approvals` with `[]` in the signing pre-image); approvals are verified separately against their own `approval_signature`s
 - The TEE attestation report confirms the manifest hash is bound to the hardware measurement
 - All fields specified in `required_fields` match their running artifacts
 - The manifest has not expired


### PR DESCRIPTION
## Decision

Resolves the two contradictions in issue #156 with the following normative decisions:

### 1. Exhaustive signing coverage table

The "covers all top-level fields except..." prose in section 3.6 was false: six top-level fields (`previous_manifest_id`, `min_verifier_version`, `prior_transparency_log_entry`, `log_retention`, `data_scope`, `operational_lifecycle`) were absent from the fixed `signed_fields` list and therefore mutable post-signing. The prose is replaced with a normative table enumerating EVERY top-level manifest field and its signing status. All previously-omitted fields are now signed, plus `@context` and `@type` (also top-level fields; binding them prevents post-signing context substitution; section 2.3 already treats them as ordinary JSON fields for canonicalization). Unsigned, with stated reasons: `attestation`, `signature`, `transparency_log_entry`.

### 2. hitl_record: detached approvals via normalization

`hitl_record` IS in the signing pre-image, with one normalization rule: `hitl_record.approvals` is normalized to `[]` when computing the pre-image. This keeps the HITL requirement itself (`required`, risk-tier metadata, `escalation_policy`, `hitl_runtime`) tamper-evident under the issuer signature while preserving ADR-0006's design goal of post-issuance approval attachment without re-signing. Approvals carry their own `approval_signature`s and are verified separately.

## Changes

- Section 3.6: signing coverage table, normalization rule, expanded `signed_fields` list
- Section 4.3: canonicalization scope row updated to reference the normalization
- Section 5.3: verifiers MUST apply the same normalization before checking the issuer signature
- ADR-0006: dated amendment (2026-06-11) recording the resolution; the wholly-excluded sentence is superseded

## Notes

- This changes the signing pre-image, so it is breaking for existing signed manifests (acceptable pre-v1.0).
- The Python reference implementation's `SIGNED_FIELDS` constant now lags the spec; needs a follow-up PR.

## Testing

- `mkdocs build`: clean (pre-existing INFO notices only)
- `pytest` (python/): 338 passed, 20 skipped

Closes #156

Generated with [Claude Code](https://claude.ai/code)