### PR TITLE
docs: scope threat-model claims to what TEE attestation actually provides

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ A verifying party who holds an Agent Manifest and its accompanying attestation r
 | TPM 2.0 | Any Azure/AWS/GCP VM with Trusted Launch | Medium |
 | AMD SEV-SNP | Azure DCasv5, AWS C6a Nitro, GCP N2D | High |
 | Intel TDX | Azure DCedsv5, GCP C3 | High |
-| OPAQUE | OPAQUE Managed Runtime | Highest |
+| OPAQUE | OPAQUE Managed Runtime | Managed (chain-verified) |
 
 Provider auto-selects based on available hardware: `OPAQUE → SEV-SNP → TDX → TPM → software`.
 

--- a/docs/tutorials/hardware-attestation.md
+++ b/docs/tutorials/hardware-attestation.md
@@ -41,7 +41,7 @@ Hardware providers require the VM types listed in the table below. The `Software
 | 2 | `TDXProvider` | Intel Xeon (Sapphire Rapids+): Azure DCedsv5, GCP C3 |
 | 3 | `OPAQUEProvider` | Any  -  delegates to OPAQUE's managed TEE |
 
-Level 2 provides the strongest locally-verifiable hardware guarantee. Level 3 adds a hardware-signed audit chain managed by OPAQUE inside their TEE.
+Level 2 roots the binding in a confidential VM (SEV-SNP/TDX); its strength depends on the verifier checking the full attestation chain and the signing key being sealed to the launch measurement. Level 3 is the operationally-managed option: the agent runs inside OPAQUE's managed TEE, with OPAQUE handling provisioning and key lifecycle and producing a hardware-signed audit chain. Level 3 is not inherently higher assurance than a correctly-verified Level 2, and verifiers must still check the returned claim's signature.
 
 ---
 

--- a/spec/agent-manifest-spec-v0.1.md
+++ b/spec/agent-manifest-spec-v0.1.md
@@ -52,7 +52,11 @@ Existing approaches reduce to operator trust. A software-signed manifest proves 
 
 > **The Anthropic Design Test - Applied to Agent Identity**
 >
-> Anthropic's Zero Trust for AI Agents framework asks: does a control make the attack impossible, or just tedious? Software-signed manifests are tedious controls. A determined operator rewrites them. Hardware-attested manifests are impossible controls - the measurement happens in silicon before any user code runs, and the signing key never leaves the TEE.
+> Anthropic's Zero Trust for AI Agents framework asks whether a control makes an attack impossible or merely tedious. Software-only manifests are tedious: a privileged operator can rewrite them. Hardware raises the bar in two specific ways, and it is worth being precise about which.
+>
+> First, the TEE launch measurement (SNP `MEASUREMENT`, TDX `MRTD`, TPM PCRs) is computed in silicon before any guest code runs, so the launch image cannot be altered undetected. Second, a signing key sealed to that measurement exists only inside an attested environment, so valid signatures cannot be produced anywhere else.
+>
+> What hardware does not do is measure individual files or in-memory objects after boot. Binding a manifest hash into a guest-supplied report field is an assertion by guest software, not a silicon measurement. The manifest makes tampering tamper-evident to a verifier who checks the full attestation chain and confirms the signing key is sealed to the measurement. It does not make in-memory tampering impossible. Read the conformance levels with that boundary in mind.
 
 ### 1.3 The Ten Unattested Surfaces
 
@@ -70,6 +74,8 @@ The following table enumerates the complete agent trust surface. Columns indicat
 | 8 | A2A Delegation | Agent-to-agent trust chain; delegated scope constraints | Orchestrator spoofing; scope laundering across delegation hops | None - no standard | Chain binding |
 | 9 | Supply Chain | Container manifest; SLSA provenance; dependency SBOMs | Compromised dependency runs as approved binary | SLSA (build-time only) | Runtime measure |
 | 10 | HITL Approvals | Human oversight records with identity and timestamp | EU AI Act Art. 14 violation; no accountability chain | None - no standard | Full binding |
+
+> **What the "Agent Manifest" column means.** "Binding" in this table is a cryptographic *signature* binding inside an attested environment, not a hardware *measurement* of each artifact. The TEE measures the launch image in silicon; it does not measure individual files, policy documents, or in-memory objects after boot. A binding is therefore only as strong as a verifier who checks the full attestation chain and confirms the signing key is sealed to the launch measurement. Terms like "hardware-sealed" and "TEE-signed" should be read in that sense.
 
 ## 2. Specification Overview
 


### PR DESCRIPTION
Addresses #206 (from #201). Rewrites the §1.2 threat-model box, adds a clarifying footnote to the §1.3 trust-surface table, and reframes the conformance/provider levels so the documentation matches what the hardware actually provides.

- §1.2: drops "impossible controls"; states what the launch measurement + sealed key do, and what they do not (no measurement of files/in-memory objects after boot; a guest-supplied report field is an assertion, not a silicon measurement).
- §1.3 table: footnote distinguishing signature-binding from hardware measurement.
- Levels: Level 2 strength conditional on chain verification; Level 3 (OPAQUE) reframed as the operationally-managed option, not inherently highest assurance, still requiring claim-signature verification.

Positioning was reviewed and approved before drafting. Pairs with #207 (field corrections) and the verification work tracked in #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)