### PR TITLE
docs(adr): ADR-0011, the manifest is a signed document not a JWT/JOSE profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Fixed
+
+**[SDK]** A `signature` block with no `algorithm` field no longer falls back to Ed25519. The field is REQUIRED by spec 3.6 but sits outside the signing pre-image, and the verifier defaulted a missing identifier to the classical algorithm; it is now a `signature.algorithm` mismatch. Completes the 0.6.0 downgrade check, which only covered a present-but-weaker identifier.
+
+### Documentation
+
+**[SPEC]** New **ADR-0011: the manifest is a signed document, not a JWT/JOSE profile** (status: Proposed). Answers the recurring "why not just a JWT extension?" question on precedent rather than on capability, steelmanning EAT ([RFC 9711](https://www.rfc-editor.org/rfc/rfc9711.html)) rather than dismissing it, and setting against it the choice every comparable multi-artifact provenance standard made: SCITT ([RFC 9943](https://www.rfc-editor.org/rfc/rfc9943.html)) mandates COSE_Sign1, DSSE rejected a JWS profile in writing, C2PA signs with `COSE_Sign1_Tagged`. The ADR also records a decision this project had never actually made: the envelope is neither JOSE nor COSE but a bespoke canonical-JSON detached signature. Migrating to COSE_Sign1 is recommended; Section 3.6 is unchanged until that is signed off.
+
+**[SPEC]** Corrected three factual errors in the spec. Section 2.2 and Section 5 described the manifest signature as "JWS", which it has never been (there is no JOSE dependency in the SDK; the signature is a detached Ed25519 or ML-DSA-65 signature over an RFC 8785 pre-image). Section 10.4 cited EAT as RFC 9528, which is EDHOC; EAT is RFC 9711.
+
+**[SPEC]** Section 3.6 gained a normative algorithm-binding rule making the 0.6.0 verifier behaviour part of the specification: because the `signature` block sits outside the pre-image, a verifier MUST cross-check the declared algorithm against the signed `crypto_profile`, MUST reject a downgrade, and MUST reject an unrecognized algorithm identifier rather than defaulting to Ed25519. Section 10.4 adds rows for RFC 9711 and RFC 9943 positioning Agent Manifest as the agent-layer profile of the SCITT model.
+
+**[SDK]** `docs/index.md` FAQ answers "why not specify it as a JWT or JOSE profile?" with the short form of the ADR-0011 argument.
+
 ## [0.6.0] — 2026-07-26
 
 Fixes the CLI that every document described but that nobody could run, and closes a signature-downgrade gap in the verifier.

--- a/docs/adr/0011-signature-envelope.md
+++ b/docs/adr/0011-signature-envelope.md
@@ -1,0 +1,95 @@
+# ADR-0011: The manifest is a signed document, not a JWT/JOSE profile
+
+**Status**: Proposed
+**Date**: 2026-07-26
+**Spec section**: Section 2.3 (Canonical Serialization), Section 3.6 (Manifest Signature)
+
+## Context
+
+A recurring question in standards conversations is: *why is this not just a JWT extension?* The question deserves a structural answer, and answering it exposed a decision this project has never actually made.
+
+### What we sign today
+
+The spec describes the signed manifest as "JWS" in two places (Section 2.2 lifecycle table, and the `pack_signature` note in Section 5). That description is wrong, and this ADR's companion change removes it. The implementation has never used JOSE:
+
+- The SDK's only cryptographic dependency is `cryptography`. No JOSE library is present.
+- `signing_pre_image()` returns the RFC 8785 canonical bytes of a fixed subset of top-level fields (`SIGNED_FIELDS`), with `hitl_record.approvals` normalized to `[]`.
+- The result is a raw Ed25519 (or ML-DSA-65, or both) signature carried in a bespoke detached JSON `signature` object.
+
+So the envelope is neither JOSE nor COSE. It is a third thing: canonical JSON plus a detached signature object, specified only by us. That is the weakest of the available positions for a project whose stated goal is a canonical standard, and it is the real subject of this ADR.
+
+### What the envelope has to carry
+
+The manifest is not shaped like a bearer token:
+
+- Ten artifact bindings, not a claim set about a caller.
+- Multiple independent signers. The issuer signs the manifest; each HITL approver signs their own approval; each delegation hop is signed by its principal; hardware attestation is appended after signing and is deliberately outside the issuer signature.
+- A 90-day default lifetime, versus the minutes-to-hours life of an access token.
+- A transparency log inclusion proof attached *after* signing (Section 3.6 ordering rules).
+
+### The strongest form of the counter-argument
+
+EAT, [RFC 9711](https://www.rfc-editor.org/rfc/rfc9711.html) (Standards Track, April 2025), is a real IETF attestation-token format in the JWT/CWT family. It supports nested tokens for composite multi-subsystem devices (Section 4.2.18.3) and Detached EAT Bundles for claims carried outside the token (Section 5). An honest reading is that an IETF-blessed *token* can, in principle, express multi-artifact and detached attestation. Any rebuttal that rests on "JWT cannot do this" is wrong and will be dismantled by anyone who knows EAT.
+
+### What comparable standards actually chose
+
+The pattern is not "tokens versus documents" in the abstract. It splits cleanly by object type:
+
+| Standard | Object | Envelope |
+|---|---|---|
+| EAT (RFC 9711) | Attestation token about a caller | JWT / CWT profile |
+| SCITT ([RFC 9943](https://www.rfc-editor.org/rfc/rfc9943.html), June 2026) | Supply-chain signed statement plus transparency receipt | COSE_Sign1, mandated |
+| in-toto / SLSA | Multi-subject build attestation | DSSE, which explicitly rejected JWS |
+| C2PA | Multi-assertion content provenance | JUMBF container, `COSE_Sign1_Tagged` claim signature |
+
+SCITT is the closest analog to what Agent Manifest is: it requires that "Signed Statements produced by Issuers must be COSE_Sign1 messages," treats the payload as content-agnostic (including detached payloads), and carries COSE Receipts as proofs in the unprotected header. That is our model, down to the Rekor-style log entry in Section 3.6.
+
+The DSSE authors documented why they declined to profile JWS: it "has a history of vulnerable implementations due to the complexity and lack of specificity in the RFC"; implementations fail to check that the algorithm matches the public key type or to validate the certificate chain root; and canonicalization is "an unnecessarily large attack surface." Their Pre-Authentication Encoding exists to bind `payloadType` and `payload` unambiguously so that signer and verifier cannot disagree about what was signed.
+
+### We have already shipped one of those bugs
+
+This is not a theoretical concern for us. Section 3.6 excludes the entire `signature` block from the signing pre-image, so `signature.algorithm` was unauthenticated, and the verifier never compared it against the signed `crypto_profile`. Until 0.6.0, a manifest declaring the post-quantum profile verified `VALID` on a classical-only Ed25519 signature. We fixed it with an explicit cross-check. COSE_Sign1 places `alg` in the *protected* header, where it is covered by the signature; the entire class of bug is structurally absent rather than patched after the fact.
+
+## Decision
+
+Two parts. The first is settled; the second is what this ADR asks for a decision on.
+
+**1. Agent Manifest is a signed document, not a bearer token, and it composes with the token layer rather than competing with it.** EAT is the right answer for "who is calling, right now, and what is their attestation evidence." An EAT (or any platform attestation token) is a valid *input* to a manifest's attestation block. The manifest itself is the durable, multi-signer, hardware-bound record of what the agent *was*. We will not profile JWS as the manifest envelope.
+
+**2. The envelope encoding is open, with a recommendation.** Migrate to **COSE_Sign1** (Option A below), aligning with SCITT and inheriting its documented safety properties, rather than continuing to specify a bespoke canonical-JSON envelope. This is a breaking change and needs explicit sign-off before it is written into the spec; until that happens the status of this ADR stays *Proposed* and Section 3.6 is unchanged.
+
+## Rationale
+
+Deciding by precedent rather than by capability is what makes the position defensible. The question is not whether a JWS or JWT profile *could* carry ten artifact bindings, because EAT shows something in that family can. The question is what every directly comparable multi-artifact, multi-signer, transparency-logged provenance standard chose when it faced this exact decision, and the answer is unanimous: a COSE or DSSE document envelope, never a JWS profile.
+
+Our current envelope is worse than either branch of that fork. It has the two properties DSSE names as reasons to avoid JWS (canonicalization before verification, and no authenticated payload-type or algorithm binding) while also lacking what JOSE and COSE both have: a specification other people implement, independent test suites, and a body of review. Being idiosyncratic is affordable for an internal format and expensive for a proposed standard.
+
+The counter-consideration is real: the canonical-JSON envelope is shipped, hardware-validated on SEV-SNP and TDX, and consumed by cmcp and ca2a through the published package. None of that is throwaway work, and Option B is a legitimate choice if the cost of churn outweighs the standards-path benefit. What is not legitimate is leaving the question unanswered, because a reviewer will find the mismatch between "SCITT-style transparency log" and "envelope of our own invention" and read the silence as an oversight.
+
+## Alternatives considered
+
+**Option A: COSE_Sign1 (recommended).** Aligns with SCITT, C2PA, and the direction of RATS. `alg` moves into the protected header and is covered by the signature. Receipts attach in the unprotected header, matching what we already do with `transparency_log_entry`. Cost: a CBOR dependency, a second signing and verification path, new conformance vectors, and a spec version bump. Consumers on 0.x break unless we support both envelopes through a deprecation window.
+
+**Option B: keep the canonical-JSON envelope and close the DSSE-cited gaps normatively.** Specify in Section 3.6 that the algorithm identifier is bound (either inside the pre-image or by a mandatory cross-check against `crypto_profile`, which 0.6.0 now implements), that an authenticated payload-type indicator is part of the pre-image, and that verifiers must reject unknown or absent algorithm identifiers rather than defaulting. Cheapest path, keeps every current consumer working, and is defensible as long as it is written down. Cost: SCITT profiling later becomes a second migration, and we carry the burden of arguing for a bespoke format in every standards conversation.
+
+**Option C: DSSE.** Solves payload-type binding and avoids canonicalization, and is proven by in-toto and SLSA. But it is not what SCITT mandates, so it does not buy the alignment that is the whole point of moving.
+
+**Option D: profile JWS/JOSE properly.** What the question actually asks for. Rejected on precedent, not capability: no comparable provenance standard took this route, and DSSE documented specific implementation hazards. It would also make Agent Manifest look like an access-token extension, which is exactly the category error the project exists to correct.
+
+**Option E: status quo, undocumented.** Rejected. The current state is a bespoke envelope described in the spec by the wrong name.
+
+## Consequences
+
+- Section 2.2 and Section 5 no longer describe the manifest signature as "JWS." That correction lands with this ADR regardless of which option is chosen.
+- If Option A is chosen: a spec version bump, a dual-envelope support window with a stated end, COSE variants of the `AM-VEC-*` conformance vectors, and coordination with cmcp and ca2a, which consume the verifier through the published package. The TypeScript SDK should then be written against the new envelope rather than ported to the old one and migrated twice.
+- If Option B is chosen: the hardening rules become normative text in Section 3.6, with negative conformance vectors for each (unbound algorithm, absent algorithm, payload-type substitution). `AM-VEC-020` is the first of these.
+- Either way, the answer to the standards question becomes: EAT and JWT for the attestation-token input, a signed document for the manifest, and no competition between the two layers.
+
+## References
+
+- [RFC 9711](https://www.rfc-editor.org/rfc/rfc9711.html) - The Entity Attestation Token (EAT), Standards Track, April 2025. Nested tokens: Section 4.2.18.3. Detached EAT Bundles: Section 5.
+- [RFC 9943](https://www.rfc-editor.org/rfc/rfc9943.html) - An Architecture for Trustworthy and Transparent Digital Supply Chains (SCITT), Standards Track, June 2026.
+- [DSSE background](https://github.com/secure-systems-lab/dsse/blob/master/background.md) - reasons against a JWS profile, and the Pre-Authentication Encoding rationale.
+- [C2PA Specification](https://spec.c2pa.org/) - JUMBF container with `COSE_Sign1_Tagged` claim signatures.
+- [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785.html) - JSON Canonicalization Scheme, the basis of the current pre-image. See ADR-0001.
+- ADR-0001 (RFC 8785 canonical JSON), ADR-0005 (ML-DSA-65 and hybrid signatures), spec Section 3.6.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -14,6 +14,7 @@ Each major design decision in the Agent Manifest Specification is recorded here 
 | [0008](0008-conformance-level-design.md) | Four conformance levels (0–3) rather than binary conformant/non-conformant | Accepted |
 | [0009](0009-spiffe-uri-agent-identity.md) | SPIFFE URIs as the canonical identity format for agent_id and issuer | Accepted |
 | [0010](0010-runtime-attestation-freshness-proofs.md) | Runtime attestation freshness proofs via caller-controlled REPORT_DATA | Accepted |
+| [0011](0011-signature-envelope.md) | The manifest is a signed document, not a JWT/JOSE profile | Proposed |
 
 To propose a new ADR, open a GitHub issue using the [spec change template](https://github.com/agentrust-io/agent-manifest/issues/new?template=spec_change.md) and follow the [ADR template](0000-template.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,14 @@ An Agent Manifest is a cryptographically signed record that anchors the 10 artif
 
 A signed JWT proves who called an API. An Agent Manifest proves who the agent was, what it was allowed to do, how it was built, what it decided, who approved it, and whether any of that changed between approval and execution.
 
+### Why not specify it as a JWT or JOSE profile?
+
+Because of what comparable standards chose, not because JWT is incapable. The IETF already picked the JWT/CWT route for attestation *tokens*: EAT ([RFC 9711](https://www.rfc-editor.org/rfc/rfc9711.html)) even supports nested tokens and detached claim sets. That is the right shape for "who is calling, right now," and an EAT is a valid input to a manifest's attestation block.
+
+Every multi-artifact provenance standard with a transparency log went the other way. SCITT ([RFC 9943](https://www.rfc-editor.org/rfc/rfc9943.html)), the closest analog to Agent Manifest, mandates COSE_Sign1 signed statements. DSSE, the envelope behind in-toto and SLSA, rejected a JWS profile in writing, citing implementation hazards and canonicalization as attack surface. C2PA uses COSE_Sign1 inside a JUMBF container.
+
+An Agent Manifest is that second kind of object: ten artifacts, several independent signers, hardware-report binding, a 90-day life, and a log receipt attached after signing. So the layering is EAT and JWT for the attestation-token input, and a signed document for the manifest. The two compose. See [ADR-0011](adr/0011-signature-envelope.md) for the full argument and the open question about which document envelope to standardize on.
+
 ### What is the agent attestation gap?
 
 Users have X.509 certificates, services have SPIFFE SVIDs, and containers have image digests, but AI agents have no unforgeable proof of which prompt, model, or policy defined their behavior. The attestation gap is the inability to prove, to a third party who does not trust the operator, that the running agent matches the approved one.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,6 +171,8 @@ nav:
       - ADR-0007 - JSON-Lines Revocation CRL: adr/0007-revocation-json-lines-crl.md
       - ADR-0008 - Conformance Level Design: adr/0008-conformance-level-design.md
       - ADR-0009 - SPIFFE URI for Agent Identity: adr/0009-spiffe-uri-agent-identity.md
+      - ADR-0010 - Runtime Attestation Freshness Proofs: adr/0010-runtime-attestation-freshness-proofs.md
+      - ADR-0011 - Signed Document, Not a JWT Profile: adr/0011-signature-envelope.md
   - Compliance:
       - Overview: compliance/index.md
       - EU AI Act: compliance/eu-ai-act.md

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -398,10 +398,19 @@ def verify_manifest(
     if sig_block:
         declared_profile = manifest.get("crypto_profile", "standard")
         permitted = PROFILE_SIGNATURE_ALGORITHMS.get(declared_profile)
-        declared_algorithm = sig_block.get("algorithm", "Ed25519")
+        declared_algorithm = sig_block.get("algorithm")
+        if declared_algorithm is None:
+            # spec 3.6: algorithm is REQUIRED and unauthenticated, so an absent
+            # identifier must not fall back to the classical default.
+            profile_downgrade = True
+            mismatches.append(MismatchDetail(
+                field="signature.algorithm",
+                expected_hash="<algorithm declared>",
+                actual_hash="<algorithm absent>",
+            ))
         # An unrecognised algorithm identifier is left to the signature
         # verification branch below, which reports it as such.
-        if (
+        elif (
             permitted is not None
             and declared_algorithm in KNOWN_SIGNATURE_ALGORITHMS
             and declared_algorithm not in permitted

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -474,6 +474,15 @@ def test_pq_profile_downgrade_detected_without_trusted_keys():
     assert any(d.field == "signature.algorithm" for d in result.mismatch_details)
 
 
+def test_absent_algorithm_does_not_default_to_ed25519():
+    m = base_manifest()
+    del m["signature"]["algorithm"]
+    result = verify_manifest(m, base_context(), store())
+    assert result.result == OverallResult.MISMATCH
+    assert result.signature_verified is False
+    assert any(d.field == "signature.algorithm" for d in result.mismatch_details)
+
+
 def test_standard_profile_with_ed25519_is_valid():
     result = verify_manifest(base_manifest(crypto_profile="standard"), base_context(), store())
     assert result.result == OverallResult.VALID

--- a/spec/agent-manifest-spec-v0.1.md
+++ b/spec/agent-manifest-spec-v0.1.md
@@ -110,7 +110,7 @@ An Agent Manifest is created once per agent deployment, updated when any bound a
 | Phase | Trigger | Actor | Output |
 |---|---|---|---|
 | 1. Authoring | Agent deployment configuration complete | Agent developer / platform team | Unsigned draft manifest (JSON-LD) |
-| 2. Signing | Human security reviewer approves configuration | Security officer / CISO delegate | Signed manifest (JWS with Ed25519 or ML-DSA-65) |
+| 2. Signing | Human security reviewer approves configuration | Security officer / CISO delegate | Signed manifest (detached Ed25519 or ML-DSA-65 signature over the RFC 8785 pre-image, section 3.6) |
 | 3. Attestation | Agent workload launches inside TEE | the Confidential Runtime | TEE attestation report binding manifest hash to hardware measurements |
 | 4. Verification | Agent crosses a trust boundary (tool call, delegation, audit) | Relying party (MCP server, auditor, regulator) | Verification result: VALID \| MISMATCH \| EXPIRED \| REVOKED \| INCOMPATIBLE_VERSION |
 | 5. Revocation | Any bound artifact changes, compromise detected, or TTL expires | Agent owner or the revocation service | Revocation record published to transparency log |
@@ -898,6 +898,10 @@ Every top-level field defined by this specification appears in exactly one row o
 
 Canonical serialization: The signature covers the RFC 8785 canonical JSON serialization of the named `signed_fields`, after applying the `hitl_record.approvals` normalization rule above. See section 2.3 for the complete canonicalization specification.
 
+Envelope note: this is a detached signature over a canonical-JSON pre-image, not a JWS or COSE structure. Whether v0.2 moves the envelope to COSE_Sign1 for alignment with RFC 9943 (SCITT) is an open decision recorded in ADR-0011; this section is normative until that decision lands.
+
+Algorithm binding (normative): the `signature` block is not part of the pre-image, so `signature.algorithm` is not covered by the signature. A verifier MUST therefore check the declared algorithm against the signed `crypto_profile` and MUST reject a manifest whose signature is weaker than the declared profile requires: a `post-quantum` manifest presented with a classical-only Ed25519 signature is a downgrade and MUST NOT verify (section 4.2). A signature stronger than the declared profile requires (for example ML-DSA-65 or hybrid under a `standard` profile) is permitted. A verifier MUST reject an unrecognized algorithm identifier rather than defaulting to Ed25519.
+
 Ed25519 validation rules <!-- CHANGED: CRYPTO-007 -->: Ed25519 implementations MUST use the cofactorless verification equation (`[S]B == R + [k]A`). Implementations MUST reject non-canonically encoded points (i.e., reject if the encoding does not round-trip through point decoding). Implementations MUST NOT use batch verification unless the batch verifier enforces the same cofactorless equation with canonical encoding checks. Implementations SHOULD use hedged signing (per draft-irtf-cfrg-det-sigs-with-noise) when signing keys reside in hardware signers subject to fault injection.
 
 Hybrid signature envelope <!-- CHANGED: CRYPTO-006 -->: When `algorithm` is `hybrid-Ed25519-ML-DSA-65`, both `classical_signature` and `pq_signature` MUST be present. Both signatures cover the identical RFC 8785 canonical JSON byte sequence of `signed_fields`. A verifier MUST verify both signatures and MUST reject the manifest if either fails. Reference: draft-ietf-pquip-hybrid-signature-spectrums for the binding model.
@@ -1165,7 +1169,7 @@ An evidence pack is a JSON document with the following structure:
 }
 ```
 
-`pack_hash` is the SHA-256 of the RFC 8785 canonical JSON of this document. The pack is signed using the TEE-sealed key, with the signature as a detached JWS appended as a top-level `pack_signature` field.
+`pack_hash` is the SHA-256 of the RFC 8785 canonical JSON of this document. The pack is signed using the TEE-sealed key, with the signature appended as a top-level `pack_signature` field in the same detached form as the manifest `signature` object (section 3.6).
 
 Access control for confidential payloads: Tool call payload fields in TRACE envelopes MUST be replaced with their SHA-256 hashes in packs served to unauthenticated verifiers. Full payloads are available only to verifiers presenting a valid SPIFFE SVID with an authorized role declared in the manifest's `policy_bundle`.
 
@@ -1606,7 +1610,9 @@ Target: Q1 2027. Submission to AAIF alongside the AGT donation.
 | CoSAI WS1 | `supply_chain` provenance aligns with CoSAI Working Stream 1 (AI supply chain security). Agent Manifest is a candidate for CoSAI WS1 recommendation. |
 | RFC 8785 (JCS) | All canonical JSON serialization uses RFC 8785. This is a normative dependency. |
 | RFC 9162 (Certificate Transparency v2) | Merkle tree construction and transparency log structures follow RFC 9162. |
-| RFC 9334 (RATS Architecture) | The attestation service plays the RATS Verifier role. Platform-native attestation reports are normalized to EAT (RFC 9528) for third-party verification. |
+| RFC 9334 (RATS Architecture) | The attestation service plays the RATS Verifier role. Platform-native attestation reports are normalized to EAT (RFC 9711) for third-party verification. |
+| RFC 9711 (EAT) | EAT is the attestation-token format for evidence about a running environment. Agent Manifest consumes an EAT as an input to the `attestation` block; it does not compete with it. The manifest itself is a signed document, not a token. See ADR-0011. |
+| RFC 9943 (SCITT) | The closest analog to Agent Manifest: signed statements plus a transparency log with receipts. Agent Manifest is intended as the agent-layer profile of this model, and the envelope alignment question is tracked in ADR-0011. |
 | RFC 9562 (UUID v7) | All UUID fields in the manifest use UUID v7 per RFC 9562. |
 
 ## 11. Appendix


### PR DESCRIPTION
Settles the "why not just a JWT extension?" question before the next standards conversation, and fixes what writing it turned up.

## The ADR

`docs/adr/0011-signature-envelope.md`, status **Proposed** because part 2 needs your sign-off.

It argues from precedent rather than from capability. EAT ([RFC 9711](https://www.rfc-editor.org/rfc/rfc9711.html), Standards Track, April 2025) is steelmanned rather than waved away: the IETF genuinely did pick the JWT/CWT route for attestation tokens, and EAT supports nested tokens (§4.2.18.3) and Detached EAT Bundles (§5). Any rebuttal resting on "JWT cannot do this" loses to anyone who knows EAT.

What decides it is that every comparable object went the other way:

| Standard | Object | Envelope |
|---|---|---|
| EAT (RFC 9711) | Attestation token about a caller | JWT / CWT profile |
| SCITT ([RFC 9943](https://www.rfc-editor.org/rfc/rfc9943.html), June 2026) | Signed statement + transparency receipt | COSE_Sign1, mandated |
| in-toto / SLSA | Multi-subject build attestation | DSSE, which rejected JWS in writing |
| C2PA | Multi-assertion content provenance | JUMBF + `COSE_Sign1_Tagged` |

**Part 1 (settled): the manifest is a signed document, not a bearer token.** An EAT is a valid *input* to the attestation block. The layers compose; we are not a competitor to the token layer.

**Part 2 (needs your call): the envelope encoding.** The ADR records something this project never actually decided. We are neither JOSE nor COSE. `signing_pre_image()` produces RFC 8785 canonical bytes and the signature is a bespoke detached JSON object, so the spec's two "JWS" references were simply wrong. That third position carries both properties DSSE cites as reasons to avoid JWS (canonicalize-before-verify, no authenticated payload-type or algorithm binding) while lacking a specification anyone else implements. Recommendation is Option A, migrate to COSE_Sign1; Option B, harden what we have and write the rules down normatively, is legitimate if the churn is not worth it. Section 3.6 is unchanged until you pick.

The argument is not hypothetical for us: the crypto-profile downgrade fixed in 0.6.0 is exactly the algorithm-agility bug DSSE warns about, and COSE_Sign1 excludes that class structurally by putting `alg` in the protected header.

## Also in this PR

**A second fail-open on the same field.** `signature.algorithm` is REQUIRED by spec 3.6 but sits outside the pre-image, and the verifier defaulted an *absent* identifier to Ed25519. 0.6.0 only caught a present-but-weaker one. A missing algorithm is now a mismatch, with a test.

**Three factual errors in the spec.** Sections 2.2 and 5 called the signature "JWS" (never true, there is no JOSE dependency). Section 10.4 cited EAT as RFC 9528, which is EDHOC; EAT is RFC 9711.

**Section 3.6 gains a normative algorithm-binding rule** so the verifier's behaviour is specified rather than merely implemented, and Section 10.4 gains RFC 9711 and RFC 9943 rows positioning Agent Manifest as the agent-layer profile of the SCITT model.

**FAQ + nav.** `docs/index.md` answers "why not specify it as a JWT or JOSE profile?" in short form. The mkdocs nav was missing ADR-0010 as well as 0011; both added.

## Verification

Every RFC citation was fetched from rfc-editor.org rather than recalled, including the two that anchor the argument. That check earned its keep: it caught the RFC 9528 error, and the DSSE and C2PA quotes were pulled from source too.

- `pytest`: 618 passed, 18 skipped
- `mypy`, `ruff`: clean

## Note, not addressed here

ADR-0005 describes `CryptoProfile` values as `standard` / `post_quantum` / `hybrid`, but the spec and the code use `standard` / `post-quantum` with hybrid expressed as a signature algorithm. ADR-0005 also says a verifier lacking ML-DSA support must reject a hybrid manifest with `INCOMPATIBLE_VERSION`, which is not what the verifier does. Worth reconciling, but it is a separate decision from this one.