### PR TITLE
docs: retarget the standards body from AAIF to CoSAI WS4

### DIFF
--- a/ANTITRUST.md
+++ b/ANTITRUST.md
@@ -1,6 +1,6 @@
 # Antitrust Policy
 
-Agent Manifest is an open specification project hosted under the agentrust-io organization and targeting donation to the Agentic AI Foundation (AAIF) under the Linux Foundation. Participation in this project is subject to antitrust and competition laws.
+Agent Manifest is an open specification project hosted under the agentrust-io organization and targeting contribution to the Coalition for Secure AI (CoSAI), Working Stream 4, an OASIS Open Project. Participation in this project is subject to antitrust and competition laws.
 
 ## Prohibited topics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Changed
+
+**[SPEC]** **Target standards body retargeted from AAIF to CoSAI Working Stream 4**, an OASIS Open Project, following the Phase 1 RFC in [cosai-oasis/ws4-secure-design-agentic-systems#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149). Affects the spec header, section 3.1 (who assigns the canonical `@context` URL), section 3.2.5 (scanner registry), section 10.1 through 10.3, and the governance set: `CHARTER.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `ANTITRUST.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `README.md`. No normative data-model, cryptographic, or conformance change; nothing about how a manifest is signed or verified moves.
+
+Three things did not change mechanically with the rest. The conformance test suite in section 8.2 was described as shipping "alongside the AGT donation to AAIF" and is now decoupled, because AGT's standards destination is governed separately and is not set by this charter. Two AAIF references are retained deliberately: the `AAIF Spec Enhancement Proposal (SEP)` route in section 6.3 and the `MCP (Anthropic / AAIF)` row in section 10.4 both describe MCP's own governance home, not this specification's target. And the IP terms are stated as consequences rather than commitments: the OASIS Open Projects IPR Policy requires a CLA plus a patent non-assert on non-trivial contributions, which is stricter than the DCO-only regime in force today, so `CHARTER.md` section 4 records that it takes effect only on WS4 acceptance and that the founding maintainer's terms under it need counsel sign-off first. Trademark transfer terms are marked to be determined rather than asserted.
+
 ### Fixed
 
 **[SDK]** `parse_tdx_quote_signature()` now rejects a quote whose declared lengths overrun the buffer instead of silently parsing a shorter value. Four lengths come from the quote, which is untrusted input: the signature-data size, `cert_size`, `qe_auth_size`, and `pck_size`. Python slicing clamps rather than overreading, so an inflated length previously yielded a short slice and parsing continued against whatever fit. No read was ever out of bounds and the downstream signature check would fail, so this is fail-closed hardening rather than a memory-safety fix, but a verifier should reject a quote that declares 400 bytes and supplies 300 rather than appraise the 300. Found while reviewing the same parse in cmcp#420, which shares the derivation.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,7 +1,7 @@
 # Technical Charter — Agent Manifest
 
-**Proposed donation target**: Agentic AI Foundation (AAIF) under the Linux Foundation  
-**Status**: Pre-donation draft — effective upon AAIF acceptance  
+**Proposed contribution target**: Coalition for Secure AI (CoSAI), Working Stream 4, an OASIS Open Project  
+**Status**: Pre-contribution draft, effective upon CoSAI WS4 acceptance. Phase 1 review is open in [WS4 issue #149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149); no contribution has been proposed yet.  
 **Version**: 0.1 (aligned with spec v0.1)
 
 ---
@@ -23,7 +23,7 @@ Out of scope: runtime policy enforcement (see Agent Governance Toolkit), MCP pro
 
 ## 3. Technical Steering Committee
 
-Upon AAIF acceptance, governance transitions from the current single-maintainer model to a Technical Steering Committee (TSC).
+Upon CoSAI WS4 acceptance, governance transitions from the current single-maintainer model to a Technical Steering Committee (TSC), aligned with the OASIS Open Projects governance model.
 
 **Composition**: 3–7 members. No single organization may hold more than 40% of TSC seats. The founding Project Lead (Imran Siddique, OPAQUE Systems) holds one permanent founding seat for the v1.0 ratification cycle, after which all seats are elected.
 
@@ -40,15 +40,17 @@ Upon AAIF acceptance, governance transitions from the current single-maintainer 
 
 ## 4. Intellectual Property Policy
 
-All contributions to the project must be made under the Apache License, Version 2.0. Contributors must sign off commits with the Developer Certificate of Origin (DCO). A Contributor License Agreement (CLA) may be required before AAIF acceptance if the foundation's IP policy requires it — contributors will be notified before any CLA requirement takes effect.
-
-No contribution may incorporate material covered by a patent the contributor is unwilling to license royalty-free to all implementations of the specification.
+All contributions to the project must be made under the Apache License, Version 2.0. Contributors must sign off commits with the Developer Certificate of Origin (DCO).
 
 The specification itself is licensed under CC-BY-4.0 to maximize adoption across implementations in any language or platform.
 
+No contribution may incorporate material covered by a patent the contributor is unwilling to license royalty-free to all implementations of the specification.
+
+**Consequences of the CoSAI target, not yet in effect.** The OASIS Open Projects IPR Policy that governs CoSAI requires contributors to sign a Contributor License Agreement and, for non-trivial contributions, a patent non-assert, releasing source code under Apache-2.0 and documentation and data under CC-BY-4.0. That is a stricter regime than DCO alone. It takes effect for this project only if and when WS4 accepts a contribution, and contributors will be notified before any CLA requirement applies. The founding maintainer's own participation terms under that policy, including how the non-assert interacts with existing Opaque patent filings, require counsel sign-off before any contribution is filed.
+
 ## 5. Trademark Policy
 
-"Agent Manifest" as a specification name and the agentrust-io GitHub organization name are currently held by the founding maintainer. Upon AAIF acceptance, trademark ownership transfers to AAIF/Linux Foundation under their standard trademark policy. Until transfer, use of the name "Agent Manifest" to describe a conformant implementation is permitted without restriction. Use to describe a non-conformant implementation is not permitted.
+"Agent Manifest" as a specification name and the agentrust-io GitHub organization name are currently held by the founding maintainer. Upon CoSAI WS4 acceptance, name and mark ownership transfer on the terms set by the OASIS Open Projects policy; the specific terms are to be determined with counsel before a contribution is filed and are not asserted here. Until transfer, use of the name "Agent Manifest" to describe a conformant implementation is permitted without restriction. Use to describe a non-conformant implementation is not permitted.
 
 ## 6. Conformance
 
@@ -69,17 +71,20 @@ This project is designed to compose with, not replace:
 
 ## 8. Amendments
 
-Amendments to this charter require a two-thirds TSC majority and a 30-day public comment period. Before AAIF acceptance, amendments require Project Lead approval and 14-day notice to contributors.
+Amendments to this charter require a two-thirds TSC majority and a 30-day public comment period. Before CoSAI WS4 acceptance, amendments require Project Lead approval and 14-day notice to contributors.
 
-## 9. Foundation Transition
+## 9. Standards Body Transition
 
-This project is targeting donation to the Agentic AI Foundation (AAIF) alongside the Agent Governance Toolkit. The transition timeline:
+This project is targeting contribution to CoSAI Working Stream 4 (Secure Design Patterns for Agentic Systems), an OASIS Open Project. The timeline:
 
 | Milestone | Target |
 |-----------|--------|
 | v0.1 developer preview | June 2026 |
-| AAIF working group formation | Q3 2026 |
-| AAIF submission (spec + conformance suite) | September 2026 |
-| v1.0 ratification under AAIF governance | 2027 |
+| WS4 Phase 1 review (RFC open, feedback collection) | July to August 9, 2026 |
+| Revised spec returned to WS4 with review dispositions | August 2026 |
+| WS4 decision on formal contribution | Q4 2026 |
+| v1.0 ratification under CoSAI governance | 2027 |
 
-Until AAIF acceptance, this charter describes the intended governance. The GOVERNANCE.md file describes the current operating governance.
+Phase 1 is a review pass, not a request to accept. Until WS4 accepts a contribution, this charter describes the intended governance and the GOVERNANCE.md file describes the current operating governance.
+
+The Agent Governance Toolkit is governed separately and its own standards destination is not set by this charter.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Agent Manifest is an open specification and reference SDK. Contributions are wel
 
 ## Before you start
 
-The spec is in active design-partner review ahead of AAIF submission. Breaking spec changes (field renames, schema incompatibilities, conformance level changes) require an issue and discussion before a PR. Non-breaking additions and bug fixes can go straight to a PR.
+The spec is in active design-partner review, and in CoSAI WS4 Phase 1 review ahead of a proposed contribution to WS4. Breaking spec changes (field renames, schema incompatibilities, conformance level changes) require an issue and discussion before a PR. Non-breaking additions and bug fixes can go straight to a PR.
 
 ## DCO sign-off
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,9 +20,9 @@ Full commit and merge rights on designated package areas. PyPI publish rights on
 
 ### Project Lead
 
-Final decision authority on specification changes, AAIF submission scope, conformance test disputes, and Maintainer appointments. Currently: Imran Siddique (OPAQUE Systems).
+Final decision authority on specification changes, standards contribution scope, conformance test disputes, and Maintainer appointments. Currently: Imran Siddique (OPAQUE Systems).
 
-**Succession**: If the Project Lead is unavailable for 30+ days without notice, the active Maintainers vote to appoint an interim lead. Succession plan will be formalized before AAIF v1.0 submission with a Technical Steering Committee structure.
+**Succession**: If the Project Lead is unavailable for 30+ days without notice, the active Maintainers vote to appoint an interim lead. Succession plan will be formalized before v1.0 contribution to CoSAI with a Technical Steering Committee structure.
 
 ## Decision-making
 
@@ -40,7 +40,7 @@ Maintainers must disclose any commercial interest in a proposal before participa
 
 ## Foundation transition
 
-This project is targeting donation to the Agentic AI Foundation (AAIF) under the Linux Foundation alongside the Agent Governance Toolkit. On acceptance, governance will transition to a TSC structure defined in [CHARTER.md](CHARTER.md) (to be added before AAIF submission). Until then, this document is the governance authority.
+This project is targeting contribution to CoSAI Working Stream 4, an OASIS Open Project. On acceptance, governance will transition to a TSC structure defined in [CHARTER.md](CHARTER.md). Until then, this document is the governance authority.
 
 ## Amendments
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,7 @@
 |------|-------------|--------|------|
 | Imran Siddique | OPAQUE Systems | @agentrust-io | Project Lead, Spec Author |
 
-The Project Lead has final decision authority on specification changes, AAIF submission scope, and maintainer appointments.
+The Project Lead has final decision authority on specification changes, standards contribution scope, and maintainer appointments.
 
 ## How to become a maintainer
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ signed = sign_manifest(manifest, key=signing_key)
 
 ## Standards alignment
 
-Targeting the [Agentic AI Foundation (AAIF)](https://agenticai.foundation) at the Linux Foundation. 197 conformance tests against the formal specification. Integrates with [TRACE](https://github.com/agentrust-io/trace-spec) for hardware-rooted attestation.
+Targeting [CoSAI](https://www.coalitionforsecureai.org/) Working Stream 4, an OASIS Open Project. 197 conformance tests against the formal specification. Integrates with [TRACE](https://github.com/agentrust-io/trace-spec) for hardware-rooted attestation.
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ Launching at Confidential Computing Summit, June 23 2026.
 - Post-quantum profile: ML-DSA-65 (NIST FIPS 204), SHAKE-256 (via `[pq]` extra)
 - Integration architecture documented: AGT, cMCP, MCP
 
-**Not in v0.1**: TypeScript SDK, Go SDK, .NET SDK, streaming decision trace, multi-agent delegation UI, AAIF submission.
+**Not in v0.1**: TypeScript SDK, Go SDK, .NET SDK, streaming decision trace, multi-agent delegation UI, CoSAI WS4 contribution.
 
 ## Next — v0.2 (Q3 2026)
 
@@ -28,13 +28,13 @@ Driven by community and early adopter feedback from the CC Summit period. Curren
 
 v0.2 will go through the RFC process (14-day comment period) for any normative changes.
 
-## Later — v1.0 AAIF standard (2027)
+## Later — v1.0 CoSAI standard (2027)
 
-- Full TSC governance under AAIF
+- Full TSC governance under CoSAI / OASIS Open
 - All open spec ambiguities resolved
 - Complete conformance certification program
 - Multi-language SDK parity (Python, TypeScript, Go, .NET, Rust)
-- AAIF-assigned canonical `@context` URL replacing the provisional v0.1 URL
+- CoSAI-assigned canonical `@context` URL replacing the provisional v0.1 URL
 - Post-quantum profile as first-class (not optional extra)
 - Streaming decision trace binding
 - Internationalization: docs in Japanese, Simplified Chinese, Korean

--- a/docs/spec-overview.md
+++ b/docs/spec-overview.md
@@ -26,7 +26,7 @@ The Agent Manifest Specification v0.1 is a formal RFC 2119 document defining the
 | 7  -  Threat Model | 10 threat classes addressed; explicit out-of-scope threats |
 | 8  -  Conformance | Levels 0–3; 197 conformance tests across 5 modules |
 | 9  -  Regulatory Mapping | EU AI Act, DORA, GDPR, HIPAA, PCI-DSS, FedRAMP |
-| 10  -  Roadmap | v0.2 targets, v1.0 AAIF submission |
+| 10  -  Roadmap | v0.2 targets, v1.0 CoSAI WS4 contribution |
 
 ## Conformance test modules
 

--- a/python/README.md
+++ b/python/README.md
@@ -138,7 +138,7 @@ manifest fails closed as `UNVERIFIABLE` and the command exits 1.
 
 The full Agent Manifest Specification v0.1 is at [`spec/agent-manifest-spec-v0.1.md`](https://github.com/agentrust-io/agent-manifest/blob/main/spec/agent-manifest-spec-v0.1.md).
 
-Being submitted to the [Agentic AI Foundation (AAIF)](https://agenticai.foundation) under the Linux Foundation alongside AGT.
+Proposed for contribution to [CoSAI](https://www.coalitionforsecureai.org/) Working Stream 4, an OASIS Open Project.
 
 ## License
 

--- a/spec/agent-manifest-spec-v0.1.md
+++ b/spec/agent-manifest-spec-v0.1.md
@@ -8,7 +8,7 @@
 | Status | Draft v0.1 - Proposed Open Standard |
 | Date | June 2026 |
 | Relationship | Extends: OWASP ASI 2026 \| Aligns: CoSAI WS1, EU AI Act Art. 14/15 |
-| Target Standards Body | Agentic AI Foundation (AAIF) - Linux Foundation |
+| Target Standards Body | Coalition for Secure AI (CoSAI) WS4 - OASIS Open |
 
 ---
 
@@ -236,7 +236,7 @@ All fields annotated as UUID v7 MUST conform to RFC 9562 Section 5.7. The string
 The `agent_id` path structure `/agent/<name>/<instance>` shown in examples is a convention, not a requirement. Trust domain must be lowercase `[a-z0-9._-]`; path segments may use `[a-zA-Z0-9._-]`. UUID v7 instance identifiers (hyphens permitted in path segments) are valid. Example: `spiffe://trust.example/agent/payments-processor/01926b4c-1234-7abc-9def-000000000001`.
 
 <!-- CHANGED: SCHEMA F-15/@context - normative note on provisional URL -->
-The `@context` URL `https://agentmanifest.agentrust.io/v0.1/context.json` is provisional for the v0.1 draft period. The AAIF working group will assign the canonical URL prior to v1.0 ratification. Implementations MUST support the canonical AAIF URL when it is assigned, and SHOULD support the v0.1 draft URL for backward compatibility with pre-ratification manifests.
+The `@context` URL `https://agentmanifest.agentrust.io/v0.1/context.json` is provisional for the v0.1 draft period. The CoSAI WS4 working stream will assign the canonical URL prior to v1.0 ratification. Implementations MUST support the canonical CoSAI-assigned URL when it is assigned, and SHOULD support the v0.1 draft URL for backward compatibility with pre-ratification manifests.
 
 <!-- CHANGED: SCHEMA F-19 - normative artifact-to-field mapping table -->
 Artifact-to-field mapping (for Level 2 "all 10 artifacts bound" conformance):
@@ -439,7 +439,7 @@ Poisoning scan rules: <!-- CHANGED: SCHEMA F-17 -->
 - A manifest with `poisoning_scan.result: flagged` MUST NOT be issued as VALID. The manifest MUST be held in `INCOMPLETE` state until flagged documents are removed and a clean scan completed.
 - For Level 1 conformance and above, `poisoning_scan.result: not-scanned` is NOT permitted. The corpus MUST be scanned before the manifest is signed.
 - For Level 0, `not-scanned` is permitted but MUST surface as a warning in the verification result.
-- `scanner_version` MUST include the scanner tool name and semantic version string in the format `"<tool-name>/<semver>"` (e.g., `"lakera-scan/1.4.2"`). When the AAIF scanner registry is established in v0.2, implementations SHOULD reference a registered scanner identifier.
+- `scanner_version` MUST include the scanner tool name and semantic version string in the format `"<tool-name>/<semver>"` (e.g., `"lakera-scan/1.4.2"`). When the CoSAI WS4 scanner registry is established in v0.2, implementations SHOULD reference a registered scanner identifier.
 
 #### 3.2.6 Memory Baseline Binding
 
@@ -1442,7 +1442,7 @@ A conformant Agent Manifest implementation MUST pass all tests in the reference 
 | AM-VERIFY | 52 tests | Verification endpoint: result schema, mismatch detection, delegation chain validation, HITL verification, revocation status check, error response schemas. |
 | AM-COMPAT | 31 tests | AGT integration, cMCP integration, MCP protocol extension, SLSA provenance binding. |
 
-Total: 197 conformance tests. The test suite will be published as an open-source repository alongside the AGT donation to AAIF. Conformance claims MUST reference a specific test suite version and MUST include a passing test run against the reference implementation.
+Total: 197 conformance tests. The test suite is published as an open-source repository under the agentrust-io organization and moves with the specification to its target standards body. Conformance claims MUST reference a specific test suite version and MUST include a passing test run against the reference implementation.
 
 ## 9. Regulatory Mapping
 
@@ -1569,7 +1569,7 @@ The Art. 13 row in section 9.1 cross-references `operational_lifecycle.expected_
 - Verification API specification with error schemas and revocation protocol
 - TEE attestation binding protocol with per-platform profiles
 - Conformance test suite (197 tests)
-- Reference implementation targeting AAIF + cMCP
+- Reference implementation targeting CoSAI WS4 + cMCP
 
 ### 10.2 Version 0.2
 
@@ -1583,20 +1583,22 @@ Targets: Q3 2026. Driven by community and early adopter feedback collected durin
 - Federated verification - cross-organizational manifest verification without shared infrastructure
 - A2A delegation chain revocation - how to invalidate a mid-chain delegation without revoking the full manifest
 - OCC RFI tracking - align to any agentic AI governance guidance issued by OCC, FDIC, or the Federal Reserve following the 2026 RFI process
-- AAIF scanner registry - define a registered scanner identifier format for `poisoning_scan.scanner_version`
+- CoSAI WS4 scanner registry - define a registered scanner identifier format for `poisoning_scan.scanner_version`
 
-### 10.3 Version 1.0 - Proposed AAIF Standard
+### 10.3 Version 1.0 - Proposed CoSAI Standard
 
-<!-- CHANGED: F-06 - added @context URL transfer as AAIF donation condition -->
+<!-- CHANGED: F-06 - added @context URL transfer as a donation condition -->
+<!-- CHANGED: target standards body retargeted from AAIF to CoSAI WS4 (OASIS Open) -->
 
-Target: Q1 2027. Submission to AAIF alongside the AGT donation.
+Target: Q1 2027. Contribution to CoSAI Working Stream 4 (Secure Design Patterns for Agentic Systems) as an OASIS Open Project deliverable. Sequencing is set by WS4: the Phase 1 review opened in [WS4 issue #149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) and no contribution is proposed until that review closes and WS4 decides.
 
 - Finalized data model with no breaking changes from v0.2
 - Interoperability validated with at least three independent implementations
-- AAIF working group review and endorsement
-- Reference implementation published as AAIF project
+- CoSAI WS4 review and endorsement
+- Reference implementation contributed as a CoSAI Open Project deliverable
 - Conformance certification program defined
-- Transfer of `agentmanifest.agentrust.io` (or successor provisional domain) to AAIF-controlled infrastructure as a condition of v1.0 acceptance. The canonical `@context` URL will be updated to an AAIF-controlled namespace at this point.
+- Transfer of `agentmanifest.agentrust.io` (or successor provisional domain) to CoSAI/OASIS-controlled infrastructure as a condition of v1.0 acceptance. The canonical `@context` URL will be updated to a CoSAI-controlled namespace at this point.
+- Opaque's participation terms under the OASIS Open Projects IPR Policy, including the CLA and the patent non-assert covering non-trivial contributions, reviewed and signed off by counsel before any contribution is filed. See [CHARTER.md](../CHARTER.md) section 4.
 
 ### 10.4 Relationship to Existing Standards
 


### PR DESCRIPTION
Retargets the v1.0 standards path from AAIF to **CoSAI Working Stream 4** (Secure Design Patterns for Agentic Systems), an OASIS Open Project, following the Phase 1 RFC in [cosai-oasis/ws4-secure-design-agentic-systems#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149).

The repo named AAIF as the donation target in 10 files. That directly contradicted the RFC, which asks WS4 to consider accepting this spec while §10.3 read "Proposed AAIF Standard." A reviewer working through the nine review tracks would have found it.

**No normative change.** Data model, cryptographic protocols, verification semantics, and conformance levels are untouched. Nothing about how a manifest is signed or verified moves.

## Three deliberate departures from a mechanical find-and-replace

**1. §8.2 decoupled from AGT.** The conformance suite was described as shipping "alongside the AGT donation to AAIF." AGT's standards destination is governed separately and is not set by this charter, so the suite is now described as moving with the specification.

**2. Two AAIF references retained.** Both describe MCP's governance home, not this spec's target, and would have been wrong to change:
- §6.3 the `AAIF Spec Enhancement Proposal (SEP)` route for MCP `Implementation` fields
- §10.4 the `MCP (Anthropic / AAIF)` relationship row

**3. IP and trademark terms stated as consequences, not commitments.** This is the part that needs a look before merge.

CoSAI runs under the [OASIS Open Projects IPR Policy](https://github.com/cosai-oasis/oasis-open-project/blob/main/GOVERNANCE.md): contributors sign a CLA and, for non-trivial contributions, a **patent non-assert**, releasing code under Apache-2.0 and docs and data under CC-BY-4.0. That is stricter than the DCO-only regime in force today.

Rather than assert terms nobody has agreed to, `CHARTER.md` §4 now records the policy, states that it takes effect only if and when WS4 accepts a contribution, and adds that the founding maintainer's participation terms under it, including how the non-assert interacts with existing Opaque patent filings, require counsel sign-off before any contribution is filed. §10.3 of the spec carries the same gate. Trademark transfer is marked to be determined rather than asserted.

## Also updated

`CHARTER.md` §9 timeline now matches the actual CoSAI sequence (Phase 1 review to Aug 9 2026, revised spec returned Aug 2026, WS4 contribution decision Q4 2026, v1.0 ratification 2027) rather than the old AAIF milestones, and the status line states plainly that Phase 1 is a review pass and not a request to accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)