### PR TITLE
fix(ci): install agent-governance-toolkit-core for AGT strict verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install package and AGT
         working-directory: python
-        run: pip install -e ".[dev]" "agent-governance-toolkit>=4.1"
+        run: pip install -e ".[dev]" "agent-governance-toolkit>=4.1" "agent-governance-toolkit-core>=4.1"
 
       - name: Install PyYAML (needed by gen script)
         run: pip install pyyaml


### PR DESCRIPTION
Stacked on #200.

The AGT `governance` job scored 1/10 on the OWASP ASI controls because the strict verifier could not import `agent_os`/`agentmesh` — the governance step installed only the `agent-governance-toolkit` meta package, not `agent-governance-toolkit-core`, which ships those control namespaces. cmcp resolves `-core` transitively (via its runtime dependency) and scores 10/10; this repo depends on neither, so the step must install it explicitly.

This adds `agent-governance-toolkit-core>=4.1` to the governance install line, bringing strict verify to 10/10. It also fixes the evidence file's `toolkit_version`, which queries that package.

Base is #200's branch since it edits the same install line; retarget to main once #200 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)