### PR TITLE
feat(sdk): expose the delegation verifier in the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Agent Manifest are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Spec changes are marked **[SPEC]**; SDK changes are marked **[SDK]**.
 
+## [Unreleased]
+
+### Added
+
+**[SDK]** Delegation verification is now part of the public API: `verify_delegation_chain`, `verify_hitl_approval`, `delegation_depth_exceeded`, `DelegationHopSigner`, and `HitlApprovalSigner` are exported from `agent_manifest`. Downstream projects (for example agentrust-io/cA2A) call `verify_delegation_chain` to verify an inbound peer's delegation chain, so the two implementations stay aligned rather than duplicated. No behavior change; these were previously reachable only through the private `_delegation` module.
+
 ## [0.2.0] — 2026-06-30
 
 ### Security

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -33,6 +33,13 @@ from ._verify import (
     FieldsVerified, MismatchDetail, EvidencePack,
     RevocationStore, RevocationRecord,
 )
+from ._delegation import (
+    verify_delegation_chain,
+    verify_hitl_approval,
+    delegation_depth_exceeded,
+    DelegationHopSigner,
+    HitlApprovalSigner,
+)
 
 __all__ = [
     "Manifest", "ArtifactBindings",
@@ -61,4 +68,6 @@ __all__ = [
     "OverallResult", "FieldResult", "DelegationResult", "HitlResult",
     "FieldsVerified", "MismatchDetail", "EvidencePack",
     "RevocationStore", "RevocationRecord",
+    "verify_delegation_chain", "verify_hitl_approval", "delegation_depth_exceeded",
+    "DelegationHopSigner", "HitlApprovalSigner",
 ]

--- a/python/tests/test_delegation_public_api.py
+++ b/python/tests/test_delegation_public_api.py
@@ -1,0 +1,45 @@
+"""The delegation verifier is part of the public API.
+
+Downstream projects (for example agentrust-io/cA2A) call this to verify an
+inbound peer's delegation chain, so it must be importable from the top-level
+package and stable, not reached through the private `_delegation` module.
+"""
+
+from __future__ import annotations
+
+import agent_manifest
+from agent_manifest import (
+    DelegationHopSigner,
+    HitlApprovalSigner,
+    delegation_depth_exceeded,
+    verify_delegation_chain,
+    verify_hitl_approval,
+)
+
+
+def test_delegation_symbols_are_public() -> None:
+    for name in (
+        "verify_delegation_chain",
+        "verify_hitl_approval",
+        "delegation_depth_exceeded",
+        "DelegationHopSigner",
+        "HitlApprovalSigner",
+    ):
+        assert name in agent_manifest.__all__
+        assert hasattr(agent_manifest, name)
+
+
+def test_verify_delegation_chain_callable_on_empty_chain() -> None:
+    # An empty chain is a valid no-op (nothing delegated); it must not raise.
+    verify_delegation_chain([], {}, manifest_id="m-1")
+
+
+def test_delegation_depth_exceeded_logic() -> None:
+    assert delegation_depth_exceeded(chain_length=5, root_max_depth=3) is True
+    assert delegation_depth_exceeded(chain_length=2, root_max_depth=3) is False
+
+
+def test_signer_classes_importable() -> None:
+    assert callable(DelegationHopSigner)
+    assert callable(HitlApprovalSigner)
+    assert callable(verify_hitl_approval)


### PR DESCRIPTION
## What

Exports the delegation verification API from `agent_manifest`, previously reachable only via the private `_delegation` module:

- `verify_delegation_chain`
- `verify_hitl_approval`
- `delegation_depth_exceeded`
- `DelegationHopSigner`, `HitlApprovalSigner`

## Why

agentrust-io/cA2A calls `verify_delegation_chain` to verify an inbound peer's delegation chain. Promoting it to the public API means the two projects share one supported, tested implementation of the attenuation/verification semantics rather than duplicating them.

No behavior change; only the public surface. Adds a test asserting the symbols are in `__all__` and importable. Full suite: **538 passed, 24 skipped.**

Closes agentrust-io/ca2a#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)