### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-08-01
+
+Shares the `TPMT_SIGNATURE` parse and teaches the quote parser both attest framings, so cmcp and ca2a can delete their copies rather than keep three implementations of the same wire formats in step by hand. Phase A1 of consolidating TEE verification into this package. No change to manifest signing or verification behaviour.
+
 ### Added
 
 **[SDK]** **`parse_tpmt_signature()` and `ParsedSignature` are now public**, so cmcp and ca2a can stop carrying a copy each. Both had byte-identical implementations of the `TPMT_SIGNATURE` unwrap that `tpm2_quote -s` and `tpm2-pytss`'s `signature.marshal()` produce, differing only in which exception they raised; cmcp's comment already named this as "the piece agent-manifest does not model". It raises `TpmVerificationError` rather than `ValueError`, so a downstream migrating off its own copy needs to widen its `except` clause. `struct.error` on a truncated buffer is now caught and re-raised as `TpmVerificationError`, which ca2a handled and cmcp did not.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.7.0"
+version = "0.8.0"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts 0.8.0 so the Phase A1 consolidation is installable and cmcp/ca2a can migrate by deletion.

Contents: `parse_tpmt_signature()` / `ParsedSignature` become public, and `parse_tpm_quote()` accepts both the bare `TPMS_ATTEST` that `tpm2_quote -m` writes and the size-prefixed `TPM2B_ATTEST` other producers write. Full detail in #258.

Minor rather than patch: two additions to the public API surface. Not a major, because behaviour for every existing caller is unchanged — bare-framed input parses to the same bytes and `verify_tpm_quote()` verifies over the same range.

Downstream migration note carried forward: `parse_tpmt_signature` raises `TpmVerificationError`, not `ValueError`. cmcp catches `ValueError` today and needs that widened when it deletes its copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)