### PR TITLE
fix(ci): resolve agt CLI in release governance step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install package and AGT for governance attestation
         working-directory: python
-        run: pip install -e "." agent-governance-toolkit-core pyyaml
+        run: pip install -e "." "agent-governance-toolkit>=4.1" "agent-governance-toolkit-core>=4.1" pyyaml
 
       - name: Generate evidence file
         run: python scripts/gen_agt_evidence.py


### PR DESCRIPTION
The governance step in publish.yml installed only `agent-governance-toolkit-core`, so `agt` was not on PATH and the post-publish step failed. Adds the meta package + core. Cosmetic post-publish fix; did not affect the 0.2.0 PyPI upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)