### PR TITLE
fix(verify): bind delegation root to issuer, enforce scope-narrowing, schema-validate, honest CLI

### DIFF
--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -128,19 +128,28 @@ def verify_delegation_chain(
     delegation_chain: list[dict[str, Any]],
     public_keys: dict[str, bytes],  # principal_id -> public key bytes
     manifest_id: str,
+    manifest_issuer: Optional[str] = None,
 ) -> None:
     """Verify all hops in a delegation chain.
 
     Checks:
+      - The chain root is bound to the manifest's signing identity (when
+        ``manifest_issuer`` is supplied).
       - Each hop signature is valid for its principal's key.
       - Hop indices are sequential starting from 0.
-      - Scope at each hop is not broader than the previous hop's grant.
+      - Scope at each hop is not broader than the previous hop's grant
+        (tools, data_classifications, constraints, ttl_seconds, depth).
       - Chain depth does not exceed root hop's max_delegation_depth.
 
     Args:
         delegation_chain: List of hop dicts from the manifest.
         public_keys: Map of principal_id -> raw Ed25519 public key bytes.
         manifest_id: Manifest ID to include in pre-image (replay protection).
+        manifest_issuer: The manifest's signing identity (issuer or agent_id).
+            When provided, the root hop's principal MUST equal this identity;
+            otherwise the chain is rejected. A chain whose root is not the
+            manifest signer could be grafted onto an unrelated manifest, so
+            this binding is fail-closed when an issuer is known.
 
     Raises:
         InvalidSignature: If any hop signature is invalid.
@@ -148,6 +157,25 @@ def verify_delegation_chain(
     """
     if not delegation_chain:
         return
