### PR TITLE
chore(release): agent-manifest python v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-07-15
+
+### Security
+
+**[SDK]** Verification can now bind trusted signing keys to authorized issuers. `VerificationContext.trusted_key_issuers` maps each trusted `key_id` to the issuer SPIFFE URIs allowed to sign with it; when supplied, a manifest whose signing key is not authorized for its declared `issuer` is rejected (fail-closed). Opt-in and backward compatible: an empty map preserves prior behavior.
+
 ### Added
 
 **[SDK]** Delegation verification is now part of the public API: `verify_delegation_chain`, `verify_hitl_approval`, `delegation_depth_exceeded`, `DelegationHopSigner`, and `HitlApprovalSigner` are exported from `agent_manifest`. Downstream projects (for example agentrust-io/cA2A) call `verify_delegation_chain` to verify an inbound peer's delegation chain, so the two implementations stay aligned rather than duplicated. No behavior change; these were previously reachable only through the private `_delegation` module.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.2.0"
+version = "0.3.0"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts a release of everything on main since the `python-v0.2.0` tag.

## Version: 0.3.0 (minor)
New public API surface (#218) makes this a minor bump, not a patch.

## Changes
- **Security (#220)** — `VerificationContext.trusted_key_issuers` binds each trusted signing `key_id` to the issuer SPIFFE URIs authorized to use it. When supplied, a manifest whose signing key is not authorized for its declared `issuer` is rejected (fail-closed). Opt-in and backward compatible: an empty map preserves prior behavior.
- **Added (#218)** — delegation verification is now public API: `verify_delegation_chain`, `verify_hitl_approval`, `delegation_depth_exceeded`, `DelegationHopSigner`, `HitlApprovalSigner`. No behavior change.

## Validation
- `python -m build` + `twine check` pass for `agent_manifest-0.3.0`.
- 0.3.0 wheel smoke-tested in a clean venv: new exports present; downstream signing (the claude-code integration) still works.

## Release mechanics
Merging this does not publish. Publish fires when the `python-v0.3.0` tag is pushed, which triggers `.github/workflows/publish.yml` (OIDC trusted publishing). Tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)