### PR TITLE
fix(verify): bind trusted keys to manifest issuers

### DIFF
--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -133,6 +133,10 @@ class VerifyRequest(BaseModel):
     the base64url-encoded public key. Signature verification is fail-closed:
     without trusted keys, a signed manifest yields ``UNVERIFIABLE`` and an
     unsigned manifest yields ``SIGNATURE_MISSING`` - never ``VALID``.
+
+    ``trusted_key_issuers`` maps each trusted key_id to the issuer SPIFFE URIs
+    authorized to sign manifests with that key. When supplied, key-to-issuer
+    authorization is fail-closed.
     """
 
     manifest_id: str
@@ -140,6 +144,8 @@ class VerifyRequest(BaseModel):
     enforce_attestation: bool = False
     # key_id (sha256 hex of pub key bytes) -> base64url-encoded public key bytes
     trusted_keys: dict[str, str] = Field(default_factory=dict)
+    # key_id -> issuer SPIFFE URIs authorized to use that signing key
+    trusted_key_issuers: dict[str, list[str]] = Field(default_factory=dict)
     # principal_id -> base64url-encoded public key bytes (for delegation chain)
     delegation_public_keys: dict[str, str] = Field(default_factory=dict)
     # When True, a manifest without a delegation_chain is a verification failure
@@ -167,6 +173,8 @@ class VerificationContext(BaseModel):
     min_slsa_level: int = 0
     # key_id (sha256 hex of pub key bytes) -> base64url-encoded public key bytes
     trusted_keys: dict[str, str] = Field(default_factory=dict)
+    # key_id -> issuer SPIFFE URIs authorized to use that signing key
+    trusted_key_issuers: dict[str, list[str]] = Field(default_factory=dict)
     # principal_id -> base64url-encoded public key bytes (for delegation chain)
     delegation_public_keys: dict[str, str] = Field(default_factory=dict)
     # When True, bound artifacts without runtime hashes cause INCOMPLETE result
@@ -181,6 +189,41 @@ class VerificationContext(BaseModel):
 
 # Manifest spec versions this verifier implementation can process (spec 2.4).
 SUPPORTED_MANIFEST_VERSIONS: frozenset[str] = frozenset({"0.1"})
+
+
+def _signature_key_issuer_mismatch(
+    manifest: dict[str, Any],
+    key_id: str,
+    trusted_key_issuers: dict[str, list[str]],
+) -> Optional[MismatchDetail]:
+    """Return a mismatch when a trusted key is not authorized for the issuer."""
+    if not trusted_key_issuers:
+        return None
+
+    issuer = manifest.get("issuer")
+    if not isinstance(issuer, str) or not issuer:
+        return MismatchDetail(
+            field="signature.issuer",
+            expected_hash="<manifest issuer authorized for signature key>",
+            actual_hash="<missing manifest issuer>",
+        )
+
+    allowed_issuers = trusted_key_issuers.get(key_id)
+    if not allowed_issuers:
+        return MismatchDetail(
+            field="signature.issuer",
+            expected_hash=f"<key_id={key_id} authorized for issuer={issuer!r}>",
+            actual_hash="<key_id has no issuer authorization>",
+        )
+
+    if issuer not in allowed_issuers:
+        return MismatchDetail(
+            field="signature.issuer",
+            expected_hash=f"<issuer in trusted_key_issuers[{key_id!r}]>",
+            actual_hash=f"<issuer={issuer!r}>",
+        )
+
+    return None
 
 
 def _strict_schema_violations(manifest: dict[str, Any]) -> list[tuple[str, str]]:
@@ -312,49 +355,57 @@ def verify_manifest(
                 actual_hash="<key_id not found in trusted_keys>",
             ))
         else:
-            from ._signing import (
-                Ed25519Verifier,
-                MlDsa65Verifier,
-                HybridVerifier,
-                _b64url_decode,
+            issuer_mismatch = _signature_key_issuer_mismatch(
+                manifest,
+                key_id,
+                context.trusted_key_issuers,
             )
-            try:
-                pub_bytes = _b64url_decode(pub_b64)
-                if algorithm == "Ed25519":
-                    Ed25519Verifier(pub_bytes).verify(manifest, sig_block.get("signature_value", ""))
-                    result.signature_verified = True
-                elif algorithm == "ML-DSA-65":
-                    MlDsa65Verifier(pub_bytes).verify(manifest, sig_block.get("signature_value", ""))
-                    result.signature_verified = True
-                elif algorithm == "hybrid-Ed25519-ML-DSA-65":
-                    # Hybrid needs both key components - key_id covers combined hash;
-                    # callers must pass both keys in trusted_keys under their individual key_ids.
-                    ed_key_id = sig_block.get("ed25519_key_id", key_id)
-                    pq_key_id = sig_block.get("ml_dsa65_key_id", key_id)
-                    ed_pub_b64 = context.trusted_keys.get(ed_key_id, pub_b64)
-                    pq_pub_b64 = context.trusted_keys.get(pq_key_id, pub_b64)
-                    ed_bytes = _b64url_decode(ed_pub_b64)
-                    pq_bytes = _b64url_decode(pq_pub_b64)
-                    HybridVerifier(ed_bytes, pq_bytes).verify(manifest, sig_block)
-                    result.signature_verified = True
-                else:
+            if issuer_mismatch is not None:
+                mismatches.append(issuer_mismatch)
+            else:
+                from ._signing import (
+                    Ed25519Verifier,
+                    MlDsa65Verifier,
+                    HybridVerifier,
+                    _b64url_decode,
+                )
+                try:
+                    pub_bytes = _b64url_decode(pub_b64)
+                    if algorithm == "Ed25519":
+                        Ed25519Verifier(pub_bytes).verify(manifest, sig_block.get("signature_value", ""))
+                        result.signature_verified = True
+                    elif algorithm == "ML-DSA-65":
+                        MlDsa65Verifier(pub_bytes).verify(manifest, sig_block.get("signature_value", ""))
+                        result.signature_verified = True
+                    elif algorithm == "hybrid-Ed25519-ML-DSA-65":
+                        # Hybrid needs both key components - key_id covers combined hash;
+                        # callers must pass both keys in trusted_keys under their individual key_ids.
+                        ed_key_id = sig_block.get("ed25519_key_id", key_id)
+                        pq_key_id = sig_block.get("ml_dsa65_key_id", key_id)
+                        ed_pub_b64 = context.trusted_keys.get(ed_key_id, pub_b64)
+                        pq_pub_b64 = context.trusted_keys.get(pq_key_id, pub_b64)
+                        ed_bytes = _b64url_decode(ed_pub_b64)
+                        pq_bytes = _b64url_decode(pq_pub_b64)
+                        HybridVerifier(ed_bytes, pq_bytes).verify(manifest, sig_block)
+                        result.signature_verified = True
+                    else:
+                        mismatches.append(MismatchDetail(
+                            field="signature",
+                            expected_hash="<known algorithm: Ed25519|ML-DSA-65|hybrid-Ed25519-ML-DSA-65>",
+                            actual_hash=f"<unknown algorithm: {algorithm!r}>",
+                        ))
+                except InvalidSignature:
                     mismatches.append(MismatchDetail(
                         field="signature",
-                        expected_hash="<known algorithm: Ed25519|ML-DSA-65|hybrid-Ed25519-ML-DSA-65>",
-                        actual_hash=f"<unknown algorithm: {algorithm!r}>",
+                        expected_hash="<valid signature>",
+                        actual_hash="<invalid signature>",
                     ))
-            except InvalidSignature:
-                mismatches.append(MismatchDetail(
-                    field="signature",
-                    expected_hash="<valid signature>",
-                    actual_hash="<invalid signature>",
-                ))
-            except ValueError as e:
-                mismatches.append(MismatchDetail(
-                    field="signature",
-                    expected_hash="<valid signature>",
-                    actual_hash=f"<malformed: {e}>",
-                ))
+                except ValueError as e:
+                    mismatches.append(MismatchDetail(
+                        field="signature",
+                        expected_hash="<valid signature>",
+                        actual_hash=f"<malformed: {e}>",
+                    ))
 
     # --- Artifact hash verification
     artifacts = manifest.get("artifacts") or {}
@@ -756,16 +807,18 @@ def create_router(
         """Verify a manifest with caller-supplied trusted keys.
 
         The request body carries ``trusted_keys`` (key_id -> base64url public
-        key) used for manifest signature verification, and optionally
-        ``delegation_public_keys`` (principal_id -> base64url public key) for
-        delegation chain verification. Verification is fail-closed - see
-        :func:`verify_manifest`.
+        key) used for manifest signature verification, optionally
+        ``trusted_key_issuers`` (key_id -> issuer SPIFFE URIs) for key issuer
+        authorization, and optionally ``delegation_public_keys`` (principal_id
+        -> base64url public key) for delegation chain verification.
+        Verification is fail-closed - see :func:`verify_manifest`.
         """
         manifest = _lookup_manifest(request.manifest_id)
         ctx = VerificationContext(
             enforce_hitl=request.enforce_hitl,
             enforce_attestation=request.enforce_attestation,
             trusted_keys=request.trusted_keys,
+            trusted_key_issuers=request.trusted_key_issuers,
             delegation_public_keys=request.delegation_public_keys,
             require_delegation=request.require_delegation,
         )

--- a/python/tests/test_am_verify.py
+++ b/python/tests/test_am_verify.py
@@ -33,6 +33,8 @@ MID   = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
 # trusted key in the verification context.
 KP = generate_ed25519()
 TRUSTED_KEYS = {KP.key_id: KP.public_b64url()}
+ISSUER_A = "spiffe://trust.example/issuer/a"
+ISSUER_B = "spiffe://trust.example/issuer/b"
 
 
 def sign(m):
@@ -367,6 +369,31 @@ def test_http_post_verify_with_trusted_keys_is_valid():
     assert r.status_code == 200
     assert r.json()["result"] == "VALID"
     assert r.json()["signature_verified"] is True
+
+
+@require_fastapi
+def test_http_post_verify_enforces_trusted_key_issuers():
+    other = generate_ed25519()
+    trusted_keys = dict(TRUSTED_KEYS)
+    trusted_keys[other.key_id] = other.public_b64url()
+    client, _ = _client({MID: manifest(issuer=ISSUER_B)})
+
+    r = client.post("/verify", json={
+        "manifest_id": MID,
+        "trusted_keys": trusted_keys,
+        "trusted_key_issuers": {
+            KP.key_id: [ISSUER_A],
+            other.key_id: [ISSUER_B],
+        },
+    })
+
+    assert r.status_code == 200
+    assert r.json()["result"] == "MISMATCH"
+    assert r.json()["signature_verified"] is False
+    assert any(
+        detail["field"] == "signature.issuer"
+        for detail in r.json()["mismatch_details"]
+    )
 
 
 @require_fastapi

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -22,12 +22,19 @@ SHA = "sha256:" + "a" * 64
 # require a signed manifest and the matching trusted key in the context.
 KP = generate_ed25519()
 TRUSTED_KEYS = {KP.key_id: KP.public_b64url()}
+ISSUER_A = "spiffe://trust.example/issuer/a"
+ISSUER_B = "spiffe://trust.example/issuer/b"
+
+
+def sign_with(m, kp):
+    """(Re-)sign a manifest dict with the supplied key in place and return it."""
+    m["signature"] = Ed25519Signer(kp).sign(m)
+    return m
 
 
 def sign(m):
     """(Re-)sign a manifest dict in place and return it."""
-    m["signature"] = Ed25519Signer(KP).sign(m)
-    return m
+    return sign_with(m, KP)
 
 
 def base_manifest(**overrides):
@@ -319,6 +326,53 @@ def test_valid_result_implies_signature_verified():
     result = verify_manifest(base_manifest(), base_context(), store())
     assert result.result == OverallResult.VALID
     assert result.signature_verified is True
+
+
+def test_trusted_key_authorized_for_manifest_issuer_is_valid():
+    ctx = base_context(trusted_key_issuers={KP.key_id: [ISSUER_A]})
+    result = verify_manifest(base_manifest(issuer=ISSUER_A), ctx, store())
+    assert result.result == OverallResult.VALID
+    assert result.signature_verified is True
+
+
+def test_trusted_key_not_authorized_for_claimed_issuer_is_mismatch():
+    other = generate_ed25519()
+    trusted_keys = dict(TRUSTED_KEYS)
+    trusted_keys[other.key_id] = other.public_b64url()
+    ctx = base_context(
+        trusted_keys=trusted_keys,
+        trusted_key_issuers={
+            KP.key_id: [ISSUER_A],
+            other.key_id: [ISSUER_B],
+        },
+    )
+
+    result = verify_manifest(base_manifest(issuer=ISSUER_B), ctx, store())
+
+    assert result.result == OverallResult.MISMATCH
+    assert result.signature_verified is False
+    assert any(d.field == "signature.issuer" for d in result.mismatch_details)
+
+
+def test_trusted_key_without_issuer_authorization_is_mismatch():
+    other = generate_ed25519()
+    ctx = base_context(trusted_key_issuers={other.key_id: [ISSUER_A]})
+
+    result = verify_manifest(base_manifest(issuer=ISSUER_A), ctx, store())
+
+    assert result.result == OverallResult.MISMATCH
+    assert result.signature_verified is False
+    assert any(d.field == "signature.issuer" for d in result.mismatch_details)
+
+
+def test_trusted_key_issuer_authorization_requires_manifest_issuer():
+    ctx = base_context(trusted_key_issuers={KP.key_id: [ISSUER_A]})
+
+    result = verify_manifest(base_manifest(), ctx, store())
+
+    assert result.result == OverallResult.MISMATCH
+    assert result.signature_verified is False
+    assert any(d.field == "signature.issuer" for d in result.mismatch_details)
 
 
 def test_tampered_manifest_signature_is_mismatch():


### PR DESCRIPTION
## Summary
- add `trusted_key_issuers` to verifier contexts as a key_id -> issuer authorization map
- fail closed when the resolved signing key is not authorized for `manifest.issuer`
- thread the authorization map through `POST /verify` and cover cross-issuer regression cases

## Why
`verify_manifest` previously checked that `signature.key_id` existed in `trusted_keys`, but not that the trusted key was authorized for the issuer claimed by the manifest. In multi-issuer trust maps, that allowed a key trusted for issuer A to sign a manifest claiming issuer B.

Closes #215.

## Validation
- `python -m pytest tests/test_verify.py tests/test_am_verify.py -q`
- `python -m pytest -q`
- `pytest -v --tb=short --cov=agent_manifest --cov-report=term-missing --cov-fail-under=80`
- `ruff check src/ tests/ --select E,F,W --ignore E501`
- `mypy src/agent_manifest`
- `bandit -r src/agent_manifest -c pyproject.toml`
- `pip-audit`
