### PR TITLE
fix(attestation): correct SNP REPORT_DATA vs HOST_DATA in spec/docs; mark providers experimental

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install package and AGT
         working-directory: python
-        run: pip install -e ".[dev]" "agent-governance-toolkit>=4.1"
+        run: pip install -e ".[dev]" "agent-governance-toolkit>=4.1" "agent-governance-toolkit-core>=4.1"
 
       - name: Install PyYAML (needed by gen script)
         run: pip install pyyaml

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -66,7 +66,7 @@ injecting a tool) would not be detected by the boot-time attestation alone.
 For deployments that need to prove the agent has not drifted since startup, use
 `attest_runtime_state(nonce, context_hash)`. This method issues a new hardware
 quote on demand. The TEE sets its caller-controlled field
-(`HOST_DATA` on SEV-SNP, `REPORTDATA` on TDX, qualifying data on TPM) to
+(`REPORT_DATA` on SEV-SNP, `REPORTDATA` on TDX, qualifying data on TPM) to
 `sha256(nonce || context_hash_bytes)` and signs it together with the unchanged
 boot measurement. A verifier that supplies the nonce and independently computes
 `context_hash` can then confirm:

--- a/docs/adr/0010-runtime-attestation-freshness-proofs.md
+++ b/docs/adr/0010-runtime-attestation-freshness-proofs.md
@@ -29,7 +29,7 @@ TEE attestation hardware has two distinct fields:
 | Field | Set by | Mutable after boot? |
 |-------|--------|-------------------|
 | `MEASUREMENT` / `MRTD` / PCR values | Hardware/firmware at launch | No — silicon-sealed |
-| `REPORT_DATA` / `HOST_DATA` (SNP/TDX) or qualifying data (TPM) | Caller software via IOCTL | Yes — caller-controlled, hardware-signed |
+| `REPORT_DATA` (SNP) / `REPORTDATA` (TDX) or qualifying data (TPM) | Caller (guest) software via IOCTL | Yes — guest-controlled, hardware-signed |
 
 The boot measurement is immutable. However, the caller-controlled field can be
 set to arbitrary bytes at any time by issuing a new IOCTL, and the hardware
@@ -69,8 +69,9 @@ are separate evidence artifacts — they are not appended to the manifest.
 
 Re-measuring the TEE is not possible after boot. The only way to get fresh
 hardware-signed evidence is via the caller-controlled field. This is not a
-workaround — it is the intended mechanism. SNP's `HOST_DATA` and TDX's
-`REPORTDATA` exist specifically for this purpose.
+workaround — it is the intended mechanism. SNP's `REPORT_DATA` (the guest-controlled
+field, distinct from the host-set `HOST_DATA`) and TDX's `REPORTDATA` exist
+specifically for this purpose.
 
 **Why sha256(nonce || context_hash_bytes) rather than nonce alone?**
 
@@ -129,7 +130,7 @@ their own enforcement loop.
 
 ## References
 
-- AMD SEV-SNP: `HOST_DATA` field — Linux kernel `sev-guest.h`, `struct snp_report_req`
+- AMD SEV-SNP: `REPORT_DATA` field, populated via the `user_data` member of `struct snp_report_req` — Linux kernel `sev-guest.h`
 - Intel TDX: `REPORTDATA` field — Intel TDX Module Architecture Spec §3.3
 - TPM 2.0: qualifying data in `TPM2_Quote` — TCG PC Client Platform Firmware Profile §4.2
 - RFC 9334: RATS architecture (Attester / Verifier / Relying Party roles)

--- a/docs/tutorials/hardware-attestation.md
+++ b/docs/tutorials/hardware-attestation.md
@@ -56,7 +56,9 @@ Level 2 provides the strongest locally-verifiable hardware guarantee. Level 3 ad
 
 ### How it works
 
