### PR TITLE
docs: fix dead links in tutorials, integrations, and operations

### DIFF
--- a/docs/integrations/agt.md
+++ b/docs/integrations/agt.md
@@ -202,5 +202,5 @@ The verification sidecar and AGT policy engine run as a single fast path: the co
 ## What's next
 
 - [Tutorial: Server-side verification](../tutorials/server-side-verification.md)  -  the verification sidecar in detail
-- [Tutorial: Revocation and key rotation](../tutorials/revocation.md)  -  manual revocation flow complementing AGT kill-switch
+- [Tutorial: Revocation and key rotation](../tutorials/revocation-and-key-rotation.md)  -  manual revocation flow complementing AGT kill-switch
 - [AGT documentation](https://github.com/microsoft/agent-governance-toolkit)  -  full AGT reference

--- a/docs/integrations/autogen-crewai.md
+++ b/docs/integrations/autogen-crewai.md
@@ -261,5 +261,5 @@ print(result)
 ## What's next
 
 - [Tutorial: A2A delegation chains](../tutorials/delegation-chains.md)  -  cryptographic delegation between AutoGen agents
-- [Tutorial: Revocation and key rotation](../tutorials/revocation.md)  -  revoke a crew member's manifest mid-operation
+- [Tutorial: Revocation and key rotation](../tutorials/revocation-and-key-rotation.md)  -  revoke a crew member's manifest mid-operation
 - [Integration: AGT](agt.md)  -  combine with AGT for policy-driven crew governance

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -225,4 +225,4 @@ When a LangChain agent presents its `manifest_id`, your service needs to look it
 ## What's next
 
 - [Tutorial: Server-side verification](../tutorials/server-side-verification.md)  -  full verification router for a FastAPI service
-- [Tutorial: Revocation and key rotation](../tutorials/revocation.md)  -  revoke a LangChain agent's manifest on compromise
+- [Tutorial: Revocation and key rotation](../tutorials/revocation-and-key-rotation.md)  -  revoke a LangChain agent's manifest on compromise

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -16,6 +16,6 @@ Agent-manifest has three operational components you need to run:
 
 2. **CRL endpoint**  -  serves the certificate revocation list at `.well-known/agent-manifest/revocation`. This must be highly available  -  verifiers poll it continuously.
 
-3. **Verification sidecar**  -  the FastAPI router (`create_router()`) that runs alongside each agent. See [Tutorial: Deploying the verifier](../tutorials/deploy-verifier.md) for the deployment pattern.
+3. **Verification sidecar**  -  the FastAPI router (`create_router()`) that runs alongside each agent. See [Tutorial: Deploying the verifier](../tutorials/deploying-the-verification-endpoint.md) for the deployment pattern.
 
 Each guide covers the operational concerns specific to one of these components.

--- a/docs/tutorials/cmcp-session-binding.md
+++ b/docs/tutorials/cmcp-session-binding.md
@@ -1,6 +1,6 @@
 # cMCP Session Binding
 
-By the end of this tutorial you will understand how cMCP (PR #323) binds a signed Agent Manifest to a session at startup, what checks it performs, and what the Trust Record carries as a result.
+By the end of this tutorial you will understand how cMCP binds a signed Agent Manifest to a session at startup, what checks it performs, and what the Trust Record carries as a result.
 
 ## What you'll learn
 
@@ -15,13 +15,13 @@ By the end of this tutorial you will understand how cMCP (PR #323) binds a signe
 pip install agent-manifest
 ```
 
-You also need a cMCP gateway with PR #323 applied (session binding support).
+You also need cMCP v0.2.0 or later (includes session binding support).
 
 ---
 
-## What cMCP PR #323 does
+## How session binding works
 
-cMCP PR #323 adds agent manifest session binding to the gateway startup sequence. When the env var `CMCP_AGENT_MANIFEST_PATH` points to a signed manifest, cMCP loads that manifest and verifies three things before the session opens:
+cMCP agent manifest session binding runs at gateway startup. When the env var `CMCP_AGENT_MANIFEST_PATH` points to a signed manifest, cMCP loads that manifest and verifies three things before the session opens:
 
 1. The manifest's cryptographic signature is valid against a configured trusted key.
 2. `manifest.agent_id` matches the authenticated agent subject from the session credentials.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -6,18 +6,26 @@ If you are new to agent-manifest, start with [Getting Started](../getting-starte
 
 ---
 
+## Getting started
+
+| Tutorial | What you'll build |
+|----------|-------------------|
+| [Your first manifest](your-first-manifest.md) | A signed Agent Manifest from scratch with Ed25519 key generation and CLI verification |
+| [CI/CD signing](ci-cd-signing.md) | A GitHub Actions workflow that signs your manifest on every release |
+| [cMCP session binding](cmcp-session-binding.md) | A cMCP gateway configured to verify and bind a signed manifest at session startup |
+
 ## Development
 
 | Tutorial | What you'll build |
 |----------|-------------------|
 | [Server-side manifest verification](server-side-verification.md) | A FastAPI service that verifies incoming agent manifests and gates requests |
 | [A2A delegation chains](delegation-chains.md) | A two-hop delegation chain with scope narrowing and chain verification |
-| [HITL approval workflows](hitl-approvals.md) | A manifest with a cryptographically signed human approval record |
-| [Revocation and key rotation](revocation.md) | A signed revocation record, a live CRL endpoint, and a key rotation procedure |
+| [HITL approval workflows](hitl-approval-workflows.md) | A manifest with a cryptographically signed human approval record |
+| [Revocation and key rotation](revocation-and-key-rotation.md) | A signed revocation record, a live CRL endpoint, and a key rotation procedure |
 | [Hardware attestation](hardware-attestation.md) | Hardware-bound attestation on SEV-SNP, TDX, and OPAQUE |
 
 ## Operations
 
 | Tutorial | What you'll build |
 |----------|-------------------|
-| [Deploying the verification endpoint](deploy-verifier.md) | A containerised verifier with health checks, CRL, and Kubernetes deployment |
+| [Deploying the verification endpoint](deploying-the-verification-endpoint.md) | A containerised verifier with health checks, CRL, and Kubernetes deployment |


### PR DESCRIPTION
## Summary

Five link targets were broken across tutorials, integrations, and operations:

- `tutorials/index.md`: fix `hitl-approvals.md` → `hitl-approval-workflows.md`, `revocation.md` → `revocation-and-key-rotation.md`, `deploy-verifier.md` → `deploying-the-verification-endpoint.md`; add "Getting Started" group listing the 3 new tutorials added in #184
- `integrations/langchain.md`, `agt.md`, `autogen-crewai.md`: fix `../tutorials/revocation.md` → `revocation-and-key-rotation.md`
- `operations/index.md`: fix `../tutorials/deploy-verifier.md` link
- `cmcp-session-binding.md`: remove stale "PR #323" references; replace with "cMCP v0.2.0 or later"

## Test plan

- [ ] CI passes
- [ ] All tutorial links resolve on the deployed site
- [ ] tutorials/index.md shows all 10 tutorials including the 3 new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)