### PR TITLE
chore: add MIT LICENSE and pin PyPI publish action to SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
Closes two agentrust-io hardening gaps for agent-manifest:
- Adds a MIT `LICENSE` (repo previously reported NOASSERTION).
- Pins `pypa/gh-action-pypi-publish` from the mutable `@release/v1` tag to commit SHA `cef2210` (v1.14.0), matching cmcp.

Ref: internal security hardening bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)