### PR TITLE
feat(tee): share the TPMT_SIGNATURE parse and accept both quote framings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Added
+
+**[SDK]** **`parse_tpmt_signature()` and `ParsedSignature` are now public**, so cmcp and ca2a can stop carrying a copy each. Both had byte-identical implementations of the `TPMT_SIGNATURE` unwrap that `tpm2_quote -s` and `tpm2-pytss`'s `signature.marshal()` produce, differing only in which exception they raised; cmcp's comment already named this as "the piece agent-manifest does not model". It raises `TpmVerificationError` rather than `ValueError`, so a downstream migrating off its own copy needs to widen its `except` clause. `struct.error` on a truncated buffer is now caught and re-raised as `TpmVerificationError`, which ca2a handled and cmcp did not.
+
+**[SDK]** **`parse_tpm_quote()` accepts a size-prefixed `TPM2B_ATTEST` as well as a bare `TPMS_ATTEST`.** `tpm2_quote -m` writes the bare form and other producers write the wrapped one, so a verifier that accepts only one rejects genuine quotes from standard tooling. `TpmQuote.raw` is now always the inner `TPMS_ATTEST`, and `verify_tpm_quote()` checks the AK signature over that rather than over its argument — verifying over the outer bytes would have failed a real wrapped quote. For bare input, which is everything the suite previously exercised, both are the same bytes and behaviour is unchanged.
+
+Framing is decided by requiring the magic to appear under one reading or the other, not by the leading bytes alone. The obvious implementation, "magic at offset 0 means bare, otherwise treat the first two bytes as a length", silently reinterprets a blob with a corrupt magic as a framing fault and reports `TPM2B_ATTEST size field invalid`, which sends whoever is debugging a one-bit corruption to the wrong problem. Two tests caught this and both are kept as regression guards.
+
 ### Changed
 
 **[SPEC]** **Target standards body retargeted from AAIF to CoSAI Working Stream 4**, an OASIS Open Project, following the Phase 1 RFC in [cosai-oasis/ws4-secure-design-agentic-systems#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149). Affects the spec header, section 3.1 (who assigns the canonical `@context` URL), section 3.2.5 (scanner registry), section 10.1 through 10.3, and the governance set: `CHARTER.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `ANTITRUST.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `README.md`. No normative data-model, cryptographic, or conformance change; nothing about how a manifest is signed or verified moves.

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -46,8 +46,8 @@ from ._tdx_verify import (
     parse_tdx_quote, parse_tdx_quote_signature, verify_tdx_quote,
 )
 from ._tpm_verify import (
-    TpmQuote, TpmVerificationError,
-    parse_tpm_quote, verify_tpm_quote,
+    TpmQuote, TpmVerificationError, ParsedSignature,
+    parse_tpm_quote, parse_tpmt_signature, verify_tpm_quote,
 )
 from ._verify import (
     verify_manifest,
@@ -96,7 +96,8 @@ __all__ = [
     "verify_cert_chain", "CertChainError",
     "TdxQuote", "TdxQuoteSignature", "TdxVerificationError",
     "parse_tdx_quote", "parse_tdx_quote_signature", "verify_tdx_quote",
-    "TpmQuote", "TpmVerificationError", "parse_tpm_quote", "verify_tpm_quote",
+    "TpmQuote", "TpmVerificationError", "ParsedSignature",
+    "parse_tpm_quote", "parse_tpmt_signature", "verify_tpm_quote",
     "verify_manifest", "verify_runtime_report",
     "VerificationContext", "VerificationResult",
     "OverallResult", "FieldResult", "DelegationResult", "HitlResult",

--- a/python/src/agent_manifest/_tpm_verify.py
+++ b/python/src/agent_manifest/_tpm_verify.py
@@ -22,14 +22,32 @@ Unlike SEV-SNP/TDX there is no single published TPM root — AK certs chain to
 per-vendor EK roots — so the caller supplies the vendor roots it trusts. Only
 the ``cryptography`` package is required; no external tools run at verify time.
 
-Note: the parsing and signature/chain logic are exercised against synthetic
-self-consistent vectors (see ``tests/test_tpm_verify.py``). Unlike the SEV-SNP
-and TDX paths, this verifier has not yet been validated against a quote from a
-real TPM; that is tracked as follow-up hardware validation.
+Two wire-format details exist because real tooling emits them, and both were
+found by running against a TPM rather than by reading the TCG structures spec:
+
+* **Quote framing.** ``tpm2_quote -m`` writes a bare ``TPMS_ATTEST``, while other
+  producers write a ``TPM2B_ATTEST`` with a two-byte big-endian size prefix.
+  :func:`parse_tpm_quote` accepts both and tells them apart by the magic, because
+  a verifier that rejects the framing the standard tooling produces is a verifier
+  nobody can use. It returns the inner ``TPMS_ATTEST`` as ``raw``, which is the
+  byte range the AK actually signed.
+* **Signature framing.** ``tpm2_quote -s`` and ``tpm2-pytss``'s
+  ``signature.marshal()`` write a ``TPMT_SIGNATURE``, not a bare DER/PKCS#1
+  signature. :func:`parse_tpmt_signature` unwraps it.
+
+Hardware validation: exercised end to end against an AK-signed quote captured on
+2026-07-31 from an Azure Trusted Launch vTPM (``Standard_D2s_v5``, Ubuntu 24.04,
+``TPM2_PT_MANUFACTURER`` = ``MSFT``, RSASSA/SHA-256 AK, PCRs 0-7 under a fresh
+32-byte nonce), with tampered attest blobs, tampered signatures and a wrong key
+all rejected. That vector is committed in ``tests/test_tpm_hardware_vector.py``
+because it carries no per-CPU identifier, so the signature path runs on every PR.
+What remains unvalidated on Azure is the AK *certificate chain*: see
+``LIMITATIONS.md`` and cmcp#431.
 """
 from __future__ import annotations
 
 import hmac
+import struct
 from dataclasses import dataclass
 from typing import Optional
 
@@ -37,6 +55,11 @@ TPM_GENERATED_VALUE = 0xFF544347
 TPM_ST_ATTEST_QUOTE = 0x8018
 _CLOCK_INFO_LEN = 17
 _FIRMWARE_VERSION_LEN = 8
+
+# TPM2_ALG_ID values for the signing schemes a quote can use.
+_ALG_RSASSA = 0x0014
+_ALG_RSAPSS = 0x0016
+_ALG_ECDSA = 0x0018
 
 
 class TpmVerificationError(Exception):
@@ -67,8 +90,39 @@ class TpmQuote:
     raw: bytes
 
 
+def _unwrap_attest(data: bytes) -> bytes:
+    """Return the inner ``TPMS_ATTEST``, accepting either framing.
+
+    A bare ``TPMS_ATTEST`` starts with ``TPM_GENERATED_VALUE``; a ``TPM2B_ATTEST``
+    starts with a two-byte big-endian size. Framing is decided by requiring the
+    magic to appear in the resulting blob under one reading or the other, not by
+    the leading bytes alone. A blob whose magic is corrupt would otherwise be
+    silently reinterpreted as a size prefix and reported as a framing fault,
+    which sends whoever is debugging it to the wrong problem.
+    """
+    if len(data) < 6:
+        raise TpmVerificationError("TPM quote too short")
+    if int.from_bytes(data[0:4], "big") == TPM_GENERATED_VALUE:
+        return data
+    size = int.from_bytes(data[0:2], "big")
+    if 0 < size <= len(data) - 2:
+        inner = data[2:2 + size]
+        if len(inner) >= 4 and int.from_bytes(inner[0:4], "big") == TPM_GENERATED_VALUE:
+            return inner
+    raise TpmVerificationError(
+        "not a TPM quote: no TPM_GENERATED magic as either a bare TPMS_ATTEST or "
+        f"a size-prefixed TPM2B_ATTEST (leading bytes {data[:4].hex()})"
+    )
+
+
 def parse_tpm_quote(attest: bytes) -> TpmQuote:
-    """Parse a ``TPMS_ATTEST`` quote blob into its appraised fields."""
+    """Parse a quote blob into its appraised fields.
+
+    Accepts a bare ``TPMS_ATTEST`` or a size-prefixed ``TPM2B_ATTEST``. The
+    returned ``raw`` is always the inner ``TPMS_ATTEST``, which is the byte range
+    the attestation key signed and therefore what a signature check must cover.
+    """
+    attest = _unwrap_attest(attest)
     if len(attest) < 6:
         raise TpmVerificationError("TPM quote too short")
     magic = int.from_bytes(attest[0:4], "big")
@@ -94,6 +148,69 @@ def parse_tpm_quote(attest: bytes) -> TpmQuote:
         pcr_digest=pcr_digest,
         raw=bytes(attest),
     )
+
+
+@dataclass(frozen=True)
+class ParsedSignature:
+    """A parsed ``TPMT_SIGNATURE``: the algorithm ids and the bare signature.
+
+    ``signature`` is in the form ``cryptography`` verifies against: PKCS#1 for
+    RSA, and a DER-encoded sequence for ECDSA (the TPM emits R and S as two
+    size-prefixed integers, which are re-encoded here).
+    """
+
+    sig_alg: int
+    hash_alg: int
+    signature: bytes
+
+
+def parse_tpmt_signature(blob: bytes) -> ParsedSignature:
+    """Unwrap a ``TPMT_SIGNATURE`` into a bare signature.
+
+    Layout: ``sigAlg`` (2), ``hashAlg`` (2), then the algorithm-specific body. For
+    RSA that is a size-prefixed ``TPM2B_PUBLIC_KEY_RSA``. For ECDSA it is two
+    size-prefixed integers, R then S.
+
+    Raises :class:`TpmVerificationError` on anything malformed, so a caller
+    cannot mistake a truncated blob for a signature that failed to verify.
+    """
+    if len(blob) < 6:
+        raise TpmVerificationError("TPMT_SIGNATURE too short")
+    try:
+        sig_alg, hash_alg = struct.unpack_from(">HH", blob, 0)
+        offset = 4
+
+        if sig_alg in (_ALG_RSASSA, _ALG_RSAPSS):
+            (size,) = struct.unpack_from(">H", blob, offset)
+            offset += 2
+            if len(blob) < offset + size:
+                raise TpmVerificationError("TPMT_SIGNATURE truncated inside the RSA signature")
+            return ParsedSignature(sig_alg, hash_alg, blob[offset:offset + size])
+
+        if sig_alg == _ALG_ECDSA:
+            from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+            parts: list[bytes] = []
+            for _ in range(2):
+                (size,) = struct.unpack_from(">H", blob, offset)
+                offset += 2
+                if len(blob) < offset + size:
+                    raise TpmVerificationError(
+                        "TPMT_SIGNATURE truncated inside the ECDSA signature"
+                    )
+                parts.append(blob[offset:offset + size])
+                offset += size
+            return ParsedSignature(
+                sig_alg,
+                hash_alg,
+                encode_dss_signature(
+                    int.from_bytes(parts[0], "big"), int.from_bytes(parts[1], "big")
+                ),
+            )
+    except struct.error as exc:
+        raise TpmVerificationError(f"TPMT_SIGNATURE is malformed: {exc}") from exc
+
+    raise TpmVerificationError(f"unsupported signature algorithm 0x{sig_alg:04x}")
 
 
 def _verify_ak_chain(ak_chain_pem: bytes, trusted_roots_pem: bytes) -> "object":
@@ -181,12 +298,16 @@ def verify_tpm_quote(
     ak = _verify_ak_chain(ak_chain_pem, trusted_roots_pem)
     ak_key = ak.public_key()  # type: ignore[attr-defined]
 
-    # Step 3: AK signature over the TPMS_ATTEST blob.
+    # Step 3: AK signature over the TPMS_ATTEST blob. Use quote.raw rather than
+    # the argument: when the caller passes a size-prefixed TPM2B_ATTEST, the TPM
+    # signed the inner structure, so verifying over the outer bytes would fail a
+    # genuine quote.
+    signed = quote.raw
     try:
         if isinstance(ak_key, ec.EllipticCurvePublicKey):
-            ak_key.verify(signature, attest, ec.ECDSA(SHA256()))
+            ak_key.verify(signature, signed, ec.ECDSA(SHA256()))
         elif isinstance(ak_key, rsa.RSAPublicKey):
-            ak_key.verify(signature, attest, padding.PKCS1v15(), SHA256())
+            ak_key.verify(signature, signed, padding.PKCS1v15(), SHA256())
         else:
             raise TpmVerificationError("unsupported AK public-key type for TPM quote")
     except InvalidSignature:

--- a/python/tests/test_tpm_hardware_vector.py
+++ b/python/tests/test_tpm_hardware_vector.py
@@ -1,0 +1,177 @@
+"""TPM quote parsing and signature verification against a real Azure vTPM capture.
+
+The vector below was produced on 2026-07-31 on a Standard_D2s_v5 Azure VM with
+Trusted Launch, vTPM and secure boot enabled, Ubuntu 24.04, TPM manufacturer
+MSFT. The AK was created with ``tpm2_createek`` followed by ``tpm2_createak``
+(RSA, RSASSA, SHA-256) and the quote taken over PCRs 0-7 under a fresh 32-byte
+nonce. It moved here from cmcp when the TPMT_SIGNATURE parse consolidated into
+agent-manifest, so the code and the evidence that validates it stay together.
+
+This vector is committed, unlike the SEV-SNP captures. It carries no per-CPU
+hardware identifier: the AK public key belongs to a virtual TPM in a VM that no
+longer exists, and the PCR values describe a stock Ubuntu image. Committing it
+means the signature path is exercised on every PR rather than only when someone
+sets a fixture directory.
+
+Scope: this validates parsing and the AK signature. It establishes no key
+provenance, because the AK certificate chain is a separate question that on
+Azure is host-dependent (see LIMITATIONS.md).
+"""
+import base64
+
+import pytest
+
+crypto = pytest.importorskip("cryptography")
+
+from agent_manifest._tpm_verify import (  # noqa: E402
+    TPM_GENERATED_VALUE,
+    TpmVerificationError,
+    parse_tpm_quote,
+    parse_tpmt_signature,
+)
+
+from cryptography.hazmat.primitives import hashes, serialization  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import padding, rsa  # noqa: E402
+
+# Bare TPMS_ATTEST as written by `tpm2_quote -m`.
+QUOTE_ATTEST = base64.b64decode(
+    "/1RDR4AYACIAC1Gr2BpHLuEP6q3wUzFvxZPNyfm9bw98RBelxxduCCr7ACBJgPpvWQ1l+6Fc3u8LC7Au"
+    "jPFVBEcFsa8HAb+gsuMjlgAAAAAAAeu7AAAAAwAAAAABICADEgASAAQAAAABAAsD/wAAACDUvEYCCXOU"
+    "AOzy8r898/XnrH99z1VrFNtVJDUg6kRSag=="
+)
+
+# TPMT_SIGNATURE as written by `tpm2_quote -s`.
+QUOTE_SIGNATURE = base64.b64decode(
+    "ABQACwEASCi0Ht6m6zPVnt4HXAahI4V4DV9nHbjWCJT0kYZVtUUS7BLmv7pt/dY2tNjWTJXAZKXJCX5i"
+    "43eo53eVzKjHN3AzFdvkLEK/ahjEQ2/D+Frb+sLe0FlfhvzgfgUyoQCDs9krmCnMy18fDjxOSO+Nm2uy"
+    "Wyg38ZTUpR1fUmjb68n9WHbPR3QZV9nNI4G0IW3AgRhcHZ7gmb9WJdLLSRdzfFJ7wDWEsAFcrtGiycc0"
+    "iRXbCOBh0xTeDTlIWn9ljEYTvDlr8duW3c2fT08ZcV4vxJA6Wa8cr1QQjpd6s1/UO0XaYXneCHxoGI1u"
+    "fbEoR4QA3qTPYNCSKNgyHH9GdV1stg=="
+)
+
+AK_PUBLIC_PEM = base64.b64decode(
+    "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFN"
+    "SUlCQ2dLQ0FRRUF5K3pCVWdBQTcvZW5CMEdyWmQrdgo4OFgvd3F0U2VKZ2dCczBZU0lkcW5HLzF4SjNy"
+    "MEpTc1hyZnJkSkpnU1BwL2t4bzY5eWVtMlhjUlBiVGIzbHQwCjJsakVyaTZlUjhjbEt5RmNFUFFMbUZC"
+    "Qmg3RU5Lai9KV3FnWnJINHhLdW93Y1BlR0ltajJ2S1hlV21LclVmb1gKVU1wdmI3eTUyeTJpNU4vTERQ"
+    "UUcrYnI5NFhyZlNQNFNKTmVJKzlWUUM1Q1ZzRDM1QmZEZncwOHNYNGd6dG5FSwp4SUpyZGFVRUgxRjFs"
+    "MkxPUjJoT0FQcjI5MmxrYUlvdTVoNHF6Y3hwbm5NTTN1djF6Q2Y1ZU5rZ2QwZ1FLdUllCjZ2T2JMcStT"
+    "ZURPWndmYzBTSzRIUjBRVEtNcnhEbSs5eEdnU3ZYeUlFVnVTOExwZzBsZGRYU1Uzd0xpUU5Td1EKOHdJ"
+    "REFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
+)
+
+NONCE = bytes.fromhex("4980fa6f590d65fba15cdeef0b0bb02e8cf155044705b1af0701bfa0b2e32396")
+
+
+def _ak() -> rsa.RSAPublicKey:
+    key = serialization.load_pem_public_key(AK_PUBLIC_PEM)
+    assert isinstance(key, rsa.RSAPublicKey)
+    return key
+
+
+def _verifies(attest: bytes, sig_blob: bytes, key: rsa.RSAPublicKey) -> bool:
+    """Rejected covers both outcomes a tampered input can produce: a blob that no
+    longer parses, and one that parses but whose signature does not check out."""
+    try:
+        parsed = parse_tpmt_signature(sig_blob)
+        signed = parse_tpm_quote(attest).raw
+        key.verify(parsed.signature, signed, padding.PKCS1v15(), hashes.SHA256())
+    except Exception:
+        return False
+    return True
+
+
+def test_parses_a_real_tpmt_signature() -> None:
+    parsed = parse_tpmt_signature(QUOTE_SIGNATURE)
+
+    assert parsed.sig_alg == 0x0014  # TPM_ALG_RSASSA
+    assert parsed.hash_alg == 0x000B  # TPM_ALG_SHA256
+    assert len(parsed.signature) == 256
+
+
+def test_parses_a_real_bare_tpms_attest() -> None:
+    quote = parse_tpm_quote(QUOTE_ATTEST)
+
+    assert quote.magic == TPM_GENERATED_VALUE
+    assert quote.qualifying_data == NONCE
+    assert quote.raw == QUOTE_ATTEST
+
+
+def test_the_same_quote_parses_under_tpm2b_framing() -> None:
+    """A producer that writes TPM2B_ATTEST must appraise identically to one that
+    writes a bare TPMS_ATTEST, and `raw` must stay the signed inner bytes."""
+    wrapped = len(QUOTE_ATTEST).to_bytes(2, "big") + QUOTE_ATTEST
+
+    quote = parse_tpm_quote(wrapped)
+
+    assert quote.raw == QUOTE_ATTEST
+    assert quote.qualifying_data == NONCE
+
+
+def test_real_hardware_quote_signature_verifies() -> None:
+    assert _verifies(QUOTE_ATTEST, QUOTE_SIGNATURE, _ak()) is True
+
+
+def test_real_hardware_quote_verifies_under_tpm2b_framing() -> None:
+    """The regression this guards: verifying over the outer TPM2B bytes rather
+    than the inner TPMS_ATTEST rejects a genuine quote."""
+    wrapped = len(QUOTE_ATTEST).to_bytes(2, "big") + QUOTE_ATTEST
+
+    assert _verifies(wrapped, QUOTE_SIGNATURE, _ak()) is True
+
+
+def test_the_quote_carries_the_nonce_it_was_taken_under() -> None:
+    """extraData sits after the qualifiedSigner name; the signature is what makes
+    it meaningful, since both fields are otherwise attacker-controllable."""
+    assert parse_tpm_quote(QUOTE_ATTEST).qualifying_data == NONCE
+
+
+@pytest.mark.parametrize("flip", [0, 40, -1])
+def test_a_tampered_attest_is_rejected(flip: int) -> None:
+    tampered = bytearray(QUOTE_ATTEST)
+    tampered[flip] ^= 0x01
+
+    assert _verifies(bytes(tampered), QUOTE_SIGNATURE, _ak()) is False
+
+
+def test_a_tampered_signature_is_rejected() -> None:
+    tampered = bytearray(QUOTE_SIGNATURE)
+    tampered[-1] ^= 0x01
+
+    assert _verifies(QUOTE_ATTEST, bytes(tampered), _ak()) is False
+
+
+def test_a_different_key_does_not_verify() -> None:
+    """A quote is only evidence if it verifies under the key the relying party
+    expects."""
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048).public_key()
+
+    assert _verifies(QUOTE_ATTEST, QUOTE_SIGNATURE, other) is False
+
+
+def test_unsupported_signature_algorithm_is_rejected() -> None:
+    with pytest.raises(TpmVerificationError, match="unsupported signature algorithm"):
+        parse_tpmt_signature(b"\x00\x99\x00\x0b\x00\x04abcd")
+
+
+def test_truncated_signature_is_rejected() -> None:
+    with pytest.raises(TpmVerificationError, match="truncated"):
+        parse_tpmt_signature(QUOTE_SIGNATURE[:20])
+
+
+def test_a_size_prefix_that_overruns_the_buffer_is_rejected() -> None:
+    """The size comes from untrusted input, so a declared length longer than the
+    blob must fail closed rather than parse whatever fits."""
+    with pytest.raises(TpmVerificationError, match="no TPM_GENERATED magic"):
+        parse_tpm_quote((len(QUOTE_ATTEST) + 64).to_bytes(2, "big") + QUOTE_ATTEST)
+
+
+def test_a_corrupt_magic_is_not_reported_as_a_framing_fault() -> None:
+    """A one-bit flip in the magic must be diagnosed as a bad magic, not silently
+    reinterpreted as a TPM2B size prefix, or the error sends whoever is debugging
+    it to the wrong problem."""
+    corrupt = bytearray(QUOTE_ATTEST)
+    corrupt[0] ^= 0x01
+
+    with pytest.raises(TpmVerificationError, match="no TPM_GENERATED magic"):
+        parse_tpm_quote(bytes(corrupt))


### PR DESCRIPTION
Phase A1 of consolidating the TEE verification stack into agent-manifest, so cmcp and ca2a consume it from PyPI instead of each carrying a copy. Continues the direction set by #247 (shared DCAP v4 signature-section parse).

## What moves in

**`parse_tpmt_signature()` / `ParsedSignature` become public.** cmcp and ca2a had byte-identical implementations of the `TPMT_SIGNATURE` unwrap that `tpm2_quote -s` and `tpm2-pytss`'s `signature.marshal()` produce, differing only in which exception they raised. cmcp's own comment already named this as "the piece agent-manifest does not model". The union takes ca2a's `struct.error` handling, which cmcp lacked.

**`parse_tpm_quote()` accepts `TPM2B_ATTEST` as well as bare `TPMS_ATTEST`.** Accepting only the bare form rejects genuine quotes from producers that write the wrapped one. `TpmQuote.raw` is now always the inner `TPMS_ATTEST`, and `verify_tpm_quote()` checks the AK signature over that rather than over its argument, because verifying over the outer bytes would fail a real wrapped quote.

## The bug the tests caught

The obvious framing check — magic at offset 0 means bare, otherwise read a length — silently reinterprets a blob with a **corrupt magic** as a framing fault and reports `TPM2B_ATTEST size field invalid`. A one-bit flip in the magic then sends whoever is debugging it to the wrong problem. Framing is now decided by requiring the magic to appear under one reading or the other. Two tests are kept as regression guards.

## Hardware validation

The Azure vTPM vector moves here from cmcp with the code it validates: `Standard_D2s_v5`, Ubuntu 24.04 Trusted Launch, `TPM2_PT_MANUFACTURER` = `MSFT`, RSASSA/SHA-256 AK, PCRs 0-7 under a fresh 32-byte nonce, captured 2026-07-31. It stays committed rather than fixture-gated because it carries no per-CPU identifier, so the signature path now runs on every PR here.

This also corrects a stale claim: the module docstring said this verifier had never been validated against a real TPM. cmcp validated the delegated path on 2026-07-31 and recorded it in its hardware-validation log. Two repos disagreeing about whether the same code path is hardware-validated is exactly the drift this consolidation exists to end.

Scope note: this validates parsing and the AK signature, **not** key provenance. The AK certificate chain on Azure is host-dependent and remains open (#431).

## Downstream migration note

`parse_tpmt_signature` raises `TpmVerificationError`, not `ValueError`. cmcp currently catches `ValueError` and will need to widen that clause in its Phase B PR. Nothing here changes behaviour for existing callers of `verify_tpm_quote` with bare input.

## Testing

`643 passed, 16 skipped` against the worktree source. Note that running the suite with the published wheel installed silently tested site-packages instead of the working tree, which is the same masking problem that bit agentrust-trace; ran under an explicit `PYTHONPATH` and verified the module path before trusting the result.

## Sequence

Phase A raises agent-manifest to the union of all three implementations (A1 TPM, A2 SNP, A3 TDX, A4 trust roots, A5 provider ABC). Phase B deletes the downstream copies, one PR per repo per capability, each gated on Phase A being on PyPI. Port-then-delete throughout: agent-manifest was **not** a superset, so a naive delete-then-import would have regressed cmcp's TPM parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)