### PR TITLE
docs: record bare-metal SEVSNPProvider hardware validation (GCP N2D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ### Changed
 
-**[SDK]** `SEVSNPProvider` now uses the kernel configfs-TSM interface (`/sys/kernel/config/tsm/report`, kernel 6.7+) for bare-metal / non-paravisor SNP guests; the previous `/dev/sev-guest` ioctl path (never hardware-validated, incorrect ABI) has been removed. On Azure use `AzureCVMProvider`.
+**[SDK]** `SEVSNPProvider` now uses the kernel configfs-TSM interface (`/sys/kernel/config/tsm/report`, kernel 6.7+) for bare-metal / non-paravisor SNP guests; the previous `/dev/sev-guest` ioctl path (never hardware-validated, incorrect ABI) has been removed. **Hardware-validated on a non-paravisor SEV-SNP guest (GCP N2D, AMD Milan):** the manifest digest lands in the guest-controlled `REPORT_DATA` and the report verifies against the AMD VCEK chain. On Azure use `AzureCVMProvider`.
 **[SDK]** Attestation providers (`AzureCVMProvider`, `SEVSNPProvider`, `TDXProvider`, `OPAQUEProvider`, `TPMProvider`) and the chain verifier are now exported from `agent_manifest`; CLI `manifest attest` accepts `--provider azure-cvm`.
 
 ## [0.3.0] — 2026-07-15

--- a/python/src/agent_manifest/_hw_providers.py
+++ b/python/src/agent_manifest/_hw_providers.py
@@ -15,10 +15,10 @@ Pick a provider by deployment environment (``select_provider`` in
 * :class:`SEVSNPProvider` — bare-metal / non-paravisor SNP guests that expose
   the report directly through the kernel configfs-TSM interface
   (``/sys/kernel/config/tsm/report``, kernel 6.7+), where the guest DOES control
-  ``REPORT_DATA``. This path is implemented to the configfs-TSM ABI but has not
-  yet been validated on non-Azure SNP hardware; on Azure use
-  :class:`AzureCVMProvider` instead. (The previous ``/dev/sev-guest`` ioctl
-  implementation was incorrect and has been removed — see #204/#205.)
+  ``REPORT_DATA``. Hardware-validated end to end on a non-paravisor SEV-SNP guest
+  (GCP N2D, AMD Milan). On Azure use :class:`AzureCVMProvider` instead. (The
+  previous ``/dev/sev-guest`` ioctl implementation was incorrect and has been
+  removed — see #204/#205.)
 
 * :class:`TDXProvider` — Intel TDX (issue #7). EXPERIMENTAL and not yet
   hardware-validated; TDX Quote verification via Intel QVL/PCS is still pending.
@@ -112,10 +112,12 @@ class SEVSNPProvider(AttestationProvider):
     first 32 bytes carry ``sha256(manifest_pre_image)``, the rest is zero.
 
     Report parsing and signature verification use :mod:`._snp_verify`, which was
-    validated against a real SNP report. This provider's configfs-TSM report
-    *acquisition* path has not yet been validated on non-Azure SNP hardware; on
-    Azure confidential VMs use :class:`AzureCVMProvider` (the guest cannot set
-    ``REPORT_DATA`` there — the paravisor binds the vTPM AK into it).
+    validated against a real SNP report. **Hardware-validated end to end on a
+    non-paravisor SEV-SNP guest (GCP N2D, AMD Milan):** the manifest digest lands
+    in the guest-controlled ``REPORT_DATA`` and the report verifies against the
+    AMD VCEK chain. On Azure confidential VMs use :class:`AzureCVMProvider`
+    instead (the guest cannot set ``REPORT_DATA`` there — the paravisor binds the
+    vTPM AK into it).
 
     Requirements:
       - AMD EPYC (Milan or later) SNP guest, kernel 6.7+ with sev-guest driver


### PR DESCRIPTION
`SEVSNPProvider` (configfs-TSM, for bare-metal / non-paravisor SNP guests) is now **hardware-validated end to end** on a real non-paravisor SEV-SNP guest — GCP N2D, AMD Milan (`dmesg`: `AMD SEV SEV-ES SEV-SNP`; guest controls `REPORT_DATA`).

Validated live: `extend_manifest_hash` → `get_attestation_report` → `verify_manifest_in_report` (True), `REPORT_DATA[:32] == sha256(manifest_pre_image)` (the guest-controlled binding Azure's paravisor can't provide), and `verify_attestation_chain(passed=True, signature=VERIFIED)` against the VCEK fetched from the AMD KDS.

Docs only — lifts the "not yet validated on non-Azure SNP hardware" caveat in the module + provider docstrings and the CHANGELOG. No code change (the provider worked as-is; the parallel cmcp fix, agentrust-io/cmcp#412, needed code because cmcp's bare-metal path used a broken ioctl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)