### PR TITLE
fix(tdx): reject declared lengths that overrun the quote buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Fixed
+
+**[SDK]** `parse_tdx_quote_signature()` now rejects a quote whose declared lengths overrun the buffer instead of silently parsing a shorter value. Four lengths come from the quote, which is untrusted input: the signature-data size, `cert_size`, `qe_auth_size`, and `pck_size`. Python slicing clamps rather than overreading, so an inflated length previously yielded a short slice and parsing continued against whatever fit. No read was ever out of bounds and the downstream signature check would fail, so this is fail-closed hardening rather than a memory-safety fix, but a verifier should reject a quote that declares 400 bytes and supplies 300 rather than appraise the 300. Found while reviewing the same parse in cmcp#420, which shares the derivation.
+
 ## [0.7.0] — 2026-07-27
 
 Shares the hardware-validated TDX quote-signature parse so the sibling repos can stop carrying their own copies of the offsets, and specifies the v0.2 COSE envelope. No change to manifest signing or verification behaviour.

--- a/python/src/agent_manifest/_tdx_verify.py
+++ b/python/src/agent_manifest/_tdx_verify.py
@@ -123,6 +123,17 @@ def parse_tdx_quote_signature(quote: bytes) -> TdxQuoteSignature:
     off = _QUOTE_HEADER_LEN + _TD_REPORT_LEN
     (auth_size,) = struct.unpack_from("<I", quote, off)
     off += 4
+    # Every length below is declared by the quote, which is untrusted input.
+    # Python slicing clamps instead of overreading, so an overstated length
+    # yields a short value rather than an error unless it is checked. A parser
+    # that fails closed must reject the mismatch: silently accepting 300 bytes
+    # where the quote declared 400 means verifying something other than what
+    # the producer said it signed.
+    if off + auth_size > len(quote):
+        raise TdxVerificationError(
+            f"quote declares {auth_size} bytes of signature data, "
+            f"{len(quote) - off} available"
+        )
     auth = quote[off:off + auth_size]
     if len(auth) < 134:
         raise TdxVerificationError("truncated quote signature data")
@@ -134,6 +145,11 @@ def parse_tdx_quote_signature(quote: bytes) -> TdxQuoteSignature:
         raise TdxVerificationError(
             f"unexpected certification data type {cert_type} (expected QE report)"
         )
+    if 134 + cert_size > len(auth):
+        raise TdxVerificationError(
+            f"quote declares {cert_size} bytes of QE certification data, "
+            f"{len(auth) - 134} available"
+        )
     cert_data = auth[134:134 + cert_size]
     if len(cert_data) < 448 + 6:
         raise TdxVerificationError("truncated QE certification data")
@@ -143,6 +159,11 @@ def parse_tdx_quote_signature(quote: bytes) -> TdxQuoteSignature:
     o2 = _SGX_REPORT_LEN + 64
     (qe_auth_size,) = struct.unpack_from("<H", cert_data, o2)
     o2 += 2
+    if o2 + qe_auth_size + 6 > len(cert_data):
+        raise TdxVerificationError(
+            f"quote declares {qe_auth_size} bytes of QE auth data, "
+            f"{max(0, len(cert_data) - o2 - 6)} available before the PCK header"
+        )
     qe_auth = cert_data[o2:o2 + qe_auth_size]
     o2 += qe_auth_size
     pck_cert_type, pck_size = struct.unpack_from("<HI", cert_data, o2)
@@ -150,6 +171,11 @@ def parse_tdx_quote_signature(quote: bytes) -> TdxQuoteSignature:
     if pck_cert_type != _CERT_TYPE_PCK_CHAIN:
         raise TdxVerificationError(
             f"unexpected PCK certification type {pck_cert_type} (expected PEM chain)"
+        )
+    if o2 + pck_size > len(cert_data):
+        raise TdxVerificationError(
+            f"quote declares {pck_size} bytes of PCK chain, "
+            f"{len(cert_data) - o2} available"
         )
 
     return TdxQuoteSignature(

--- a/python/tests/test_tdx_verify.py
+++ b/python/tests/test_tdx_verify.py
@@ -187,3 +187,38 @@ def test_parse_signature_rejects_wrong_certification_type():
     tampered[off:off + 2] = (5).to_bytes(2, "little")  # PCK chain where a QE report belongs
     with pytest.raises(TdxVerificationError, match="certification data type"):
         parse_tdx_quote_signature(bytes(tampered))
+
+
+def test_parse_signature_rejects_overstated_cert_size():
+    """A declared length longer than the buffer must fail, not silently shorten.
+
+    Python slicing clamps rather than overreading, so an inflated `cert_size`
+    used to yield a short `cert_data` and parsing continued against whatever
+    fit. A fail-closed parser rejects the mismatch: verifying 300 bytes where
+    the quote declared 400 is verifying something other than what the producer
+    said it signed.
+    """
+    quote, _ = _build_quote(hashlib.sha256(b"certsize").digest())
+    off = 48 + 584 + 4 + 130  # cert_size, just after the 2-byte cert_type
+    tampered = bytearray(quote)
+    tampered[off:off + 4] = (0xFFFF).to_bytes(4, "little")
+    with pytest.raises(TdxVerificationError, match="QE certification data"):
+        parse_tdx_quote_signature(bytes(tampered))
+
+
+def test_parse_signature_rejects_overstated_auth_size():
+    quote, _ = _build_quote(hashlib.sha256(b"authsize").digest())
+    off = 48 + 584  # the uint32 signature-data length
+    tampered = bytearray(quote)
+    tampered[off:off + 4] = (0xFFFFF).to_bytes(4, "little")
+    with pytest.raises(TdxVerificationError, match="signature data"):
+        parse_tdx_quote_signature(bytes(tampered))
+
+
+def test_parse_signature_rejects_overstated_qe_auth_size():
+    quote, _ = _build_quote(hashlib.sha256(b"qeauth").digest())
+    off = 48 + 584 + 4 + 134 + 384 + 64  # qe_auth_size, inside the cert data
+    tampered = bytearray(quote)
+    tampered[off:off + 2] = (0xFFFF).to_bytes(2, "little")
+    with pytest.raises(TdxVerificationError, match="QE auth data"):
+        parse_tdx_quote_signature(bytes(tampered))


### PR DESCRIPTION
Found while reviewing [cmcp#420](https://github.com/agentrust-io/cmcp/pull/420), which derives the same parse independently and has the same gap. I offered the fix there, so here it is on the shared side.

## The gap

Four lengths in the TDX signature section are declared by the quote, which is untrusted input: the signature-data size, `cert_size`, `qe_auth_size`, and `pck_size`. Each was used to slice without checking it fits.

Python slicing clamps rather than overreading, so an inflated length produced a **short slice** and parsing continued against whatever happened to fit. Nothing read out of bounds, and the downstream signature check would fail, so this is fail-closed hardening rather than a memory-safety fix.

It is still worth rejecting. Appraising 300 bytes where the producer declared 400 means verifying something other than what they said they signed, and surfacing that as a generic signature failure hides the actual cause from whoever has to debug it. The new errors say which length was wrong and how much was available.

## Tests

Three, each tampering one declared length in an otherwise valid quote built by the suite's own helper:

- overstated `cert_size`
- overstated signature-data size
- overstated `qe_auth_size`

626 passed, 18 skipped. mypy, ruff, bandit clean.

`pck_size` gets the same check but no separate test: with the preceding checks in place it is unreachable from a single-field tamper, and a test that cannot fail before the fix is not worth having.