+
+    # Bind the chain root to the manifest's signing identity. The root hop
+    # establishes the authority the rest of the chain narrows from, so it must
+    # originate from the same principal that signed the manifest. Match either
+    # principal_id or principal_manifest_id so SPIFFE-keyed and manifest-keyed
+    # roots are both accepted.
+    if manifest_issuer:
+        root = delegation_chain[0]
+        root_identities = {
+            root.get("principal_id"),
+            root.get("principal_manifest_id"),
+        }
+        if manifest_issuer not in root_identities:
+            raise ValueError(
+                "Delegation chain root principal "
+                f"{root.get('principal_id')!r} does not match the manifest "
+                f"signing identity {manifest_issuer!r}; the chain is not bound "
+                "to the manifest issuer"
+            )
 
     root_max_depth = delegation_chain[0]["scope_grant"].get(
         "max_delegation_depth", DEFAULT_MAX_DELEGATION_DEPTH
@@ -234,6 +262,42 @@ def _check_scope_narrowing(parent: dict[str, Any], child: dict[str, Any], hop_in
         raise ValueError(
             f"Scope laundering at hop {hop_index}: "
             f"child claims data_classifications {extra!r} not granted by parent"
+        )
+
+    # Constraints are restrictions, so narrowing means the child MUST keep
+    # every parent constraint and may only add more. Dropping a parent
+    # constraint widens the grant and is rejected.
+    parent_constraints = set(parent.get("constraints") or [])
+    child_constraints = set(child.get("constraints") or [])
+    dropped = parent_constraints - child_constraints
+    if dropped:
+        raise ValueError(
+            f"Scope laundering at hop {hop_index}: "
+            f"child drops parent constraints {dropped!r}; child constraints "
+            "must be a superset of the parent's"
+        )
+
+    # ttl_seconds: a child may not live longer than its parent. Absent (None)
+    # means unbounded; a child claiming unbounded under a bounded parent, or a
+    # larger bound, widens the grant.
+    parent_ttl = parent.get("ttl_seconds")
+    child_ttl = child.get("ttl_seconds")
+    if parent_ttl is not None and (child_ttl is None or child_ttl > parent_ttl):
+        raise ValueError(
+            f"Scope laundering at hop {hop_index}: "
+            f"child ttl_seconds {child_ttl!r} exceeds parent ttl_seconds "
+            f"{parent_ttl!r}"
+        )
+
+    # max_delegation_depth: a child may not authorize a deeper sub-chain than
+    # its parent permitted. Omission defaults to the spec value (3).
+    parent_depth = parent.get("max_delegation_depth", DEFAULT_MAX_DELEGATION_DEPTH)
+    child_depth = child.get("max_delegation_depth", DEFAULT_MAX_DELEGATION_DEPTH)
+    if child_depth > parent_depth:
+        raise ValueError(
+            f"Scope laundering at hop {hop_index}: "
+            f"child max_delegation_depth {child_depth} exceeds parent "
+            f"max_delegation_depth {parent_depth}"
         )
 
 

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -183,6 +183,42 @@ class VerificationContext(BaseModel):
 SUPPORTED_MANIFEST_VERSIONS: frozenset[str] = frozenset({"0.1"})
 
 
+def _strict_schema_violations(manifest: dict[str, Any]) -> list[tuple[str, str]]:
+    """Run the manifest through the Pydantic schema and return fail-closed errors.
+
+    Returns a list of (location, message) tuples for every validation error
+    that is NOT a tolerated "missing required field" error. An empty list
+    means the manifest carries no disqualifying schema violation.
+
+    Tolerated: ``missing`` errors only. Disqualifying: unknown fields
+    (``extra_forbidden``), type errors, bad enums, unparseable or
+    out-of-window timestamps, and any ``value_error`` raised by a model
+    validator (e.g. the expiry-window rule).
+    """
+    from pydantic import ValidationError
+
+    from .models import Manifest
+
+    # An empty delegation_chain means "no delegation"; the engine already
+    # normalizes it to absent (``manifest.get("delegation_chain") or []``).
+    # The schema models it as ``min_length=1`` (omit when empty), so drop an
+    # empty/None chain before validating to avoid flagging the benign idiom.
+    if not manifest.get("delegation_chain"):
+        manifest = {k: v for k, v in manifest.items() if k != "delegation_chain"}
+
+    try:
+        Manifest.model_validate(manifest)
+    except ValidationError as exc:
+        violations: list[tuple[str, str]] = []
+        for err in exc.errors():
+            if err.get("type") == "missing":
+                continue
+            loc = ".".join(str(p) for p in err.get("loc", ()))
+            violations.append((loc, err.get("msg", "schema error")))
+        return violations
+    return []
+
+
 def verify_manifest(
     manifest: dict[str, Any],
     context: VerificationContext,
@@ -213,6 +249,31 @@ def verify_manifest(
     result = VerificationResult(manifest_id=manifest_id, result=OverallResult.VALID)
     mismatches: list[MismatchDetail] = []
     fields = result.fields_verified
+
+    # --- Schema validation (fail-closed). verify_manifest accepts a raw dict,
+    # so it must run the manifest through the Pydantic guards before trusting
+    # any field. This makes extra="forbid" (unknown fields), enum/type
+    # constraints, the expiry window, and timestamp parsing actually apply on
+    # the verify path. A malformed expires_at is a schema failure here, not a
+    # silently non-expiring manifest.
+    #
+    # Only pure "missing required field" errors are tolerated: the engine
+    # treats absent artifact bindings and metadata as NOT_BOUND and degrades
+    # safely, and requiring every business field would reject otherwise
+    # well-formed manifests the engine can still evaluate. Every other class of
+    # error (unknown field, wrong type, bad enum, unparseable/out-of-window
+    # timestamp, or any value_error from a model validator) fails closed.
+    schema_violations = _strict_schema_violations(manifest)
+    if schema_violations:
+        result.result = OverallResult.MISMATCH
+        for loc, msg in schema_violations:
+            mismatches.append(MismatchDetail(
+                field=f"schema:{loc}" if loc else "schema",
+                expected_hash="<schema-valid manifest>",
+                actual_hash=f"<{msg}>",
+            ))
+        result.mismatch_details = mismatches
+        return result
 
     # --- Version negotiation (spec 2.2 / 2.4) - MUST be checked before
     # verifying so unsupported manifests are never silently misinterpreted.
@@ -421,7 +482,12 @@ def verify_manifest(
                     pid: _b64url_decode(b64)
                     for pid, b64 in context.delegation_public_keys.items()
                 }
-                verify_delegation_chain(chain, pub_keys, manifest_id)
+                # Bind the chain root to the manifest signing identity so a
+                # valid chain cannot be grafted onto an unrelated manifest.
+                manifest_issuer = manifest.get("issuer") or manifest.get("agent_id")
+                verify_delegation_chain(
+                    chain, pub_keys, manifest_id, manifest_issuer=manifest_issuer
+                )
                 fields.delegation_chain = DelegationResult.VALID
             except (InvalidSignature, ValueError) as e:
                 fields.delegation_chain = DelegationResult.INVALID
@@ -537,6 +603,17 @@ def verify_manifest(
             result.result = OverallResult.INCOMPLETE
         elif context.enforce_attestation and not result.attestation_verified:
             result.result = OverallResult.ATTESTATION_UNAVAILABLE
+
+    # Surface bound-but-unchecked artifacts even in non-strict mode so callers
+    # never read a VALID result as proof that artifact bindings were checked.
+    # A signature-only VALID means the manifest is authentic, not that the
+    # running artifacts match what it bound (VERIFY-001).
+    if unverified_bound:
+        result.warnings.append(
+            "artifact bindings NOT verified (no runtime hashes provided for "
+            + ", ".join(sorted(unverified_bound))
+            + "); VALID reflects signature only"
+        )
 
     return result
 

--- a/python/src/agent_manifest/cli.py
+++ b/python/src/agent_manifest/cli.py
@@ -306,7 +306,28 @@ def verify(
             click.echo(f"  MISMATCH {d.field}: expected {d.expected_hash[:20]}...", err=True)
         sys.exit(1)
     else:
-        click.echo("Result: VALID", err=True)
+        # A VALID result from this command authenticates the signature, but the
+        # CLI never supplies runtime artifact hashes, so any bound artifact is
+        # unchecked. Do not print a bare "VALID" that could be misread as proof
+        # the running artifacts match the manifest (VERIFY-001).
+        artifact_warning = next(
+            (w for w in result.warnings if "artifact bindings NOT verified" in w),
+            None,
+        )
+        if artifact_warning:
+            click.echo(
+                "Result: VALID (signature only - artifact bindings NOT verified)",
+                err=True,
+            )
+            click.echo(
+                "  WARNING: this manifest binds artifacts, but no runtime "
+                "hashes were checked. The signature is authentic; the running "
+                "artifacts were NOT compared against the manifest. Provide "
+                "runtime hashes (or use strict verification) to verify bindings.",
+                err=True,
+            )
+        else:
+            click.echo("Result: VALID", err=True)
 
 
 class _CRLRevocationStore(RevocationStore):

--- a/python/tests/test_am_verify.py
+++ b/python/tests/test_am_verify.py
@@ -219,8 +219,8 @@ def test_memory_baseline_expired():
     m = manifest()
     m["artifacts"]["memory_baseline"] = {
         "snapshot_hash": SHA_A,
-        "approved_at": TS_PAST,
-        "ttl_seconds": 60,
+        "approved_at": TS_PAST,  # 1 day ago, so a 1h TTL is well past expiry
+        "ttl_seconds": 3600,  # schema minimum (1 hour)
     }
     r = verify_manifest(sign(m), ctx(memory_snapshot_hash=SHA_A), store())
     assert r.fields_verified.memory_baseline == FieldResult.EXPIRED

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -140,3 +140,33 @@ def test_cli_verify_with_missing_public_key_file_fails_cleanly(tmp_path):
     assert result.exit_code != 0
     assert "Public key file not found or is not a regular file" in result.output
     assert "Traceback" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Fix #4: CLI must be honest when artifacts are bound but not checked
+# ---------------------------------------------------------------------------
+
+
+def test_cli_verify_bound_artifacts_without_runtime_hashes_qualifies_valid(tmp_path):
+    # The manifest binds system_prompt and policy_bundle hashes, but the CLI
+    # supplies no runtime hashes, so those bindings are never compared. The
+    # output must qualify the VALID status and warn - never a bare "VALID".
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+
+    result = CliRunner().invoke(
+        cli,
+        ["manifest", "verify", str(signed_path), "--public-key", str(public_path)],
+    )
+
+    # Signature is genuinely valid (exit 0), but the status must be qualified.
+    assert result.exit_code == 0
+    payload = _json_stdout(result)
+    assert payload["result"] == "VALID"
+    assert "VALID (signature only - artifact bindings NOT verified)" in result.output
+    assert "WARNING" in result.output
+    # The bare "Result: VALID" line must NOT be emitted in this case.
+    assert "Result: VALID\n" not in result.output
+    # And the result payload carries the machine-readable warning too.
+    assert any("artifact bindings NOT verified" in w for w in payload["warnings"])

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -133,6 +133,125 @@ def test_missing_public_key_raises():
 
 
 # ---------------------------------------------------------------------------
+# Fix #1: chain root must be bound to the manifest signing identity
+# ---------------------------------------------------------------------------
+
+def test_root_principal_must_match_manifest_issuer():
+    kp = generate_ed25519()
+    root_pid = "spiffe://x/root"
+    sig = DelegationHopSigner(kp).sign_hop(
+        hop=0, principal_id=root_pid, principal_type="agent",
+        delegated_at=NOW, scope_grant=SCOPE, manifest_id=MID,
+    )
+    chain = [{"hop": 0, "principal_id": root_pid, "principal_type": "agent",
+               "delegated_at": NOW, "scope_grant": SCOPE, "delegation_signature": sig}]
+    # Root principal does not match the supplied manifest issuer -> rejected.
+    with pytest.raises(ValueError, match="does not match the manifest"):
+        verify_delegation_chain(
+            chain, {root_pid: kp.public_bytes}, MID,
+            manifest_issuer="spiffe://x/some-other-issuer",
+        )
+
+
+def test_root_principal_matching_issuer_passes():
+    kp = generate_ed25519()
+    issuer = "spiffe://x/issuer"
+    sig = DelegationHopSigner(kp).sign_hop(
+        hop=0, principal_id=issuer, principal_type="agent",
+        delegated_at=NOW, scope_grant=SCOPE, manifest_id=MID,
+    )
+    chain = [{"hop": 0, "principal_id": issuer, "principal_type": "agent",
+               "delegated_at": NOW, "scope_grant": SCOPE, "delegation_signature": sig}]
+    verify_delegation_chain(
+        chain, {issuer: kp.public_bytes}, MID, manifest_issuer=issuer,
+    )  # must not raise
+
+
+def test_root_principal_matches_via_principal_manifest_id():
+    kp = generate_ed25519()
+    root_pid = "spiffe://x/root"
+    issuer = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+    sig = DelegationHopSigner(kp).sign_hop(
+        hop=0, principal_id=root_pid, principal_type="agent",
+        delegated_at=NOW, scope_grant=SCOPE, manifest_id=MID,
+    )
+    chain = [{"hop": 0, "principal_id": root_pid, "principal_type": "agent",
+               "delegated_at": NOW, "scope_grant": SCOPE,
+               "delegation_signature": sig, "principal_manifest_id": issuer}]
+    verify_delegation_chain(
+        chain, {root_pid: kp.public_bytes}, MID, manifest_issuer=issuer,
+    )  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Fix #2: scope narrowing covers constraints, ttl_seconds, max_delegation_depth
+# ---------------------------------------------------------------------------
+
+def _two_hop_chain(root_scope, child_scope):
+    kp_root, kp_child = generate_ed25519(), generate_ed25519()
+    sig0 = DelegationHopSigner(kp_root).sign_hop(
+        hop=0, principal_id="spiffe://x/root", principal_type="human",
+        delegated_at=NOW, scope_grant=root_scope, manifest_id=MID,
+    )
+    sig1 = DelegationHopSigner(kp_child).sign_hop(
+        hop=1, principal_id="spiffe://x/child", principal_type="agent",
+        delegated_at=NOW, scope_grant=child_scope, manifest_id=MID,
+    )
+    chain = [
+        {"hop": 0, "principal_id": "spiffe://x/root", "principal_type": "human",
+         "delegated_at": NOW, "scope_grant": root_scope, "delegation_signature": sig0},
+        {"hop": 1, "principal_id": "spiffe://x/child", "principal_type": "agent",
+         "delegated_at": NOW, "scope_grant": child_scope, "delegation_signature": sig1},
+    ]
+    keys = {"spiffe://x/root": kp_root.public_bytes,
+            "spiffe://x/child": kp_child.public_bytes}
+    return chain, keys
+
+
+def test_child_dropping_parent_constraint_is_rejected():
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
+            "constraints": ["region==eu", "amount<1000"]}
+    child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
+             "constraints": ["region==eu"]}  # dropped amount<1000
+    chain, keys = _two_hop_chain(root, child)
+    with pytest.raises(ValueError, match="drops parent constraints"):
+        verify_delegation_chain(chain, keys, MID)
+
+
+def test_child_adding_constraint_is_allowed():
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
+            "constraints": ["region==eu"]}
+    child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
+             "constraints": ["region==eu", "amount<100"]}  # added, superset
+    chain, keys = _two_hop_chain(root, child)
+    verify_delegation_chain(chain, keys, MID)  # must not raise
+
+
+def test_child_raising_ttl_is_rejected():
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600}
+    child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 7200}
+    chain, keys = _two_hop_chain(root, child)
+    with pytest.raises(ValueError, match="ttl_seconds .* exceeds parent"):
+        verify_delegation_chain(chain, keys, MID)
+
+
+def test_child_unbounded_ttl_under_bounded_parent_is_rejected():
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600}
+    child = {"tools": ["t"], "max_delegation_depth": 3}  # ttl absent = unbounded
+    chain, keys = _two_hop_chain(root, child)
+    with pytest.raises(ValueError, match="ttl_seconds .* exceeds parent"):
+        verify_delegation_chain(chain, keys, MID)
+
+
+def test_child_raising_max_delegation_depth_is_rejected():
+    root = {"tools": ["t"], "max_delegation_depth": 1, "ttl_seconds": 3600}
+    child = {"tools": ["t"], "max_delegation_depth": 5, "ttl_seconds": 3600}
+    chain, keys = _two_hop_chain(root, child)
+    with pytest.raises(ValueError, match="max_delegation_depth .* exceeds parent"):
+        verify_delegation_chain(chain, keys, MID)
+
+
+# ---------------------------------------------------------------------------
 # HITL approval signing
 # ---------------------------------------------------------------------------
 

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -130,8 +130,8 @@ def test_memory_baseline_ttl_expired():
     m = base_manifest()
     m["artifacts"]["memory_baseline"] = {
         "snapshot_hash": SHA,
-        "approved_at": PAST,
-        "ttl_seconds": 60,
+        "approved_at": PAST,  # 1 day ago, so a 1h TTL is well past expiry
+        "ttl_seconds": 3600,  # schema minimum (1 hour)
     }
     ctx = base_context(memory_snapshot_hash=SHA)
     result = verify_manifest(sign(m), ctx, store())
