### PR TITLE
fix(workflows): skip maintainer gate for maintainer-authored PRs

### DIFF
--- a/.github/workflows/require-maintainer-approval.yml
+++ b/.github/workflows/require-maintainer-approval.yml
@@ -24,16 +24,30 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    if: >-
-      github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.author_association != 'MEMBER' &&
-      github.event.pull_request.author_association != 'OWNER'
+    if: github.event.pull_request.base.ref == 'main'
     steps:
       - name: Check for named-maintainer review
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const MAINTAINERS = ['imran-siddique'];
+
+            // Maintainer-authored PRs skip the gate. author_association is
+            // not reliable for this: it only reports MEMBER when the
+            // author's org membership is public, and a PR author cannot
+            // approve their own PR, so without this skip a maintainer with
+            // private membership could never clear the gate.
+            const author = context.payload.pull_request.user.login;
+            if (MAINTAINERS.includes(author)) {
+              core.info(`Author ${author} is a maintainer, skipping gate`);
+              return;
+            }
+
+            const association = context.payload.pull_request.author_association;
+            if (association === 'MEMBER' || association === 'OWNER') {
+              core.info(`Author is ${association}, skipping gate`);
+              return;
+            }
 
             // Both pull_request_target and pull_request_review payloads
             // carry the PR at context.payload.pull_request.


### PR DESCRIPTION
The gate's job-level `if` skips on author_association MEMBER/OWNER, but GitHub only reports MEMBER when the author's org membership is public, so a maintainer with private membership gets CONTRIBUTOR and the gate demands an approval the author cannot give (authors cannot approve their own PRs). This keeps the base-branch check in the job-level `if`, moves the association skip in-script, and adds an explicit skip when the PR author is in MAINTAINERS; confirmed live on cmcp#291, where the gate failed while all tests passed.

Note: this PR is itself gate-blocked by the bug it fixes. Approve and re-run the gate, or admin-merge.

Generated with [Claude Code](https://claude.ai/code)