### PR TITLE
fix(verify): bind hybrid signatures to combined key id

### DIFF
--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -189,6 +189,30 @@ class VerificationContext(BaseModel):
 
 # Manifest spec versions this verifier implementation can process (spec 2.4).
 SUPPORTED_MANIFEST_VERSIONS: frozenset[str] = frozenset({"0.1"})
+_HYBRID_ED25519_PUBLIC_KEY_BYTES = 32
+
+
+def _split_hybrid_public_key(
+    key_id: str,
+    public_key_bytes: bytes,
+) -> tuple[bytes, bytes]:
+    """Split and authenticate a combined Ed25519 || ML-DSA-65 public key."""
+    if len(public_key_bytes) <= _HYBRID_ED25519_PUBLIC_KEY_BYTES:
+        raise ValueError(
+            "Hybrid public key must be Ed25519 public key bytes followed by "
+            "ML-DSA-65 public key bytes"
+        )
+
+    actual_key_id = hashlib.sha256(public_key_bytes).hexdigest()
+    if not hmac.compare_digest(actual_key_id, key_id):
+        raise ValueError(
+            "Hybrid public key bytes do not match signature.key_id"
+        )
+
+    return (
+        public_key_bytes[:_HYBRID_ED25519_PUBLIC_KEY_BYTES],
+        public_key_bytes[_HYBRID_ED25519_PUBLIC_KEY_BYTES:],
+    )
 
 
 def _signature_key_issuer_mismatch(
@@ -378,14 +402,11 @@ def verify_manifest(
                         MlDsa65Verifier(pub_bytes).verify(manifest, sig_block.get("signature_value", ""))
                         result.signature_verified = True
                     elif algorithm == "hybrid-Ed25519-ML-DSA-65":
-                        # Hybrid needs both key components - key_id covers combined hash;
-                        # callers must pass both keys in trusted_keys under their individual key_ids.
-                        ed_key_id = sig_block.get("ed25519_key_id", key_id)
-                        pq_key_id = sig_block.get("ml_dsa65_key_id", key_id)
-                        ed_pub_b64 = context.trusted_keys.get(ed_key_id, pub_b64)
-                        pq_pub_b64 = context.trusted_keys.get(pq_key_id, pub_b64)
-                        ed_bytes = _b64url_decode(ed_pub_b64)
-                        pq_bytes = _b64url_decode(pq_pub_b64)
+                        # Hybrid key_id covers the registered combined public key:
+                        # sha256(Ed25519 public bytes || ML-DSA-65 public bytes).
+                        # Component key ids from the unsigned signature block are
+                        # intentionally ignored.
+                        ed_bytes, pq_bytes = _split_hybrid_public_key(key_id, pub_bytes)
                         HybridVerifier(ed_bytes, pq_bytes).verify(manifest, sig_block)
                         result.signature_verified = True
                     else:

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -1,7 +1,9 @@
 """Tests for the verification engine - issue #10."""
+import hashlib
 from datetime import datetime, timedelta, timezone
 
-from agent_manifest._signing import Ed25519Signer, generate_ed25519
+from agent_manifest import _signing
+from agent_manifest._signing import Ed25519Signer, _b64url_encode, generate_ed25519
 from agent_manifest._verify import (
     DelegationResult,
     FieldResult,
@@ -389,6 +391,63 @@ def test_unknown_key_id_is_mismatch():
     result = verify_manifest(base_manifest(), ctx, store())
     assert result.result == OverallResult.MISMATCH
     assert result.signature_verified is False
+
+
+def _hybrid_manifest(key_id: str):
+    m = base_manifest()
+    m["signature"] = {
+        "algorithm": "hybrid-Ed25519-ML-DSA-65",
+        "key_id": key_id,
+        "key_type": "software",
+        "signed_at": NOW.isoformat().replace("+00:00", "Z"),
+        "classical_signature": "AA",
+        "pq_signature": "AA",
+        "signature_value": "",
+    }
+    return m
+
+
+def test_hybrid_signature_uses_combined_trusted_key(monkeypatch):
+    ed_pub = b"e" * 32
+    pq_pub = b"p" * 1952
+    combined_pub = ed_pub + pq_pub
+    key_id = hashlib.sha256(combined_pub).hexdigest()
+    seen = {}
+
+    class FakeHybridVerifier:
+        def __init__(self, ed25519_public_bytes, ml_dsa65_public_bytes):
+            seen["ed"] = ed25519_public_bytes
+            seen["pq"] = ml_dsa65_public_bytes
+
+        def verify(self, manifest_dict, signature_block):
+            seen["verified"] = True
+
+    monkeypatch.setattr(_signing, "HybridVerifier", FakeHybridVerifier)
+    ctx = base_context(trusted_keys={key_id: _b64url_encode(combined_pub)})
+
+    result = verify_manifest(_hybrid_manifest(key_id), ctx, store())
+
+    assert result.result == OverallResult.VALID
+    assert result.signature_verified is True
+    assert seen == {"ed": ed_pub, "pq": pq_pub, "verified": True}
+
+
+def test_hybrid_trusted_key_must_match_combined_key_id():
+    ed_pub = b"e" * 32
+    pq_pub = b"p" * 1952
+    key_id = hashlib.sha256(ed_pub + pq_pub).hexdigest()
+    wrong_combined_pub = ed_pub + (b"q" * 1952)
+    ctx = base_context(trusted_keys={key_id: _b64url_encode(wrong_combined_pub)})
+
+    result = verify_manifest(_hybrid_manifest(key_id), ctx, store())
+
+    assert result.result == OverallResult.MISMATCH
+    assert result.signature_verified is False
+    assert any(
+        d.field == "signature"
+        and "Hybrid public key bytes do not match signature.key_id" in d.actual_hash
+        for d in result.mismatch_details
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- derive hybrid verifier component keys from the trusted combined public key registered under `signature.key_id`
- verify `sha256(ed25519_pub || ml_dsa65_pub) == signature.key_id` before checking hybrid signatures
- remove trust in unsigned per-component key ids and add no-`pyoqs` regression coverage for the key-selection path

## Why
Hybrid verification previously allowed the signature block to steer component key lookup via `ed25519_key_id` / `ml_dsa65_key_id`. Those fields are not the trust anchor. The verifier should bind both components to the registered combined key id and reject any trusted key material that does not hash back to that id.

Closes #216.

## Validation
- `PYTHONPATH=src python3 -m pytest tests/test_verify.py -q`
- `python -m pytest -q`
- `pytest -v --tb=short --cov=agent_manifest --cov-report=term-missing --cov-fail-under=80`
- `ruff check src/ tests/ --select E,F,W --ignore E501`
- `mypy src/agent_manifest`
- `bandit -r src/agent_manifest -c pyproject.toml`
- `pip-audit`