@@ -410,3 +410,40 @@ def test_missing_version_is_incompatible():
 def test_supported_version_passes_version_gate():
     result = verify_manifest(base_manifest(version="0.1"), base_context(), store())
     assert result.result == OverallResult.VALID
+
+
+# ---------------------------------------------------------------------------
+# Fix #3: schema validation on the verify path (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_top_level_field_fails_schema():
+    m = base_manifest(rogue_field="injected")
+    result = verify_manifest(m, base_context(), store())
+    assert result.result == OverallResult.MISMATCH
+    assert any(d.field.startswith("schema") for d in result.mismatch_details)
+
+
+def test_unknown_nested_field_fails_schema():
+    m = base_manifest()
+    m["artifacts"]["system_prompt"]["rogue_field"] = "injected"
+    result = verify_manifest(sign(m), base_context(), store())
+    assert result.result == OverallResult.MISMATCH
+    assert any(d.field.startswith("schema") for d in result.mismatch_details)
+
+
+def test_malformed_expires_at_fails_schema_not_silently_valid():
+    # A malformed expires_at must be a failure, not a silently non-expiring
+    # manifest. Re-sign so the signature itself is not the failure.
+    m = base_manifest()
+    m["expires_at"] = "not-a-real-timestamp"
+    result = verify_manifest(sign(m), base_context(), store())
+    assert result.result == OverallResult.MISMATCH
+    assert any(d.field.startswith("schema") for d in result.mismatch_details)
+
+
+def test_bad_enum_value_fails_schema():
+    m = base_manifest(crypto_profile="totally-not-a-profile")
+    result = verify_manifest(m, base_context(), store())
+    assert result.result == OverallResult.MISMATCH
+    assert any(d.field.startswith("schema") for d in result.mismatch_details)

