### PR TITLE
fix: remove partner names and commercial-program language

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,7 +4,7 @@ Organizations using or evaluating Agent Manifest in production or pilot deployme
 
 To add your organization, open a PR editing this file. Include: organization name, use case (one sentence), and optionally a contact or case study link.
 
-## Design partners (v0.1 preview)
+## Founding contributors
 
 | Organization | Use case |
 |---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ Launching at Confidential Computing Summit, June 23 2026.
 
 ## Next — v0.2 (Q3 2026)
 
-Driven by design-partner feedback from the CC Summit. Current candidates:
+Driven by community and early adopter feedback from the CC Summit period. Current candidates:
 
 - **HITL approval scheme clarification** — specify whether hybrid mode applies to approver signatures; document approver key rotation
 - **Policy bundle test vector** — add Merkle root test vector for composite bundles (Section 3.2.2)
@@ -46,4 +46,4 @@ v0.2 will go through the RFC process (14-day comment period) for any normative c
 
 ## How to influence the roadmap
 
-Open a GitHub issue with the `spec` label describing the problem you are trying to solve. Design partner feedback from the CC Summit period (June–September 2026) has priority for v0.2 scope decisions.
+Open a GitHub issue with the `spec` label describing the problem you are trying to solve. Community and early adopter feedback from the CC Summit period (June–September 2026) has priority for v0.2 scope decisions.

--- a/spec/agent-manifest-spec-v0.1.md
+++ b/spec/agent-manifest-spec-v0.1.md
@@ -1437,11 +1437,9 @@ The Art. 13 row in section 9.1 cross-references `operational_lifecycle.expected_
 - Conformance test suite (197 tests)
 - Reference implementation targeting AAIF + cMCP
 
-### 10.2 Version 0.2 - Design Partner Feedback
+### 10.2 Version 0.2
 
-<!-- CHANGED: REG-003 - added OCC RFI tracking to roadmap -->
-
-Targets: Q3 2026. Input from ServiceNow, JPMC, Across AI, and sovereign AI partners.
+Targets: Q3 2026. Driven by community and early adopter feedback collected during the CC Summit period (June–September 2026).
 
 - Memory baseline protocol for stateful agents (v0.1 defines the binding; v0.2 defines the checkpoint protocol)
 - RAG corpus incremental update protocol - how to bind a delta without re-hashing the full corpus


### PR DESCRIPTION
## Summary

Removes internal commercial information that leaked into public-facing files:

- **spec/agent-manifest-spec-v0.1.md §10.2**: Removed ServiceNow, JPMC, and Across AI from the v0.2 roadmap section. These are real enterprise partners who did not consent to being named in a public specification document. Replaced with generic "community and early adopter feedback" framing.
- **ADOPTERS.md**: Renamed "Design partners (v0.1 preview)" to "Founding contributors" — the section only lists Opaque Systems, which is the founding contributor, not a paying design partner. The "design partner" heading was implying a commercial program.
- **ROADMAP.md**: Two instances of "design-partner feedback" replaced with "community and early adopter feedback."

## Test plan

- [ ] CI passes
- [ ] No partner names remain in any public-facing file (`grep -r "JPMC\|Across AI\|ServiceNow\|Core42" .`)