### PR TITLE
fix(ci): repair Scorecard workflow for private repo

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,15 +7,17 @@ on:
     - cron: "0 4 * * 1"  # Weekly on Monday at 04:00 UTC
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
-  id-token: write
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
 
     steps:
       - uses: actions/checkout@v4
@@ -23,11 +25,13 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          # publish_results requires a public repo; flip to true after the
+          # 2026-06-23 public launch.
+          publish_results: false
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Scorecard has been failing on main with `Resource not accessible by integration`: several scorecard checks need broader read scopes than the narrow workflow-level grant, and `publish_results: true` requires a public repo. This applies the official template layout (top-level `read-all`, job-level writes), disables publish_results while private (dated note to flip after the 2026-06-23 launch), and pins the action by commit SHA.

Generated with [Claude Code](https://claude.ai/code)