### PR TITLE
ci: skip SARIF upload while repo is private

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,3 +40,5 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: /language:python
+          # TODO(2026-06-23): flip to "always" after repo goes public
+          upload: never


### PR DESCRIPTION
## Summary

- Sets `upload: never` on the CodeQL analyze step; identical approach to the Scorecard `publish_results: false` fix
- SARIF upload requires GitHub Advanced Security, which is not available on private repos
- Adds a `TODO(2026-06-23)` comment to flip back to `always` when the repo goes public

## Test plan

- [ ] `Analyze Python` check goes green on this PR
- [ ] Flip `upload: never` -> `upload: always` on June 23 alongside the other launch-day toggles