### PR TITLE
docs: document Azure TDX offline-attestation limitation (MAA-required)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Documentation
+
+**[SDK]** `LIMITATIONS.md`: document that **Azure TDX is not supported for offline attestation** (hardware-confirmed). Azure runs TDX behind the Hyper-V paravisor, so the guest gets no signed DCAP quote — only a MAC'd `TDREPORT` via the vTPM — and rooting that as genuine silicon needs a networked service (Azure MAA). Offline TDX attestation is supported on non-paravisor guests (e.g. GCP C3); on Azure use SEV-SNP (`AzureCVMProvider`). Azure-MAA TDX support is tracked as a follow-up.
+
 ## [0.5.0] — 2026-07-21
 
 Generalizes the verification API so cmcp and ca2a can delegate their full SNP/TDX/TPM crypto to this package (via PyPI) without changing behavior or rewriting their test fixtures. Backward compatible — all existing functions and signatures are unchanged.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -71,9 +71,20 @@ This provider and every link of the chain above were validated against a report
 captured from a live Azure SEV-SNP VM. Intel TDX is hardware-validated on a
 non-paravisor TDX guest (GCP C3): the configfs-TSM `tdx_guest` provider returns
 a DCAP quote whose ECDSA-P256 signature, QE binding, and PCK certificate chain
-(to the pinned Intel SGX Root CA) are verified. Azure TDX (behind a Hyper-V
-paravisor, like Azure SNP) surfaces attestation through the vTPM and is a
-separate follow-up.
+(to the pinned Intel SGX Root CA) are verified.
+
+**Azure TDX is not supported for offline attestation** (confirmed on real
+Azure TDX hardware). Azure runs TDX behind the Hyper-V paravisor: there is no
+`/dev/tdx-guest` and the configfs-TSM `tdx_guest` provider does not register
+(the guest driver cannot bind), so the guest cannot obtain a signed DCAP quote.
+The only attestation surface is the vTPM/HCL blob, which carries a **MAC'd
+`TDREPORT`**, not a remotely-verifiable quote. Verifying a MAC'd `TDREPORT` as
+genuine silicon requires a networked attestation service (**Azure MAA**) or an
+on-platform Quoting Enclave, neither of which the SDK's offline verifier can
+use. Azure-TDX support would therefore mean a networked MAA integration (a
+different trust model from the offline SNP/TDX paths) and is out of scope; it is
+tracked as a follow-up. Use SEV-SNP (`AzureCVMProvider`) on Azure, or a
+non-paravisor TDX guest (e.g. GCP C3) for offline TDX attestation.
 
 ## Hardware attestation scope: boot-time binding only
 


### PR DESCRIPTION
Records a hardware-confirmed platform constraint: **Azure TDX cannot be attested offline.**

Confirmed on a real Azure TDX VM (Standard_EC2es_v6, westeurope): TDX runs behind the Hyper-V paravisor, so there is **no `/dev/tdx-guest`** and the configfs-TSM `tdx_guest` provider does not register (the guest driver can't bind, even after `modprobe`). The guest obtains **no signed DCAP quote** — only a **MAC'd `TDREPORT`** via the vTPM/HCL surface (which binds the vTPM AK, `REPORTDATA == sha256(runtime_data)`, exactly like Azure SNP). A MAC'd `TDREPORT` is not remotely verifiable offline; rooting it as genuine silicon requires **Azure MAA** (networked) or an on-platform Quoting Enclave.

So the SDK's offline `_tdx_verify` (DCAP + Intel PCK chain) cannot root Azure TDX. Offline TDX attestation is supported on **non-paravisor** guests (validated on GCP C3); on Azure, use **SEV-SNP** (`AzureCVMProvider`). Azure-MAA TDX support (a networked trust model, distinct from the offline paths) is deferred and tracked.

Docs-only (LIMITATIONS + CHANGELOG). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)