### PR TITLE
feat(sdk): export the relying-party verification API from the package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Added
+
+**[SDK]** Export the verification API from the package root, so relying parties
+and gateways call `agent_manifest.verify_manifest()` and `VerificationContext`
+directly instead of importing the private `_verify` module (#175).
+
 ## [0.1.0] — 2026-06-23
 
 Stable launch release at Confidential Computing Summit, June 23 2026.

--- a/docs/api-reference/verification.md
+++ b/docs/api-reference/verification.md
@@ -2,6 +2,24 @@
 
 The core verification engine and FastAPI router. See [Tutorial: Server-side verification](../tutorials/server-side-verification.md) for usage examples.
 
+## Public API
+
+For gateway and runtime-session binding, call the package-root export rather than
+the private `_verify` module:
+
+```python
+from agent_manifest import RevocationStore, VerificationContext, verify_manifest
+```
+
+`verify_manifest()` is the supported high-level entry point.
+`VerificationContext.trusted_keys` maps an issuer `key_id` (the SHA-256 hex of
+the public key bytes) to its base64url-encoded Ed25519 public key, the form
+returned by `Ed25519KeyPair.public_b64url()`. A consumer that holds raw public
+key bytes must base64url-encode them before populating `trusted_keys`. Signers
+and verifiers share `agent_manifest.signing_pre_image()` for the exact RFC 8785
+canonical byte sequence, including the `hitl_record.approvals` normalization, so
+a relying party never reconstructs the pre-image itself.
+
 ## Core function
 
 ::: agent_manifest._verify.verify_manifest
@@ -26,11 +44,21 @@ The core verification engine and FastAPI router. See [Tutorial: Server-side veri
 
 ::: agent_manifest._verify.MismatchDetail
 
+`EvidencePack` is an optional reference (trace id, signer, hash, and URI) to an
+externally retained evidence pack that a verifier can record alongside a result.
+
 ::: agent_manifest._verify.EvidencePack
 
-## Revocation store
+## Revocation
+
+`RevocationStore` is the revocation lookup a verifier consults during
+`verify_manifest()`; the default is in-memory, and production deployments back it
+with a persistent store. `RevocationRecord` is a single revocation entry: which
+manifest was revoked, when, why, and by whom.
 
 ::: agent_manifest._verify.RevocationStore
+
+::: agent_manifest._verify.RevocationRecord
 
 ## FastAPI router
 

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -23,6 +23,13 @@ from ._signing import (
     signing_pre_image,
     generate_ed25519, Ed25519KeyPair, Ed25519Signer, Ed25519Verifier,
 )
+from ._verify import (
+    verify_manifest,
+    VerificationContext, VerificationResult,
+    OverallResult, FieldResult, DelegationResult, HitlResult,
+    FieldsVerified, MismatchDetail, EvidencePack,
+    RevocationStore, RevocationRecord,
+)
 
 __all__ = [
     "Manifest", "ArtifactBindings",
@@ -44,4 +51,8 @@ __all__ = [
     "canonicalize", "canonical_hash",
     "SIGNED_FIELDS", "signing_pre_image",
     "generate_ed25519", "Ed25519KeyPair", "Ed25519Signer", "Ed25519Verifier",
+    "verify_manifest", "VerificationContext", "VerificationResult",
+    "OverallResult", "FieldResult", "DelegationResult", "HitlResult",
+    "FieldsVerified", "MismatchDetail", "EvidencePack",
+    "RevocationStore", "RevocationRecord",
 ]

--- a/python/tests/test_public_api.py
+++ b/python/tests/test_public_api.py
@@ -80,3 +80,23 @@ def test_public_verify_roundtrip_valid_then_mismatch():
         manifest, drifted, agent_manifest.RevocationStore()
     )
     assert mismatch.result == agent_manifest.OverallResult.MISMATCH
+
+
+def test_partial_context_leaves_unprovided_fields_not_bound():
+    # A verifier only checks what it can observe at runtime. With a partial
+    # context (system prompt provided, policy bundle omitted), the unprovided
+    # field is reported NOT_BOUND rather than a mismatch, and the overall result
+    # stays VALID.
+    keypair = agent_manifest.generate_ed25519()
+    manifest, sha_a, _sha_b = _signed_manifest(keypair)
+    trusted = {keypair.key_id: keypair.public_b64url()}
+
+    partial = agent_manifest.VerificationContext(
+        system_prompt_hash=sha_a,
+        trusted_keys=trusted,
+    )
+    result = agent_manifest.verify_manifest(
+        manifest, partial, agent_manifest.RevocationStore()
+    )
+    assert result.result == agent_manifest.OverallResult.VALID
+    assert result.fields_verified.policy_bundle == agent_manifest.FieldResult.NOT_BOUND

--- a/python/tests/test_public_api.py
+++ b/python/tests/test_public_api.py
@@ -1,0 +1,82 @@
+"""Public API surface: the relying-party verification engine must be importable
+from the package root, not only from the private agent_manifest._verify module.
+
+This closes the verification-contract gap raised in agent-manifest#175 (and seen
+in the cMCP integration, agentrust-io/cmcp#302): a relying party should call
+agent_manifest.verify_manifest rather than reach into a private module or
+reimplement the canonical pre-image. The roundtrip exercises the same VALID and
+MISMATCH paths as AM-VERIFY-07 / AM-VERIFY-11 through the public import path.
+"""
+from datetime import datetime, timedelta, timezone
+
+import agent_manifest
+
+_PUBLIC_VERIFY_API = (
+    "verify_manifest",
+    "VerificationContext",
+    "VerificationResult",
+    "OverallResult",
+    "FieldResult",
+    "DelegationResult",
+    "HitlResult",
+    "FieldsVerified",
+    "MismatchDetail",
+    "EvidencePack",
+    "RevocationStore",
+    "RevocationRecord",
+)
+
+
+def _signed_manifest(keypair):
+    now = datetime.now(timezone.utc)
+    sha_a = "sha256:" + "a" * 64
+    sha_b = "sha256:" + "b" * 64
+    manifest = {
+        "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+        "agent_id": "spiffe://trust.example/agent/kyc/prod",
+        "version": "0.1",
+        "issued_at": now.isoformat().replace("+00:00", "Z"),
+        "expires_at": (now + timedelta(days=90)).isoformat().replace("+00:00", "Z"),
+        "crypto_profile": "standard",
+        "artifacts": {
+            "system_prompt": {"hash": sha_a},
+            "policy_bundle": {"hash": sha_b, "enforcement_mode": "enforce"},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
+        },
+    }
+    manifest["signature"] = agent_manifest.Ed25519Signer(keypair).sign(manifest)
+    return manifest, sha_a, sha_b
+
+
+def test_relying_party_api_is_exported_from_package_root():
+    for name in _PUBLIC_VERIFY_API:
+        assert name in agent_manifest.__all__, f"{name} missing from __all__"
+        assert hasattr(agent_manifest, name), f"{name} not importable from package root"
+
+
+def test_public_verify_roundtrip_valid_then_mismatch():
+    keypair = agent_manifest.generate_ed25519()
+    manifest, sha_a, sha_b = _signed_manifest(keypair)
+    trusted = {keypair.key_id: keypair.public_b64url()}
+
+    matching = agent_manifest.VerificationContext(
+        system_prompt_hash=sha_a,
+        policy_bundle_hash=sha_b,
+        model_version="claude-3",
+        trusted_keys=trusted,
+    )
+    valid = agent_manifest.verify_manifest(
+        manifest, matching, agent_manifest.RevocationStore()
+    )
+    assert valid.result == agent_manifest.OverallResult.VALID
+
+    drifted = agent_manifest.VerificationContext(
+        system_prompt_hash="sha256:" + "f" * 64,  # running prompt differs from manifest
+        policy_bundle_hash=sha_b,
+        model_version="claude-3",
+        trusted_keys=trusted,
+    )
+    mismatch = agent_manifest.verify_manifest(
+        manifest, drifted, agent_manifest.RevocationStore()
+    )
+    assert mismatch.result == agent_manifest.OverallResult.MISMATCH


### PR DESCRIPTION
## Summary
Export the relying-party verification engine from the package root, so
`agent_manifest.verify_manifest` is the canonical entry point a verifier or
gateway calls.

## Problem
`verify_manifest` and its result/context types live in the private
`agent_manifest._verify` module. They are documented in
`docs/api-reference/verification.md`, but are not in the package's public API
(`__all__`). Today relying parties, and even this repo's own tests, import them
from the private `_verify` path. In the cMCP integration (agentrust-io/cmcp#302)
this led to reimplementing the canonical signing pre-image by hand instead of
reusing the SDK, which is the concern raised in #175.

## Change
Export the hosting-agnostic engine and result types from `agent_manifest`:
`verify_manifest`, `VerificationContext`, `VerificationResult`, `OverallResult`,
`FieldResult`, `DelegationResult`, `HitlResult`, `FieldsVerified`,
`MismatchDetail`, `EvidencePack`, `RevocationStore`, `RevocationRecord`.

`create_router` (the FastAPI HTTP wiring) is intentionally left in the submodule,
so importing the package does not pull FastAPI as a hard dependency (FastAPI is
imported lazily inside `create_router`).

## Tests
`tests/test_public_api.py`: asserts the API is importable from the package root,
plus a VALID-then-MISMATCH roundtrip through the public path.

## Validation
- `pytest tests`: 440 passed, 22 skipped (no regression)
- `ruff check`: clean
- `import agent_manifest` does not require FastAPI

Non-breaking addition; existing imports are unaffected.

## Open question for maintainers
This exposes the engine that currently lives under `_verify`. Since it is already
documented as public API, exporting it at the top level seems right, but if you
prefer a different public surface (for example a dedicated `agent_manifest.verify`
namespace), happy to adjust. This PR is the concrete answer to #175.