-`SEVSNPProvider.extend_manifest_hash()` computes `SHA-256(manifest_pre_image)` and places the 32-byte digest in the first half of the `HOST_DATA` field of the SNP attestation report. `HOST_DATA` is 64 bytes reserved for user-defined binding data. Verifiers check that `HOST_DATA[:32]` matches the expected manifest hash.
+> **Experimental:** the hardware providers are reference implementations and are not yet validated against real SEV-SNP/TDX hardware. The report field naming, byte offsets, and IOCTL ABI are being corrected (see issue #205). Do not rely on them in production.
+
+`SEVSNPProvider.extend_manifest_hash()` computes `SHA-256(manifest_pre_image)` and places the 32-byte digest in the first half of the guest-controlled `REPORT_DATA` field of the SNP attestation report, populated via the `user_data` member of the report request. `REPORT_DATA` is 64 bytes reserved for guest-supplied binding data. Verifiers check that `REPORT_DATA[:32]` matches the expected manifest hash. (`HOST_DATA` is a separate, host-set field and is not used here.)
 
 ### Usage
 
@@ -74,7 +76,7 @@ except AttestationUnavailableError as e:
 with open("manifest.json") as f:
     manifest = json.load(f)
 
-# Extends SHA-256(manifest_pre_image) into HOST_DATA
+# Extends SHA-256(manifest_pre_image) into REPORT_DATA (guest-controlled field)
 provider.extend_manifest_hash(manifest)
 
 # Read the attestation report
@@ -299,7 +301,7 @@ verifier challenge.
 
 ### How it works
 
-The hardware's caller-controlled field (`HOST_DATA` on SEV-SNP, `REPORTDATA`
+The hardware's guest-controlled field (`REPORT_DATA` on SEV-SNP, `REPORTDATA`
 on TDX, qualifying data on TPM) is set to:
 
 ```

--- a/python/src/agent_manifest/_hw_providers.py
+++ b/python/src/agent_manifest/_hw_providers.py
@@ -1,12 +1,20 @@
 """AMD SEV-SNP, Intel TDX, and TEE attestation providers — issues #6, #7, #8.
 
+EXPERIMENTAL: these hardware providers are reference implementations and have
+NOT been validated against real SEV-SNP/TDX hardware. The report field usage,
+byte offsets, and IOCTL ABI below are known to be incorrect or unverified and
+are tracked for a hardware-validated rewrite (issues #204, #205). Do not rely
+on these providers for production attestation.
+
 These providers extend _providers.py:AttestationProvider for higher-assurance
 hardware attestation than TPM.
 
 SEV-SNP (issue #6):
-  Uses /dev/sev-guest to extend the manifest hash into the HOST_DATA field
-  of the SNP attestation report. HOST_DATA is a 64-byte field specifically
-  reserved for user-defined data — ideal for binding a manifest hash.
+  Uses /dev/sev-guest to bind the manifest hash into the guest-controlled
+  REPORT_DATA field of the SNP attestation report (populated via the user_data
+  member of the report request). REPORT_DATA is a 64-byte field reserved for
+  guest-supplied data. HOST_DATA is a separate, host-set field (32 bytes) that
+  the guest cannot write, and is NOT used here.
 
 TDX (issue #7):
   Uses /dev/tdx-guest to extend the manifest hash into RTMR[1].
@@ -46,9 +54,14 @@ _SNP_REPORT_IOCTL = 0xC0A00300  # _IOWR('s', 0, struct snp_report_req) — kerne
 class SEVSNPProvider(AttestationProvider):
     """AMD SEV-SNP attestation via /dev/sev-guest (Linux kernel 5.19+).
 
-    Extends the manifest hash into HOST_DATA (64 bytes) of the SNP attestation
-    report. The first 32 bytes of HOST_DATA carry the SHA-256 of the manifest
-    pre-image; the remaining 32 bytes are zero-padded.
+    EXPERIMENTAL / not hardware-validated — see the module docstring and #205.
+
+    Binds the manifest hash into the guest-controlled REPORT_DATA (64 bytes) of
+    the SNP attestation report. The first 32 bytes carry the SHA-256 of the
+    manifest pre-image; the remaining 32 bytes are zero-padded. (HOST_DATA is a
+    separate host-set field and is not used.) The report-parsing offsets in this
+    class are not yet corrected for REPORT_DATA and must be fixed against the
+    AMD ABI before production use (#205).
 
     Requirements:
       - AMD EPYC (Milan or later) with SEV-SNP enabled in BIOS
@@ -122,7 +135,9 @@ class SEVSNPProvider(AttestationProvider):
             platform="amd-sev-snp",
             manifest_hash=self._manifest_hash or "",
             raw={
-                "host_data": self._report_bytes[0x140:0x180].hex(),  # HOST_DATA at offset 0x140
+                # FIXME(#205): guest-supplied data lives in REPORT_DATA (offset 0x50), not
+                # HOST_DATA (0x140). This reads the wrong field and is not hardware-validated.
+                "host_data": self._report_bytes[0x140:0x180].hex(),
                 "measurement": measurement_hex,
                 "vmpl": 0,
                 # HW-008: VCEK chain not verified — the ioctl response does not embed
@@ -138,8 +153,8 @@ class SEVSNPProvider(AttestationProvider):
         if self._report_bytes is not None:
             import hmac as _hmac
             expected_hex = self.manifest_hash_value(manifest_json).split(":", 1)[-1]
-            # HOST_DATA is at offset 0x140 in snp_attestation_report; first 32 bytes
-            # hold the SHA-256 digest we placed there in extend_manifest_hash()
+            # FIXME(#205): reads HOST_DATA (offset 0x140); guest-supplied data is in
+            # REPORT_DATA (offset 0x50). Not hardware-validated — see module docstring.
             actual = self._report_bytes[0x140:0x140 + 32].hex()
             return _hmac.compare_digest(actual, expected_hex)
         # External report: fall back to manifest_hash field comparison

--- a/python/src/agent_manifest/_providers.py
+++ b/python/src/agent_manifest/_providers.py
@@ -67,7 +67,7 @@ class RuntimeAttestationReport:
     """
 
     platform: str
-    # sha256(nonce || context_hash_bytes) placed in REPORT_DATA / HOST_DATA
+    # sha256(nonce || context_hash_bytes) placed in the guest-controlled field (REPORT_DATA on SNP)
     report_data_hash: str
     # sha256:<hex> of the caller-supplied runtime context (system prompt, policy, tools…)
     context_hash: str
@@ -111,7 +111,7 @@ class AttestationProvider(ABC):
         startup, this method can be called periodically or per-N-calls to produce
         a hardware-signed freshness proof of the agent's current runtime state.
 
-        The hardware sets REPORT_DATA / HOST_DATA to:
+        The hardware sets the guest-controlled field (REPORT_DATA on SNP) to:
             sha256(nonce || bytes.fromhex(context_hash.split(":")[-1]))
         and signs it together with the unchanged boot measurement, so a verifier
         holding the nonce can confirm both TEE identity and current state.

--- a/spec/agent-manifest-spec-v0.1.md
+++ b/spec/agent-manifest-spec-v0.1.md
@@ -656,9 +656,9 @@ The attestation service acts as a RATS Verifier in the sense of RFC 9334. For de
 The following profiles define, per platform, the measurement field used to carry the `manifest_hash_in_report`, the format of the `measurement` field, and which component performs the extension.
 
 **AMD SEV-SNP**
-- `manifest_hash_in_report` is extended into the `HOST_DATA` field of the SNP attestation report (32 bytes, purpose-built for guest-supplied data). Do NOT use a PCR register for this purpose.
+- `manifest_hash_in_report` is bound via the `HOST_DATA` field of the SNP attestation report (32 bytes). `HOST_DATA` is host-supplied launch data: it is set by the host/launcher (the Confidential Runtime) at `SNP_LAUNCH_FINISH` and the guest can read but not modify it after launch. This boot-time binding is therefore only as trustworthy as the launcher that measures the manifest. `HOST_DATA` is NOT the guest-controlled field; the guest-controlled field is `REPORT_DATA` (64 bytes), used for the runtime freshness proofs in §3.3.2. Do NOT use a PCR register for this purpose.
 - `measurement` field: SHA-256 of initial guest memory pages (64 bytes, 128 lowercase hex characters).
-- Extension actor: the Confidential Runtime extends `HOST_DATA` before guest launch.
+- Extension actor: the Confidential Runtime (host/launcher) sets `HOST_DATA` at `SNP_LAUNCH_FINISH`, before the guest runs; the guest cannot alter it.
 
 **Intel TDX**
 - `manifest_hash_in_report` is extended into `RTMR[3]` using `TDG.MR.RTMR.EXTEND` before any workload code runs.
@@ -692,7 +692,7 @@ For deployments requiring continuous or challenge-response evidence, the SDK exp
 
 **Scope of the TEE boot measurement**
 
-The TEE boot measurement (`MEASUREMENT` on SNP, `MRTD` on TDX, PCR values on TPM) is hardware-immutable after launch. No re-measurement of the TEE is possible. What `attest_runtime_state()` provides is a fresh hardware-signed quote in which the caller-controlled field (`HOST_DATA` on SNP, `REPORTDATA` on TDX) is set to a value that binds the nonce and the current runtime context. The hardware signs both the immutable boot measurement and this caller-supplied value, giving the verifier:
+The TEE boot measurement (`MEASUREMENT` on SNP, `MRTD` on TDX, PCR values on TPM) is hardware-immutable after launch. No re-measurement of the TEE is possible. What `attest_runtime_state()` provides is a fresh hardware-signed quote in which the guest-controlled field (`REPORT_DATA` on SNP, `REPORTDATA` on TDX) is set to a value that binds the nonce and the current runtime context. The hardware signs both the immutable boot measurement and this caller-supplied value, giving the verifier:
 
 1. **TEE identity** — the boot measurement has not changed since the boot-time `attestation` block was produced
 2. **Current state** — the caller-supplied field encodes `sha256(nonce || context_hash_bytes)`


### PR DESCRIPTION
Addresses the documentation-level findings in #201 (reported by @QinyuanWu) and tracking issues #203 / #205.

## What this corrects

The SNP attestation report has two distinct fields, and the docs/code conflated them:

- **`HOST_DATA`** — host-supplied launch data, set by the host/launcher at `SNP_LAUNCH_FINISH`, 32 bytes, **not guest-writable**.
- **`REPORT_DATA`** — guest-controlled, 64 bytes, populated via the report request's `user_data`.

Per the agreed model:
- **Boot-time binding (§3.3.1):** the launcher (Confidential Runtime) binds the manifest into `HOST_DATA` at launch. Kept, but the false "purpose-built for guest-supplied data" claim is corrected, and the trust assumption (the binding is only as good as the launcher measuring the manifest) is now stated.
- **Runtime freshness (§3.3.2) and the guest SDK:** use the guest-controlled `REPORT_DATA`, not `HOST_DATA`. Corrected across spec §3.3.2, ADR-0010, `LIMITATIONS.md`, the tutorial, and the provider docstrings.

## Marked experimental (#205)

The hardware providers (`_hw_providers.py`) are now clearly labeled EXPERIMENTAL / not hardware-validated. The SNP report-parsing offsets still read the `HOST_DATA` offset (`0x140`) rather than `REPORT_DATA` (`0x50`); this and the IOCTL ABI are flagged inline with `FIXME(#205)` and left for the hardware-validated rewrite rather than changing offsets blind.

## Deferred (not in this PR)

- The code-level ABI/offset/key correction and real quote/VCEK signature verification — tracked in #204 / #205 (need real-hardware validation).
- The §1.2 threat-model rewrite and attestation-level relabeling — #206.

Refs #201, #203, #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
