### PR TITLE
ci: upgrade setuptools before pip-audit (clears PYSEC-2026-3447)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,12 @@ jobs:
       - name: bandit
         working-directory: python
         run: bandit -r src/agent_manifest -c pyproject.toml
-      - name: Upgrade pip before audit
-        run: pip install --upgrade pip
+      - name: Upgrade pip and setuptools before audit
+        # setuptools ships in the runner env; keep it current so a newly
+        # published advisory in the build tooling (e.g. PYSEC-2026-3447,
+        # fixed in 83.0.0) does not fail the audit. hatchling is our build
+        # backend, so this only touches the CI environment, not the package.
+        run: pip install --upgrade pip setuptools
       - name: pip-audit
         working-directory: python
         run: pip-audit


### PR DESCRIPTION
The Security scan (pip-audit) started failing on every build after setuptools advisory PYSEC-2026-3447 (fixed in 83.0.0) was published. It surfaced on the v0.3.0 release merge; #218 and #220 passed the same scan earlier the same day, confirming it is time-of-check, not a code change.

setuptools is only present in the CI runner environment (agent-manifest builds with hatchling), so upgrading pip + setuptools before the audit clears the finding without affecting the package or its dependencies. CI-only.

Generated with Claude Code