### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-07-27
+
+Shares the hardware-validated TDX quote-signature parse so the sibling repos can stop carrying their own copies of the offsets, and specifies the v0.2 COSE envelope. No change to manifest signing or verification behaviour.
+
 ### Added
 
 **[SPEC]** **COSE envelope specified for manifest version 0.2**: [`spec/agent-manifest-cose-envelope-v0.2.md`](spec/agent-manifest-cose-envelope-v0.2.md), phase 1 of the ADR-0011 migration ([#243](https://github.com/agentrust-io/agent-manifest/issues/243)). `COSE_Sign1` (tag 18), or `COSE_Sign` (tag 98) with two signers for a hybrid Ed25519 + ML-DSA-65 signature so that both entries covering one payload is structural rather than an application rule. Protected header carries `alg` (`-8` / `-49`, RFC 9053 and RFC 9964), `kid`, `content type` (3), and `typ` (16, RFC 9596); the payload is the RFC 8785 canonical JSON of the manifest, carried inline; the SCITT receipt attaches as `receipts` (unprotected label 394, RFC 9942 receipts). Media types `application/agent-manifest+json` (payload) and `application/agent-manifest+cose` (object), standards-tree, registration pending.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.6.1"
+version = "0.7.0"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Publishes the shared TDX parser so cmcp and ca2a can stop carrying their own copies of the DCAP v4 offsets.

## Why now

`parse_tdx_quote_signature()` landed in #247 but is unreleased, so neither sibling repo can consume it. Both still have the flat-parse bug it fixes:

- cmcp: `src/cmcp_verify/tdx.py`
- ca2a: `src/ca2a_runtime/tee/tdx.py` **and** `src/ca2a_verify/tdx.py`

Real DCAP v4 quotes nest the QE material under a type-6 `QE_REPORT_CERTIFICATION_DATA` header. A flat parse reads the QE report six bytes early and therefore rejects every genuine quote. Releasing this lets both repos fix it by deletion rather than by writing a third hand-rolled parser, which is what is happening on cmcp's in-flight branch right now.

## Contents

**Added**
- `parse_tdx_quote_signature()` and `TdxQuoteSignature`, the hardware-validated DCAP v4 signature-section parse, written against a real GCP C3 quote (#247)
- `spec/agent-manifest-cose-envelope-v0.2.md`, the v0.2 COSE envelope specification, ADR-0011 phase 1 (#248)

Minor rather than patch: new exported API. No change to manifest signing or verification behaviour, and manifest version 0.1 is untouched.

## Verification

- 623 passed, 18 skipped
- `python -m build` plus `twine check`: both artifacts PASSED for 0.7.0

After merge: tag `python-v0.7.0` for the OIDC publish, then confirm from the installed PyPI package before touching the sibling repos.