--- a/python/tests/test_verify_delegation.py
+++ b/python/tests/test_verify_delegation.py
@@ -26,6 +26,8 @@ from agent_manifest._verify import (
 NOW = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 MID = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
 SHA = "sha256:" + "a" * 64
+# The manifest signing identity (agent_id) the chain root MUST be bound to.
+AGENT_ID = "spiffe://trust.example/agent/kyc/prod"
 
 SCOPE = {
     "tools": ["com.example.read"],
@@ -110,7 +112,7 @@ def _make_chain(kp, principal_id="spiffe://trust.example/agent/root", n_hops=1) 
 
 def test_valid_chain_single_hop():
     kp = generate_ed25519()
-    pid = "spiffe://trust.example/orchestrator"
+    pid = AGENT_ID  # chain root must be bound to the manifest signing identity
     chain = _make_chain(kp, principal_id=pid)
     m = base_manifest(delegation_chain=chain)
     ctx = base_context(delegation_public_keys={pid: kp.public_b64url()})
@@ -122,7 +124,7 @@ def test_valid_chain_single_hop():
 def test_valid_chain_multi_hop():
     root_kp = generate_ed25519()
     sub_kp = generate_ed25519()
-    root_pid = "spiffe://trust.example/root"
+    root_pid = AGENT_ID  # root bound to manifest signing identity
     sub_pid = "spiffe://trust.example/sub"
     narrow_scope = {**SCOPE, "tools": ["com.example.read"]}
 
@@ -150,14 +152,16 @@ def test_valid_chain_multi_hop():
     assert result.result == OverallResult.VALID
 
 
-def test_valid_chain_service_principal_type():
+def test_valid_chain_agent_principal_type():
+    # principal_type must be a schema-valid PrincipalType (human/system/agent);
+    # the manifest schema gate rejects out-of-enum values such as "service".
     kp = generate_ed25519()
-    pid = "spiffe://trust.example/svc/gateway"
+    pid = AGENT_ID  # root bound to manifest signing identity
     sig = DelegationHopSigner(kp).sign_hop(
-        hop=0, principal_id=pid, principal_type="service",
+        hop=0, principal_id=pid, principal_type="agent",
         delegated_at=NOW, scope_grant=SCOPE, manifest_id=MID,
     )
-    chain = [{"hop": 0, "principal_id": pid, "principal_type": "service",
+    chain = [{"hop": 0, "principal_id": pid, "principal_type": "agent",
                "delegated_at": NOW, "scope_grant": SCOPE, "delegation_signature": sig}]
     m = base_manifest(delegation_chain=chain)
     ctx = base_context(delegation_public_keys={pid: kp.public_b64url()})
@@ -168,6 +172,34 @@ def test_valid_chain_service_principal_type():
 # ---------------------------------------------------------------------------
 # UNVERIFIABLE - chain present but no keys supplied
 # ---------------------------------------------------------------------------
+
+
+def test_chain_root_not_bound_to_issuer_is_mismatch():
+    """Fix #1: a verifiable chain whose root != manifest signing identity fails."""
+    kp = generate_ed25519()
+    rogue_pid = "spiffe://trust.example/attacker"  # not the manifest agent_id
+    chain = _make_chain(kp, principal_id=rogue_pid)
+    m = base_manifest(delegation_chain=chain)  # agent_id is AGENT_ID, not rogue_pid
+    ctx = base_context(delegation_public_keys={rogue_pid: kp.public_b64url()})
+    result = verify_manifest(m, ctx, store())
+    assert result.fields_verified.delegation_chain == DelegationResult.INVALID
+    assert result.result == OverallResult.MISMATCH
+    assert any(
+        "does not match the manifest" in d.actual_hash
+        for d in result.mismatch_details
+    )
+
+
+def test_chain_root_bound_to_issuer_field_is_valid():
+    """When issuer is set, a chain rooted at the issuer verifies."""
+    kp = generate_ed25519()
+    issuer = "spiffe://trust.example/signing-authority"
+    chain = _make_chain(kp, principal_id=issuer)
+    m = base_manifest(delegation_chain=chain, issuer=issuer)
+    ctx = base_context(delegation_public_keys={issuer: kp.public_b64url()})
+    result = verify_manifest(m, ctx, store())
+    assert result.fields_verified.delegation_chain == DelegationResult.VALID
+    assert result.result == OverallResult.VALID
 
 
 def test_chain_without_keys_is_unverifiable():
@@ -307,7 +339,7 @@ def test_require_delegation_with_no_chain_is_mismatch():
 
 def test_require_delegation_with_valid_chain_is_valid():
     kp = generate_ed25519()
-    pid = "spiffe://trust.example/root"
+    pid = AGENT_ID  # root bound to manifest signing identity
     chain = _make_chain(kp, principal_id=pid)
     m = base_manifest(delegation_chain=chain)
     ctx = base_context(
@@ -368,7 +400,7 @@ def test_empty_principal_id_raises():
 def test_invalid_principal_type_via_verify_manifest():
     """Structural violation in chain must surface as MISMATCH via full verify path."""
     kp = generate_ed25519()
-    pid = "spiffe://trust.example/root"
+    pid = AGENT_ID  # root bound to manifest signing identity
     # Build valid sig but inject invalid principal_type
     sig = DelegationHopSigner(kp).sign_hop(
         hop=0, principal_id=pid, principal_type="agent",
@@ -379,5 +411,7 @@ def test_invalid_principal_type_via_verify_manifest():
     m = base_manifest(delegation_chain=chain)
     ctx = base_context(delegation_public_keys={pid: kp.public_b64url()})
     result = verify_manifest(m, ctx, store())
-    assert result.fields_verified.delegation_chain == DelegationResult.INVALID
+    # An out-of-enum principal_type is now caught fail-closed by the manifest
+    # schema gate, which runs before delegation processing.
     assert result.result == OverallResult.MISMATCH
+    assert any(d.field.startswith("schema") for d in result.mismatch_details)


### PR DESCRIPTION
## Summary

Security hardening for the verification and delegation paths. All four changes fail closed.

1. **Bind the delegation chain root to the manifest signing identity.** `verify_delegation_chain` takes an optional `manifest_issuer`; `verify_manifest` passes the manifest's `issuer` (falling back to `agent_id`). The root hop's `principal_id` or `principal_manifest_id` must equal it, so a verifiable chain cannot be grafted onto an unrelated manifest.

2. **Extend scope-narrowing enforcement.** Beyond `tools` and `data_classifications`, a child hop must keep every parent `constraint` (superset), and its `ttl_seconds` and `max_delegation_depth` may not exceed the parent's. Any violation fails the chain.

3. **Schema-validate on the verify path.** `verify_manifest` runs the raw manifest dict through the Pydantic `Manifest` schema before trusting any field, so `extra="forbid"` (unknown fields), enum/type constraints, the expiry window, and timestamp parsing apply. A malformed `expires_at` is now a fail-closed schema error, not a silently non-expiring manifest. Only missing-required-field errors are tolerated (the engine already degrades absent bindings to `NOT_BOUND`); every other violation fails closed.

4. **Honest CLI artifact-binding status.** When a manifest binds artifacts but no runtime hashes are checked, the engine records a warning and the CLI prints `VALID (signature only - artifact bindings NOT verified)` with a prominent warning, instead of a bare `VALID`.

## Tests

- Root principal != manifest issuer is rejected (unit + via `verify_manifest`).
- Child hop dropping a parent constraint / raising `ttl_seconds` / raising `max_delegation_depth` is rejected; adding a constraint is allowed.
- Manifests with an unknown field (top-level and nested), a malformed `expires_at`, or a bad enum fail verify with a `schema:*` mismatch.
- CLI output for a bound-but-unchecked manifest shows the signature-only qualifier and warning.

`pytest -q`: 533 passed, 24 skipped. `ruff check src/ tests/ --select E,F,W --ignore E501`: clean.

## Out of scope (tracked for Wave 2)

The `kid`->issuer authorization model and the hybrid per-component `key_id` selection both need an issuer<->key authorization design and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)