### PR TITLE
fix(tee): mark OPAQUE managed attestation explicitly not implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 **[SDK]** `SEVSNPProvider` now uses the kernel configfs-TSM interface (`/sys/kernel/config/tsm/report`, kernel 6.7+) for bare-metal / non-paravisor SNP guests; the previous `/dev/sev-guest` ioctl path (never hardware-validated, incorrect ABI) has been removed. **Hardware-validated on a non-paravisor SEV-SNP guest (GCP N2D, AMD Milan):** the manifest digest lands in the guest-controlled `REPORT_DATA` and the report verifies against the AMD VCEK chain. On Azure use `AzureCVMProvider`.
 **[SDK]** Attestation providers (`AzureCVMProvider`, `SEVSNPProvider`, `TDXProvider`, `OPAQUEProvider`, `TPMProvider`) and the chain verifier are now exported from `agent_manifest`; CLI `manifest attest` accepts `--provider azure-cvm`.
+**[SDK]** `OPAQUEProvider` is now explicitly **not implemented** and fails closed at construction. The OPAQUE managed attestation service is not generally available and the SDK never verified the TRACE claim it would return (no claim-signature or `service_measurement` check — issue #201 §5); shipping a path that looked verified but was not is worse than none. Use a locally-verifiable provider (SEV-SNP / TDX / Azure CVM) for Level 1+. The prior unverified HTTP flow has been removed.
 
 ## [0.3.0] — 2026-07-15
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -134,6 +134,6 @@ Hardware attestation adds latency at agent startup (not per-request):
 | TPM | 50–200 ms |
 | SEV-SNP | 10–50 ms |
 | TDX | 10–50 ms |
-| OPAQUE | 100–500 ms (network round-trip) |
+| OPAQUE | not implemented (managed service not GA; provider fails closed) |
 
 Manifest verification (signature check + hash comparison) is < 5 ms in all cases.

--- a/docs/api-reference/attestation.md
+++ b/docs/api-reference/attestation.md
@@ -27,7 +27,15 @@ Hardware attestation providers for Levels 1–3. See [Tutorial: Hardware attesta
 
 ::: agent_manifest._hw_providers.TDXProvider
 
-## Level 3  -  OPAQUE
+## Level 3  -  OPAQUE (not implemented)
+
+!!! warning "Not implemented"
+    OPAQUE managed runtime attestation is **not implemented**. The managed
+    service is not generally available, and the SDK does not verify the TRACE
+    claim such a service would return (no claim-signature check, no
+    `service_measurement` verification). `OPAQUEProvider` therefore fails closed
+    at construction. Use a locally-verifiable provider (SEV-SNP / TDX / Azure
+    CVM) for Level 1+ attestation. Tracked with issue #201 (§5).
 
 ::: agent_manifest._hw_providers.OPAQUEProvider
 

--- a/python/src/agent_manifest/_hw_providers.py
+++ b/python/src/agent_manifest/_hw_providers.py
@@ -26,7 +26,9 @@ Pick a provider by deployment environment (``select_provider`` in
   ``_tdx_verify.py``. Azure TDX (paravisor/vTPM-rooted, like Azure SNP) is a
   separate follow-up.
 
-* :class:`OPAQUEProvider` — OPAQUE managed runtime attestation service (#8).
+* :class:`OPAQUEProvider` — OPAQUE managed runtime attestation (#8). NOT
+  IMPLEMENTED: the managed service is not generally available and the SDK does
+  not verify its TRACE claim, so the provider fails closed at construction.
 
 Report parsing and the SNP signature/VCEK-chain verification live in
 ``_snp_verify.py`` and were validated against a report captured from real
@@ -630,181 +632,44 @@ class TDXProvider(AttestationProvider):
 
 
 class OPAQUEProvider(AttestationProvider):
-    """OPAQUE managed runtime attestation.
+    """OPAQUE managed runtime attestation — NOT IMPLEMENTED.
 
-    Delegates to the OPAQUE attestation service running in a managed TEE at
-    OPAQUE_ATTESTATION_URL. The service:
-      1. Accepts the manifest pre-image
-      2. Measures it in silicon (AMD SEV-SNP or Intel TDX, depending on region)
-      3. Returns a TRACE claim with hardware-signed audit_chain_root
+    The OPAQUE managed attestation service is not generally available, and the
+    SDK does not verify the TRACE claim such a service would return (no claim
+    signature check and no verification of the service's own enclave
+    measurement). Rather than ship a path that looks like verification but is
+    not (see issue #201 §5), this provider is explicitly disabled: constructing
+    it raises AttestationUnavailableError.
 
-    The signing key never leaves the TEE — this is the highest assurance level.
-
-    Environment variables:
-      OPAQUE_ATTESTATION_URL: Base URL of the OPAQUE attestation service
-      OPAQUE_API_KEY: API key for the service (or use mTLS)
-
-    Raises:
-        AttestationUnavailableError: If the service is not reachable.
+    It will be implemented when the managed service is available and a real
+    claim-verification path exists (signature verified against a pinned OPAQUE
+    key, plus a service_measurement check per spec §3.3). Until then, use a
+    locally-verifiable provider (SEV-SNP / TDX / Azure CVM) for Level 1+.
     """
 
-    _MAX_RESPONSE_BYTES = 1 * 1024 * 1024  # 1 MB cap on attestation service responses
+    _NOT_IMPLEMENTED = (
+        "OPAQUE managed runtime attestation is not implemented. The managed "
+        "service is not generally available, and the SDK does not verify the "
+        "returned TRACE claim's signature or the service's enclave measurement, "
+        "so it must not be relied upon. Use a locally-verifiable provider "
+        "(SEV-SNP / TDX / Azure CVM) for Level 1+ attestation."
+    )
 
     def __init__(self) -> None:
-        import urllib.parse
-        raw_url = os.environ.get("OPAQUE_ATTESTATION_URL", "").rstrip("/")
-        if not raw_url:
-            raise AttestationUnavailableError(
-                "OPAQUE_ATTESTATION_URL environment variable not set. "
-                "Set it to the OPAQUE attestation service endpoint."
-            )
-        parsed = urllib.parse.urlparse(raw_url)
-        if parsed.scheme != "https":
-            raise AttestationUnavailableError(
-                f"OPAQUE_ATTESTATION_URL must use https:// (got {parsed.scheme!r}). "
-                "Plaintext HTTP would expose manifest pre-images and API keys."
-            )
-        host = parsed.hostname or ""
-        if host in ("localhost", "127.0.0.1", "::1") or host.startswith("169.254.") or \
-                host.startswith("10.") or host.startswith("192.168.") or \
-                (host.startswith("172.") and 16 <= int(host.split(".")[1] or "0", 10) <= 31):
-            raise AttestationUnavailableError(
-                f"OPAQUE_ATTESTATION_URL must not target loopback or private addresses (got {host!r})."
-            )
-        self._url = raw_url
-        self._manifest_hash: Optional[str] = None
-        self._trace_claim: Optional[dict[str, Any]] = None
+        raise AttestationUnavailableError(self._NOT_IMPLEMENTED)
 
     def extend_manifest_hash(self, manifest_json: dict[str, Any]) -> None:
-        """Send manifest pre-image to OPAQUE attestation service."""
-        try:
-            import httpx
-        except ImportError:
-            raise AttestationUnavailableError(
-                'OPAQUEProvider requires httpx: pip install "agent-manifest[server]"'
-            )
-
-        pre = self.manifest_pre_image(manifest_json)
-        digest = hashlib.sha256(pre).hexdigest()
-        self._manifest_hash = f"sha256:{digest}"
-
-        headers = {}
-        api_key = os.environ.get("OPAQUE_API_KEY")
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-
-        import base64
-        try:
-            response = httpx.post(
-                f"{self._url}/v1/attest",
-                json={"manifest_pre_image": base64.b64encode(pre).decode()},
-                headers=headers,
-                timeout=30.0,
-            )
-        except (httpx.HTTPError, OSError) as e:
-            raise AttestationUnavailableError(
-                f"OPAQUE attestation service unreachable: {type(e).__name__}"
-            ) from e
-
-        if response.status_code != 200:
-            raise AttestationUnavailableError(
-                f"OPAQUE attestation service returned HTTP {response.status_code}. "
-                "Check service logs."
-            )
-
-        content_length = int(response.headers.get("content-length", "0"))
-        if content_length > self._MAX_RESPONSE_BYTES:
-            raise AttestationUnavailableError(
-                f"OPAQUE attestation service response too large: {content_length} bytes"
-            )
-        try:
-            self._trace_claim = response.json()
-        except ValueError as e:
-            raise AttestationUnavailableError(
-                f"OPAQUE attestation service returned invalid JSON: {type(e).__name__}"
-            ) from e
+        raise NotImplementedError(self._NOT_IMPLEMENTED)
 
     def get_attestation_report(self) -> AttestationReport:
-        if self._trace_claim is None:
-            raise AttestationUnavailableError(
-                "Call extend_manifest_hash() before get_attestation_report()."
-            )
-        return AttestationReport(
-            platform="opaque",
-            manifest_hash=self._manifest_hash or "",
-            raw=self._trace_claim,
-        )
+        raise NotImplementedError(self._NOT_IMPLEMENTED)
 
     def verify_manifest_in_report(
         self, report: AttestationReport, manifest_json: dict[str, Any]
     ) -> bool:
-        return report.manifest_hash == self.manifest_hash_value(manifest_json)
+        raise NotImplementedError(self._NOT_IMPLEMENTED)
 
     def attest_runtime_state(
-        self,
-        nonce: bytes,
-        context_hash: str,
+        self, nonce: bytes, context_hash: str
     ) -> RuntimeAttestationReport:
-        """Delegate runtime re-attestation to the OPAQUE attestation service.
-
-        Calls POST /v1/attest-runtime with the nonce and context_hash.
-        The service measures both inside its managed TEE and returns a
-        hardware-signed TRACE claim covering the nonce and context.
-        """
-        try:
-            import httpx
-        except ImportError:
-            raise AttestationUnavailableError(
-                'OPAQUEProvider requires httpx: pip install "agent-manifest[server]"'
-            )
-
-        context_bytes = bytes.fromhex(context_hash.split(":", 1)[-1])
-        qualifying = hashlib.sha256(nonce + context_bytes).digest()
-        report_data_hash = f"sha256:{hashlib.sha256(qualifying).hexdigest()}"
-
-        import base64
-        headers: dict[str, str] = {}
-        api_key = os.environ.get("OPAQUE_API_KEY")
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-
-        try:
-            response = httpx.post(
-                f"{self._url}/v1/attest-runtime",
-                json={
-                    "nonce": base64.b64encode(nonce).decode(),
-                    "context_hash": context_hash,
-                },
-                headers=headers,
-                timeout=30.0,
-            )
-        except (httpx.HTTPError, OSError) as e:
-            raise AttestationUnavailableError(
-                f"OPAQUE runtime attestation service unreachable: {type(e).__name__}"
-            ) from e
-
-        if response.status_code != 200:
-            raise AttestationUnavailableError(
-                f"OPAQUE runtime attestation returned HTTP {response.status_code}"
-            )
-
-        content_length = int(response.headers.get("content-length", "0"))
-        if content_length > self._MAX_RESPONSE_BYTES:
-            raise AttestationUnavailableError(
-                f"OPAQUE runtime attestation response too large: {content_length} bytes"
-            )
-
-        try:
-            raw = response.json()
-        except ValueError as e:
-            raise AttestationUnavailableError(
-                f"OPAQUE runtime attestation returned invalid JSON: {type(e).__name__}"
-            ) from e
-
-        return RuntimeAttestationReport(
-            platform="opaque",
-            report_data_hash=report_data_hash,
-            context_hash=context_hash,
-            nonce_hex=nonce.hex(),
-            raw=raw,
-        )
+        raise NotImplementedError(self._NOT_IMPLEMENTED)

--- a/python/tests/test_hw_providers.py
+++ b/python/tests/test_hw_providers.py
@@ -15,7 +15,6 @@ Strategy:
 import os
 import struct
 import sys
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -282,190 +281,16 @@ def test_tdx_wrong_tsm_provider_raises(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# OPAQUEProvider — all platforms (mock httpx)
+# OPAQUEProvider — not implemented (managed service not GA; see issue #201 §5)
 # ---------------------------------------------------------------------------
 
 
-def test_opaque_raises_without_env_var(monkeypatch):
-    monkeypatch.delenv("OPAQUE_ATTESTATION_URL", raising=False)
-    with pytest.raises(AttestationUnavailableError, match="OPAQUE_ATTESTATION_URL"):
+def test_opaque_provider_is_not_implemented():
+    """OPAQUE managed attestation is disabled: the managed service is not
+    generally available and the SDK does not verify its TRACE claim, so the
+    provider fails closed at construction rather than looking verified."""
+    with pytest.raises(AttestationUnavailableError, match="not implemented"):
         OPAQUEProvider()
-
-
-def test_opaque_raises_on_empty_env_var(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "")
-    with pytest.raises(AttestationUnavailableError, match="OPAQUE_ATTESTATION_URL"):
-        OPAQUEProvider()
-
-
-def test_opaque_report_before_extend_raises(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-    with pytest.raises(AttestationUnavailableError, match="extend_manifest_hash"):
-        provider.get_attestation_report()
-
-
-def test_opaque_extend_success(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-
-    fake_trace = {"eat_profile": "tag:agentrust.io,2026:trace-v0.1", "iat": 1234567890}
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = fake_trace
-
-    with patch("httpx.post", return_value=mock_response) as mock_post:
-        provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-    called_url = mock_post.call_args[0][0]
-    assert called_url == "https://attest.example.com/v1/attest"
-
-    report = provider.get_attestation_report()
-    assert report.platform == "opaque"
-    assert report.manifest_hash.startswith("sha256:")
-    assert report.raw == fake_trace
-
-
-def test_opaque_extend_posts_pre_image(monkeypatch):
-    import base64
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {}
-
-    with patch("httpx.post", return_value=mock_response) as mock_post:
-        provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-    body = mock_post.call_args.kwargs["json"]
-    assert "manifest_pre_image" in body
-    decoded = base64.b64decode(body["manifest_pre_image"])
-    assert len(decoded) > 0
-
-
-def test_opaque_extend_pre_image_is_correct(monkeypatch):
-    """The posted pre-image must match manifest_pre_image()."""
-    import base64
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {}
-
-    with patch("httpx.post", return_value=mock_response) as mock_post:
-        provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-    body = mock_post.call_args.kwargs["json"]
-    posted = base64.b64decode(body["manifest_pre_image"])
-    expected = provider.manifest_pre_image(SAMPLE_MANIFEST)
-    assert posted == expected
-
-
-def test_opaque_extend_with_api_key(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    monkeypatch.setenv("OPAQUE_API_KEY", "secret-key-123")
-    provider = OPAQUEProvider()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {}
-
-    with patch("httpx.post", return_value=mock_response) as mock_post:
-        provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-    headers = mock_post.call_args.kwargs["headers"]
-    assert headers.get("Authorization") == "Bearer secret-key-123"
-
-
-def test_opaque_extend_without_api_key_sends_empty_headers(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    monkeypatch.delenv("OPAQUE_API_KEY", raising=False)
-    provider = OPAQUEProvider()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {}
-
-    with patch("httpx.post", return_value=mock_response) as mock_post:
-        provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-    headers = mock_post.call_args.kwargs["headers"]
-    assert "Authorization" not in headers
-
-
-def test_opaque_extend_http_error_raises(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 503
-    mock_response.text = "Service Unavailable"
-
-    with patch("httpx.post", return_value=mock_response):
-        with pytest.raises(AttestationUnavailableError, match="503"):
-            provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-
-def test_opaque_extend_401_raises(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 401
-    mock_response.text = "Unauthorized"
-
-    with patch("httpx.post", return_value=mock_response):
-        with pytest.raises(AttestationUnavailableError, match="401"):
-            provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-
-def test_opaque_manifest_hash_format(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {}
-
-    with patch("httpx.post", return_value=mock_response):
-        provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-    report = provider.get_attestation_report()
-    assert report.manifest_hash.startswith("sha256:")
-    assert len(report.manifest_hash) == 7 + 64
-
-
-def test_opaque_verify_manifest_match(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-    expected = provider.manifest_hash_value(SAMPLE_MANIFEST)
-    report = AttestationReport(platform="opaque", manifest_hash=expected)
-    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
-
-
-def test_opaque_verify_manifest_mismatch(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com")
-    provider = OPAQUEProvider()
-    report = AttestationReport(platform="opaque", manifest_hash="sha256:" + "aa" * 32)
-    assert not provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
-
-
-def test_opaque_url_trailing_slash_stripped(monkeypatch):
-    monkeypatch.setenv("OPAQUE_ATTESTATION_URL", "https://attest.example.com/")
-    provider = OPAQUEProvider()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {}
-
-    with patch("httpx.post", return_value=mock_response) as mock_post:
-        provider.extend_manifest_hash(SAMPLE_MANIFEST)
-
-    called_url = mock_post.call_args[0][0]
-    assert not called_url.startswith("https://attest.example.com//")
-    assert called_url == "https://attest.example.com/v1/attest"
 
 
 # ---------------------------------------------------------------------------
@@ -491,11 +316,3 @@ def test_tdx_hardware_roundtrip():
     assert report.platform == "intel-tdx"
     assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)
 
-
-@NEEDS_OPAQUE
-def test_opaque_hardware_roundtrip():
-    provider = OPAQUEProvider()
-    provider.extend_manifest_hash(SAMPLE_MANIFEST)
-    report = provider.get_attestation_report()
-    assert report.platform == "opaque"
-    assert provider.verify_manifest_in_report(report, SAMPLE_MANIFEST)


### PR DESCRIPTION
Addresses §5 of the design review in #201: the OPAQUE provider was marketed as the "highest assurance" Level 3, yet the managed service isn't GA and the SDK never verified the TRACE claim it returns (no claim-signature check, no `service_measurement` verification) — `verify_manifest_in_report` was a `hash == hash` tautology.

Per product direction (the managed service is not close to ready), we mark it **explicitly not implemented** rather than implement a partial verification:
- `OPAQUEProvider.__init__` raises `AttestationUnavailableError` ("not implemented … not GA"); its methods raise `NotImplementedError`.
- The prior unverified HTTP flow and the "measures it in silicon / highest assurance" docstrings are removed.
- Docs (API reference Level 3 section, LIMITATIONS perf table), CHANGELOG updated; OPAQUE unit tests replaced with a fail-closed assertion.

Guidance: use a locally-verifiable provider (SEV-SNP / TDX / Azure CVM) for Level 1+. 563 tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)