### PR TITLE
feat(tee): shared TPM 2.0 quote verifier + agent-manifest 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-07-21
+
+Makes agent-manifest the canonical hardware-verification library for the org: SEV-SNP, TDX, and now TPM quote verification live here and are consumed by cmcp and ca2a via this PyPI package rather than duplicated per repo.
+
 ### Added
+
+**[SDK]** Shared TPM 2.0 quote verifier (`agent_manifest._tpm_verify`, exported: `parse_tpm_quote`, `verify_tpm_quote`, `TpmQuote`, `TpmVerificationError`). Fail-closed appraisal of a `TPMS_ATTEST` quote: magic/type structural check, AK certificate chain to a caller-pinned trusted root, AK signature (ECDSA-P256 or RSA PKCS#1 v1.5 / SHA-256) over the attest blob, and constant-time qualifying-data (nonce) + PCR-digest binding checks. Wired into `verify_attestation_chain` (dispatch on `platform in {"tpm","aws-nitro"}`). Ported from ca2a's reference implementation so the three repos share one verifier. Caveat: exercised against synthetic self-consistent vectors; unlike the SEV-SNP/TDX paths it is not yet validated against a real TPM quote (follow-up).
 
 **[SDK]** Intel TDX DCAP quote verification (`agent_manifest._tdx_verify`, exported), **hardware-validated on a non-paravisor TDX guest (GCP C3)**. `TDXProvider` now uses the configfs-TSM `tdx_guest` provider, which returns a full remotely-verifiable DCAP quote (v4, ECDSA-P256) instead of a bare local `TDREPORT`. Verification checks the quote's attestation-key signature over the TD report, the QE report binding, the PCK signature over the QE report, and the PCK certificate chain up to the **pinned Intel SGX Root CA** (embedded; offline). Wired into `verify_attestation_chain`, which now returns `passed=True` for a TDX report only when the quote + PCK chain verify. Closes the TDX half of the "shipped the binding without verification" gap (#204/#228); the previous `/dev/tdx-guest` ioctl path (raw TDREPORT, no signature check, RTMR-extend that never happened) has been removed. Azure TDX (paravisor/vTPM-rooted) remains a follow-up.
 **[SDK]** `AzureCVMProvider` — hardware-attested manifest binding on Azure confidential VMs, validated on live SEV-SNP silicon (Azure DCasv5). Azure runs SNP behind a Hyper-V paravisor, so there is no `/dev/sev-guest`; the SNP report is read from the vTPM NV index `0x01400001` and the manifest hash is bound through the vTPM (PCR + AK-signed quote), with the AK rooted in silicon by the SNP report + VCEK chain. Auto-selected by `provider='auto'` on Azure.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.3.0"
+version = "0.4.0"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -44,6 +44,10 @@ from ._tdx_verify import (
     TdxQuote, TdxVerificationError,
     parse_tdx_quote, verify_tdx_quote,
 )
+from ._tpm_verify import (
+    TpmQuote, TpmVerificationError,
+    parse_tpm_quote, verify_tpm_quote,
+)
 from ._verify import (
     verify_manifest,
     verify_runtime_report,
@@ -89,6 +93,7 @@ __all__ = [
     "verify_snp_signature", "verify_vcek_chain", "verify_runtime_data_binding",
     "fetch_vcek",
     "TdxQuote", "TdxVerificationError", "parse_tdx_quote", "verify_tdx_quote",
+    "TpmQuote", "TpmVerificationError", "parse_tpm_quote", "verify_tpm_quote",
     "verify_manifest", "verify_runtime_report",
     "VerificationContext", "VerificationResult",
     "OverallResult", "FieldResult", "DelegationResult", "HitlResult",

--- a/python/src/agent_manifest/_attestation.py
+++ b/python/src/agent_manifest/_attestation.py
@@ -147,6 +147,47 @@ def _verify_tdx_signature_step(
         return SignatureStatus.FAILED
 
 
+def _verify_tpm_signature_step(
+    tpm_attest: Optional[bytes],
+    tpm_signature: Optional[bytes],
+    tpm_ak_chain_pem: Optional[bytes],
+    tpm_trusted_roots_pem: Optional[bytes],
+    expected_qualifying_data: Optional[bytes],
+    expected_pcr_digest: Optional[bytes],
+    reasons: list[str],
+) -> SignatureStatus:
+    """Verify a TPM 2.0 quote (AK chain + AK signature + bindings), if supplied.
+
+    Requires the TPMS_ATTEST blob, its AK signature, the AK certificate chain,
+    and the caller's trusted TPM roots (there is no single published TPM root).
+    Returns ``VERIFIED`` / ``FAILED`` / ``NOT_IMPLEMENTED`` (material absent).
+    """
+    if not (tpm_attest and tpm_signature and tpm_ak_chain_pem and tpm_trusted_roots_pem):
+        reasons.append(
+            "hardware signature not checked: TPM attest/signature/AK-chain/"
+            "trusted-roots not all supplied"
+        )
+        return SignatureStatus.NOT_IMPLEMENTED
+    from ._tpm_verify import TpmVerificationError, verify_tpm_quote
+
+    try:
+        ok = verify_tpm_quote(
+            tpm_attest,
+            tpm_signature,
+            tpm_ak_chain_pem,
+            trusted_roots_pem=tpm_trusted_roots_pem,
+            expected_qualifying_data=expected_qualifying_data,
+            expected_pcr_digest=expected_pcr_digest,
+        )
+    except TpmVerificationError as e:
+        reasons.append(f"TPM quote verification failed: {e}")
+        return SignatureStatus.FAILED
+    if ok:
+        return SignatureStatus.VERIFIED
+    reasons.append("TPM quote signature or binding did not verify")
+    return SignatureStatus.FAILED
+
+
 def verify_attestation_chain(
     report: Any,
     *,
@@ -157,6 +198,12 @@ def verify_attestation_chain(
     cert_chain_pem: Optional[bytes] = None,
     trusted_ark_der: Optional[bytes] = None,
     trusted_tdx_root_pem: Optional[bytes] = None,
+    tpm_attest: Optional[bytes] = None,
+    tpm_signature: Optional[bytes] = None,
+    tpm_ak_chain_pem: Optional[bytes] = None,
+    tpm_trusted_roots_pem: Optional[bytes] = None,
+    expected_qualifying_data: Optional[bytes] = None,
+    expected_pcr_digest: Optional[bytes] = None,
 ) -> ChainVerificationResult:
     """Verify a boot-time ``AttestationReport`` against expected values.
 
@@ -222,6 +269,16 @@ def verify_attestation_chain(
     platform = getattr(report, "platform", "") or ""
     if platform == "intel-tdx":
         signature = _verify_tdx_signature_step(report, reasons, trusted_tdx_root_pem)
+    elif platform in ("tpm", "aws-nitro"):
+        signature = _verify_tpm_signature_step(
+            tpm_attest,
+            tpm_signature,
+            tpm_ak_chain_pem,
+            tpm_trusted_roots_pem,
+            expected_qualifying_data,
+            expected_pcr_digest,
+            reasons,
+        )
     else:
         signature = _verify_snp_signature_step(
             report,

--- a/python/src/agent_manifest/_tpm_verify.py
+++ b/python/src/agent_manifest/_tpm_verify.py
@@ -1,0 +1,205 @@
+"""TPM 2.0 quote (TPMS_ATTEST) parsing and offline signature-chain verification.
+
+This is the TPM analogue of :mod:`._snp_verify` and :mod:`._tdx_verify`, and the
+shared implementation the org consolidates onto (cmcp and ca2a consume it via
+PyPI rather than carrying their own copies). It was ported from ca2a's
+``ca2a_verify.tpm`` reference implementation.
+
+Verification is fail-closed, in four steps:
+
+1. The structure is confirmed to be a TPM-generated quote (``magic`` ==
+   ``TPM_GENERATED_VALUE`` and ``attest_type`` == ``TPM_ST_ATTEST_QUOTE``).
+2. The attestation-key (AK) certificate chain is verified up to a
+   caller-supplied trusted root (leaf issued-by next, root pinned by
+   SHA-256 fingerprint). A self-signed AK is never trusted on its own.
+3. The AK signature over the ``TPMS_ATTEST`` blob is verified (ECDSA-P256 or
+   RSA PKCS#1 v1.5, both over SHA-256).
+4. The qualifying data (the verifier's nonce, carried in ``extraData``) and the
+   PCR digest (the platform measurement) are checked against expected values
+   with constant-time compares.
+
+Unlike SEV-SNP/TDX there is no single published TPM root — AK certs chain to
+per-vendor EK roots — so the caller supplies the vendor roots it trusts. Only
+the ``cryptography`` package is required; no external tools run at verify time.
+
+Note: the parsing and signature/chain logic are exercised against synthetic
+self-consistent vectors (see ``tests/test_tpm_verify.py``). Unlike the SEV-SNP
+and TDX paths, this verifier has not yet been validated against a quote from a
+real TPM; that is tracked as follow-up hardware validation.
+"""
+from __future__ import annotations
+
+import hmac
+from dataclasses import dataclass
+from typing import Optional
+
+TPM_GENERATED_VALUE = 0xFF544347
+TPM_ST_ATTEST_QUOTE = 0x8018
+_CLOCK_INFO_LEN = 17
+_FIRMWARE_VERSION_LEN = 8
+
+
+class TpmVerificationError(Exception):
+    """Raised when a TPM quote or its certificate chain fails verification."""
+
+
+def _read_u16(buf: bytes, pos: int) -> tuple[int, int]:
+    if pos + 2 > len(buf):
+        raise TpmVerificationError("TPM quote truncated reading a 16-bit field")
+    return int.from_bytes(buf[pos:pos + 2], "big"), pos + 2
+
+
+def _read_2b(buf: bytes, pos: int) -> tuple[bytes, int]:
+    size, pos = _read_u16(buf, pos)
+    if pos + size > len(buf):
+        raise TpmVerificationError("TPM quote truncated reading a sized buffer")
+    return buf[pos:pos + size], pos + size
+
+
+@dataclass(frozen=True)
+class TpmQuote:
+    """The parsed subset of a TPM 2.0 quote (TPMS_ATTEST) that is appraised."""
+
+    magic: int
+    attest_type: int
+    qualifying_data: bytes  # extraData: the verifier's nonce
+    pcr_digest: bytes  # the platform measurement
+    raw: bytes
+
+
+def parse_tpm_quote(attest: bytes) -> TpmQuote:
+    """Parse a ``TPMS_ATTEST`` quote blob into its appraised fields."""
+    if len(attest) < 6:
+        raise TpmVerificationError("TPM quote too short")
+    magic = int.from_bytes(attest[0:4], "big")
+    attest_type, pos = _read_u16(attest, 4)
+    _qualified_signer, pos = _read_2b(attest, pos)  # TPM2B_NAME
+    qualifying_data, pos = _read_2b(attest, pos)  # extraData / nonce
+    pos += _CLOCK_INFO_LEN + _FIRMWARE_VERSION_LEN
+    # TPML_PCR_SELECTION
+    if pos + 4 > len(attest):
+        raise TpmVerificationError("TPM quote truncated reading PCR selection count")
+    count = int.from_bytes(attest[pos:pos + 4], "big")
+    pos += 4
+    for _ in range(count):
+        if pos + 3 > len(attest):
+            raise TpmVerificationError("TPM quote truncated reading a PCR selection")
+        size_of_select = attest[pos + 2]
+        pos += 3 + size_of_select
+    pcr_digest, _pos = _read_2b(attest, pos)
+    return TpmQuote(
+        magic=magic,
+        attest_type=attest_type,
+        qualifying_data=qualifying_data,
+        pcr_digest=pcr_digest,
+        raw=bytes(attest),
+    )
+
+
+def _verify_ak_chain(ak_chain_pem: bytes, trusted_roots_pem: bytes) -> "object":
+    """Verify a leaf-first AK chain up to a pinned trusted root; return the leaf.
+
+    Raises :class:`TpmVerificationError` on any failure.
+    """
+    from cryptography import x509
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.hashes import SHA256
+
+    chain = x509.load_pem_x509_certificates(ak_chain_pem)
+    roots = x509.load_pem_x509_certificates(trusted_roots_pem)
+    if not chain:
+        raise TpmVerificationError("empty AK certificate chain")
+    if not roots:
+        raise TpmVerificationError("no trusted TPM roots supplied")
+
+    for i in range(len(chain) - 1):
+        try:
+            chain[i].verify_directly_issued_by(chain[i + 1])
+        except (ValueError, TypeError, InvalidSignature) as exc:
+            raise TpmVerificationError(
+                f"AK chain certificate at position {i} is not validly issued by the next: {exc}"
+            ) from exc
+
+    trusted = {c.fingerprint(SHA256()) for c in roots}
+    if chain[-1].fingerprint(SHA256()) not in trusted:
+        raise TpmVerificationError(
+            "AK chain root is not among the supplied trusted TPM roots"
+        )
+    return chain[0]
+
+
+def verify_tpm_quote(
+    attest: bytes,
+    signature: bytes,
+    ak_chain_pem: bytes,
+    *,
+    trusted_roots_pem: bytes,
+    expected_qualifying_data: Optional[bytes] = None,
+    expected_pcr_digest: Optional[bytes] = None,
+) -> bool:
+    """Fully verify a TPM 2.0 quote offline (all four steps, fail-closed).
+
+    Args:
+        attest: the raw ``TPMS_ATTEST`` blob the TPM signed.
+        signature: the AK signature over ``attest`` (DER ECDSA-P256 or RSA
+            PKCS#1 v1.5, SHA-256).
+        ak_chain_pem: the AK certificate chain (PEM, leaf first).
+        trusted_roots_pem: the caller's trusted vendor EK/AK roots (PEM).
+        expected_qualifying_data: if given, the quote's ``extraData`` (nonce)
+            must equal it.
+        expected_pcr_digest: if given, the quote's PCR digest must equal it.
+
+    Returns:
+        ``True`` only when the structure, AK chain, AK signature, and any
+        supplied bindings all check out. Returns ``False`` on a well-formed but
+        invalid signature or a binding mismatch. Raises
+        :class:`TpmVerificationError` on a malformed quote / broken chain or if
+        ``cryptography`` is unavailable.
+    """
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+        from cryptography.hazmat.primitives.hashes import SHA256
+    except ImportError as e:  # pragma: no cover
+        raise TpmVerificationError(
+            "TPM quote verification requires the 'cryptography' package"
+        ) from e
+
+    quote = parse_tpm_quote(attest)
+
+    # Step 1: structural — this must be a TPM-generated quote.
+    if quote.magic != TPM_GENERATED_VALUE:
+        raise TpmVerificationError(
+            f"TPMS_ATTEST magic is not TPM_GENERATED (magic={quote.magic:#x})"
+        )
+    if quote.attest_type != TPM_ST_ATTEST_QUOTE:
+        raise TpmVerificationError(
+            f"attestation is not a quote (type={quote.attest_type:#x})"
+        )
+
+    # Step 2: AK certificate chain up to a pinned trusted root.
+    ak = _verify_ak_chain(ak_chain_pem, trusted_roots_pem)
+    ak_key = ak.public_key()  # type: ignore[attr-defined]
+
+    # Step 3: AK signature over the TPMS_ATTEST blob.
+    try:
+        if isinstance(ak_key, ec.EllipticCurvePublicKey):
+            ak_key.verify(signature, attest, ec.ECDSA(SHA256()))
+        elif isinstance(ak_key, rsa.RSAPublicKey):
+            ak_key.verify(signature, attest, padding.PKCS1v15(), SHA256())
+        else:
+            raise TpmVerificationError("unsupported AK public-key type for TPM quote")
+    except InvalidSignature:
+        return False
+
+    # Step 4: bindings (constant-time).
+    if expected_qualifying_data is not None and not hmac.compare_digest(
+        quote.qualifying_data, expected_qualifying_data
+    ):
+        return False
+    if expected_pcr_digest is not None and not hmac.compare_digest(
+        quote.pcr_digest, expected_pcr_digest
+    ):
+        return False
+
+    return True

--- a/python/tests/test_tpm_verify.py
+++ b/python/tests/test_tpm_verify.py
@@ -1,0 +1,218 @@
+"""Tests for the shared TPM 2.0 quote verifier (`agent_manifest._tpm_verify`).
+
+Synthetic, self-consistent crypto: a generated attestation key (EC or RSA), a
+mock AK certificate chain to a test root, and a hand-built ``TPMS_ATTEST`` blob
+signed by the AK. Covers the happy path plus tamper / pinning / wrong-key /
+binding-mismatch rejection. (The parse + signature/chain logic is exercised
+here; validation against a real TPM quote is tracked as follow-up.)
+"""
+import datetime
+
+import pytest
+
+crypto = pytest.importorskip("cryptography")
+
+from agent_manifest._tpm_verify import (  # noqa: E402
+    TPM_GENERATED_VALUE,
+    TPM_ST_ATTEST_QUOTE,
+    TpmVerificationError,
+    parse_tpm_quote,
+    verify_tpm_quote,
+)
+
+from cryptography import x509  # noqa: E402
+from cryptography.hazmat.primitives import hashes  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa  # noqa: E402
+from cryptography.hazmat.primitives.serialization import Encoding  # noqa: E402
+from cryptography.x509.oid import NameOID  # noqa: E402
+
+_T0 = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+
+
+def _name(cn):
+    return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+
+
+def _cert(subject, subject_pub, issuer, issuer_key, halg=hashes.SHA256()):
+    return (
+        x509.CertificateBuilder()
+        .subject_name(_name(subject))
+        .issuer_name(_name(issuer))
+        .public_key(subject_pub)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(_T0)
+        .not_valid_after(_T0 + datetime.timedelta(days=3650))
+        .sign(issuer_key, halg)
+    )
+
+
+def _ak_chain(kind="ec"):
+    """Return (ak_private_key, ak_chain_pem, trusted_roots_pem) — root directly signs AK."""
+    if kind == "ec":
+        root_key = ec.generate_private_key(ec.SECP256R1())
+        ak_key = ec.generate_private_key(ec.SECP256R1())
+    else:
+        root_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        ak_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    root = _cert("test-tpm-root", root_key.public_key(), "test-tpm-root", root_key)
+    ak = _cert("test-ak", ak_key.public_key(), "test-tpm-root", root_key)
+    chain_pem = ak.public_bytes(Encoding.PEM) + root.public_bytes(Encoding.PEM)
+    return ak_key, chain_pem, root.public_bytes(Encoding.PEM)
+
+
+def _build_attest(
+    nonce: bytes,
+    pcr_digest: bytes,
+    magic: int = TPM_GENERATED_VALUE,
+    attest_type: int = TPM_ST_ATTEST_QUOTE,
+) -> bytes:
+    """Construct a minimal but structurally-valid TPMS_ATTEST quote blob."""
+    out = magic.to_bytes(4, "big")
+    out += attest_type.to_bytes(2, "big")
+    out += (0).to_bytes(2, "big")  # qualifiedSigner: empty TPM2B_NAME
+    out += len(nonce).to_bytes(2, "big") + nonce  # extraData / qualifying data
+    out += b"\x00" * 17  # clockInfo
+    out += b"\x00" * 8  # firmwareVersion
+    out += (1).to_bytes(4, "big")  # TPML_PCR_SELECTION count
+    out += (0x000B).to_bytes(2, "big")  # hashAlg = sha256
+    out += (3).to_bytes(1, "big")  # sizeofSelect
+    out += b"\x00\x00\x01"  # pcrSelect bitmap
+    out += len(pcr_digest).to_bytes(2, "big") + pcr_digest
+    return out
+
+
+def _sign(ak_key, attest):
+    if isinstance(ak_key, ec.EllipticCurvePrivateKey):
+        return ak_key.sign(attest, ec.ECDSA(hashes.SHA256()))
+    return ak_key.sign(attest, padding.PKCS1v15(), hashes.SHA256())
+
+
+NONCE = bytes(range(32))
+PCR = bytes(range(32, 64))
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_extracts_fields():
+    q = parse_tpm_quote(_build_attest(NONCE, PCR))
+    assert q.magic == TPM_GENERATED_VALUE
+    assert q.attest_type == TPM_ST_ATTEST_QUOTE
+    assert q.qualifying_data == NONCE
+    assert q.pcr_digest == PCR
+
+
+def test_parse_rejects_truncated():
+    with pytest.raises(TpmVerificationError):
+        parse_tpm_quote(b"\xff")
+
+
+# ---------------------------------------------------------------------------
+# Full verification round-trip (EC and RSA AKs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["ec", "rsa"])
+def test_verify_accepts_valid(kind):
+    ak_key, chain, roots = _ak_chain(kind)
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+    assert verify_tpm_quote(
+        attest, sig, chain,
+        trusted_roots_pem=roots,
+        expected_qualifying_data=NONCE,
+        expected_pcr_digest=PCR,
+    ) is True
+
+
+def test_verify_rejects_tampered_attest():
+    ak_key, chain, roots = _ak_chain()
+    attest = bytearray(_build_attest(NONCE, PCR))
+    sig = _sign(ak_key, bytes(attest))
+    attest[-1] ^= 0x01  # flip a PCR-digest bit after signing
+    assert verify_tpm_quote(bytes(attest), sig, chain, trusted_roots_pem=roots) is False
+
+
+def test_verify_rejects_wrong_ak_key():
+    ak_key, chain, roots = _ak_chain()
+    attest = _build_attest(NONCE, PCR)
+    other = ec.generate_private_key(ec.SECP256R1())
+    sig = _sign(other, attest)  # signed by a key that is not the AK
+    assert verify_tpm_quote(attest, sig, chain, trusted_roots_pem=roots) is False
+
+
+def test_verify_rejects_untrusted_root():
+    ak_key, chain, _roots = _ak_chain()
+    _, _, other_roots = _ak_chain()  # a different, unrelated root
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+    with pytest.raises(TpmVerificationError, match="trusted TPM roots"):
+        verify_tpm_quote(attest, sig, chain, trusted_roots_pem=other_roots)
+
+
+def test_verify_rejects_qualifying_data_mismatch():
+    ak_key, chain, roots = _ak_chain()
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+    assert verify_tpm_quote(
+        attest, sig, chain, trusted_roots_pem=roots,
+        expected_qualifying_data=b"\x00" * 32,
+    ) is False
+
+
+def test_verify_rejects_pcr_mismatch():
+    ak_key, chain, roots = _ak_chain()
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+    assert verify_tpm_quote(
+        attest, sig, chain, trusted_roots_pem=roots,
+        expected_pcr_digest=b"\x11" * 32,
+    ) is False
+
+
+def test_verify_raises_on_wrong_magic():
+    ak_key, chain, roots = _ak_chain()
+    attest = _build_attest(NONCE, PCR, magic=0x00000000)
+    sig = _sign(ak_key, attest)
+    with pytest.raises(TpmVerificationError, match="TPM_GENERATED"):
+        verify_tpm_quote(attest, sig, chain, trusted_roots_pem=roots)
+
+
+def test_verify_raises_on_non_quote_type():
+    ak_key, chain, roots = _ak_chain()
+    attest = _build_attest(NONCE, PCR, attest_type=0x8017)
+    sig = _sign(ak_key, attest)
+    with pytest.raises(TpmVerificationError, match="not a quote"):
+        verify_tpm_quote(attest, sig, chain, trusted_roots_pem=roots)
+
+
+# ---------------------------------------------------------------------------
+# verify_attestation_chain dispatch (platform == "tpm")
+# ---------------------------------------------------------------------------
+
+
+def test_attestation_chain_dispatches_tpm():
+    from agent_manifest import (
+        AttestationReport,
+        SignatureStatus,
+        verify_attestation_chain,
+    )
+
+    ak_key, chain, roots = _ak_chain()
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+    # A TPM report binds the manifest via a PCR/qualifying-data, not report_data;
+    # here we only assert the signature step reaches VERIFIED via the TPM path.
+    report = AttestationReport(platform="tpm", manifest_hash="sha256:" + "00" * 32)
+    result = verify_attestation_chain(
+        report,
+        expected_manifest_hash="sha256:" + "00" * 32,
+        tpm_attest=attest,
+        tpm_signature=sig,
+        tpm_ak_chain_pem=chain,
+        tpm_trusted_roots_pem=roots,
+        expected_qualifying_data=NONCE,
+    )
+    assert result.signature is SignatureStatus.VERIFIED


### PR DESCRIPTION
Makes agent-manifest the **canonical hardware-verification library** for the org. It already exposed hardware-validated SEV-SNP (`_snp_verify`) and TDX (`_tdx_verify`) verification; this adds the missing **TPM 2.0 quote verifier** so cmcp and ca2a can drop their own copies and depend on this package via PyPI (follow-up PRs).

## What
- New `agent_manifest._tpm_verify` (exported: `parse_tpm_quote`, `verify_tpm_quote`, `TpmQuote`, `TpmVerificationError`). Fail-closed `TPMS_ATTEST` appraisal: magic/type check → AK cert chain to a **caller-pinned** trusted root (no blind self-signed AK) → AK signature (ECDSA-P256 or RSA PKCS#1 v1.5, SHA-256) → constant-time qualifying-data (nonce) + PCR-digest binding.
- Wired into `verify_attestation_chain` (dispatch on `platform in {tpm, aws-nitro}`), consistent with the SNP/TDX steps — fail-closed, `VERIFIED` only when signature + chain + bindings hold.
- Ported from ca2a's reference `ca2a_verify.tpm`, so all three repos converge on one implementation.
- **Version bump 0.3.0 → 0.4.0** for the PyPI release that unblocks the cmcp/ca2a consolidation.

## Caveat (stated honestly)
Unlike the SEV-SNP and TDX verifiers (validated on real silicon), the TPM path is exercised only against **synthetic self-consistent vectors** here; validation against a real TPM quote is a tracked follow-up. The cert-chain + signature logic is fully testable synthetically and is covered.

12 TPM tests + full suite (575) pass; ruff + mypy clean. Scope: agent-manifest only — cmcp/ca2a refactors are separate PRs after 0.4.0 is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)