### PR TITLE
release: promote to v0.1.0 stable for CC Summit launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+## [0.1.0] — 2026-06-23
+
+Stable launch release at Confidential Computing Summit, June 23 2026.
+
+### Fixed
+
+**[SDK]** Enforce `poisoning_scan.result` rules in verifier — bad scan results now correctly fail closed (#167).
+**[SDK]** Align Pydantic models, examples, and signing logic to the v0.1 spec (#165).
+**[SDK]** Transparency log and signing error paths fully covered; fail-closed verifier restored (#168).
+
 ## [0.1.0-alpha1] — 2026-06-04
 
 Initial developer preview. Launching at Confidential Computing Summit, June 23 2026.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.1.0a1"
+version = "0.1.0"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Stable v0.1.0 for the June 23 CC Summit launch.

- `python/pyproject.toml`: `0.1.0a1` → `0.1.0`
- `CHANGELOG.md`: adds `[0.1.0] - 2026-06-23` entry covering the three fixes shipped since alpha: poisoning_scan verifier enforcement (#167), model/signing alignment (#165), and transparency log error path coverage (#168)

After merge: tag `python-v0.1.0` and the publish workflow will push `agent-manifest 0.1.0` to PyPI.