### PR TITLE
fix(delegation): reconcile principal-type set with PrincipalType enum

### DIFF
--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -28,8 +28,25 @@ from ._signing import Ed25519Verifier, Ed25519KeyPair
 # verifying parties MUST apply a default value of 3.
 DEFAULT_MAX_DELEGATION_DEPTH = 3
 
-# A2A spec §4.2: allowed principal_type values.
-VALID_PRINCIPAL_TYPES = frozenset({"human", "agent", "service"})
+# A2A spec §4.2 / agent-manifest spec §3.4: allowed principal_type values.
+# The Pydantic ``PrincipalType`` enum in ``models`` is the single source of
+# truth (it is what the JSON schema gate enforces). We derive the validator's
+# set from that enum rather than duplicating a literal so the two can never
+# drift. The import is deferred because ``models`` imports this module at load
+# time; importing it at module top level here would create a cycle.
+def _valid_principal_types() -> frozenset[str]:
+    """Allowed ``principal_type`` values, derived from ``PrincipalType``."""
+    from .models import PrincipalType
+
+    return frozenset(member.value for member in PrincipalType)
+
+
+def __getattr__(name: str) -> Any:
+    # Expose ``VALID_PRINCIPAL_TYPES`` as a lazily-derived module attribute so
+    # it stays in lockstep with the ``PrincipalType`` enum.
+    if name == "VALID_PRINCIPAL_TYPES":
+        return _valid_principal_types()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # Required fields per delegation hop (A2A spec §4.2 / agent-manifest spec §3.4).
 _REQUIRED_HOP_FIELDS = frozenset({
@@ -111,10 +128,11 @@ def _validate_hop_structure(hop: dict[str, Any], hop_index: int) -> None:
             f"Delegation hop {hop_index} missing required fields: {sorted(missing)}"
         )
     principal_type = hop["principal_type"]
-    if principal_type not in VALID_PRINCIPAL_TYPES:
+    valid_principal_types = _valid_principal_types()
+    if principal_type not in valid_principal_types:
         raise ValueError(
             f"Delegation hop {hop_index} has invalid principal_type {principal_type!r}; "
-            f"must be one of {sorted(VALID_PRINCIPAL_TYPES)}"
+            f"must be one of {sorted(valid_principal_types)}"
         )
     # principal_id must be non-empty string (SPIFFE URI, DID, or mailto)
     principal_id = hop["principal_id"]

--- a/python/tests/test_verify_delegation.py
+++ b/python/tests/test_verify_delegation.py
@@ -415,3 +415,25 @@ def test_invalid_principal_type_via_verify_manifest():
     # schema gate, which runs before delegation processing.
     assert result.result == OverallResult.MISMATCH
     assert any(d.field.startswith("schema") for d in result.mismatch_details)
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: delegation validator set must equal the PrincipalType enum
+# ---------------------------------------------------------------------------
+
+
+def test_valid_principal_types_match_principal_type_enum():
+    """The delegation validator's allowed set must equal the canonical enum.
+
+    ``PrincipalType`` (the JSON-schema-backed Pydantic enum) is the single
+    source of truth. ``VALID_PRINCIPAL_TYPES`` is derived from it, so the two
+    can never disagree; this test fails loudly if that derivation ever breaks.
+    """
+    from agent_manifest._delegation import VALID_PRINCIPAL_TYPES
+    from agent_manifest.models import PrincipalType
+
+    enum_values = {member.value for member in PrincipalType}
+    assert set(VALID_PRINCIPAL_TYPES) == enum_values
+    # Guard against regressing to the old, inconsistent literal set.
+    assert "service" not in VALID_PRINCIPAL_TYPES
+    assert {"human", "system", "agent"} == enum_values


### PR DESCRIPTION
## Problem

`_delegation.VALID_PRINCIPAL_TYPES` was a hand-written literal `{human, agent, service}` while the Pydantic `PrincipalType` enum is `{human, system, agent}`. They disagreed on `service` (validator-only) and `system` (enum-only). The schema gate merged in #211 surfaced the inconsistency: an out-of-enum `principal_type` now fails closed at the schema layer, so the validator's stray `service` could never actually pass end-to-end, and its missing `system` diverged from what the schema accepts.

## Authoritative source: `PrincipalType` enum (`human` / `system` / `agent`)

Verified against actual usage before deciding:

- It backs the JSON schema the verifier enforces (the schema gate from #211).
- The spec agrees: `spec/agent-manifest-spec-v0.1.md` declares `"principal_type": "human | system | agent -- REQUIRED"`.
- Every example, fixture, doc, and test uses `human`, `system`, or `agent`. `docs/compliance/hipaa.md` uses `"system"`. **No** manifest/example/test anywhere uses `service`.
- The existing #211 test comment already documents that the schema gate rejects out-of-enum values "such as `service`".

So `service` was dead/incorrect and `system` was the genuinely valid value missing from the validator. No evidence supports adding `service`/`system` to the enum.

## Change

- `VALID_PRINCIPAL_TYPES` is now **derived** from `PrincipalType` rather than duplicated, so the two can never drift again. Because `models` imports `_delegation` at load time, the enum import is deferred inside a helper (`_valid_principal_types()`) and the module-level `VALID_PRINCIPAL_TYPES` name is exposed lazily via module `__getattr__`.
- `_validate_hop_structure` uses the derived set.
- Added `test_valid_principal_types_match_principal_type_enum` asserting the delegation set equals the enum (and that `service` is gone), so future drift fails loudly.

No existing test/fixture used `service`, so nothing needed updating beyond the new guard test.

## Validation

- `pytest -q`: 534 passed, 24 skipped
- `ruff check src/ tests/ --select E,F,W --ignore E501`: clean
- `mypy src/`: clean (no issues, 16 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
