### PR TITLE
chore(release): agent-manifest 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 All notable changes to Agent Manifest are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Spec changes are marked **[SPEC]**; SDK changes are marked **[SDK]**.
 
-## [Unreleased]
+## [0.2.0] — 2026-06-30
+
+### Security
+
+**[SDK]** Delegation chain root is now bound to the manifest issuer/agent identity — forged-authority chains are rejected.
+**[SDK]** Scope-narrowing enforces constraint-superset, non-increasing `ttl_seconds`, and non-increasing `max_delegation_depth`.
+**[SDK]** Verification schema-validates the manifest (fail-closed); CLI `verify` no longer prints bare `VALID` when artifact bindings were not checked.
+
+### Changed
+
+**[SPEC]** SNP/TDX attestation field corrections and provider experimental markers (`REPORT_DATA` at `0x50`); threat-model/levels documentation scoped to what TEE attestation provides.
+
+### Fixed
+
+**[SDK]** `PrincipalType` set reconciled (no `service`).
 
 ### Added
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.1.1"
+version = "0.2.0"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release agent-manifest 0.2.0. Bumps `python/pyproject.toml` version `0.1.1` -> `0.2.0` and records the 0.2.0 changelog section.

## 0.2.0

- **Security:** delegation chain root is now bound to the manifest issuer/agent identity (forged-authority chains rejected).
- **Security:** scope-narrowing enforces constraint-superset, non-increasing `ttl_seconds`, and non-increasing `max_delegation_depth`.
- **Security:** verification schema-validates the manifest (fail-closed); CLI `verify` no longer prints bare `VALID` when artifact bindings were not checked.
- SNP/TDX attestation field corrections and provider experimental markers (REPORT_DATA at 0x50); threat-model/levels documentation scoped to what TEE attestation provides.
- **Fixed:** PrincipalType set reconciled (no `service`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
