### PR TITLE
docs: update the TRACE profile URI in the attestation tutorial

### DIFF
--- a/docs/tutorials/hardware-attestation.md
+++ b/docs/tutorials/hardware-attestation.md
@@ -176,7 +176,7 @@ assert provider.verify_manifest_in_report(report, manifest)
 
 ```json
 {
-  "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
+  "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
   "iat": 1749120000,
   "manifest_hash": "sha256:e3b0c44...",
   "audit_chain_root": "sha256:a1b2c3...",


### PR DESCRIPTION
One line missed by the org-wide sweep. `docs/tutorials/hardware-attestation.md` shows a TRACE record carrying `tag:agentrust.io,2026:trace-v0.1`.

That identifier named a domain the project never controlled and has been corrected upstream to `tag:agentrust-io.com,2026:trace-v0.2` (agentrust-io/trace-spec#107). A tutorial is the worst place to leave an invalid identifier, since it exists to be copied.