### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-01
+
+Shares the SEV-SNP report union so cmcp and ca2a can delete four copies of the layout between them, and restores a check that existed only in the copies being deleted: the report's declared `sig_algo` is now verified before the signature is checked under it. Phase A2 of consolidating TEE verification into this package.
+
 ### Added
 
 **[SDK]** **`SnpReport` now carries `guest_svn`, `vmpl` and `signature_algo`**, and `load_snp_cert_chain()` is public. Phase A2 of the TEE consolidation: cmcp and ca2a carried four copies of the SEV-SNP report layout between them (two inside cmcp alone), and all four agreed on every offset, so this is a union rather than a reconciliation. The three fields were parsed by the downstream copies and not by this one, which meant a consumer of agent-manifest could not enforce checks those copies enforced.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.8.0"
+version = "0.9.0"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts 0.9.0 so the Phase A2 SNP consolidation is installable and cmcp/ca2a can migrate by deletion. Contents in #260.

Minor rather than patch: three new `SnpReport` fields and `load_snp_cert_chain()` on the public surface.

One behaviour change worth flagging for anyone pinning: `verify_snp_signature()` now raises on a report whose `sig_algo` is not `SIG_ALGO_ECDSA_P384_SHA384`. Real reports always set it, and both downstream copies already enforced this, so no genuine hardware path changes. Synthetic fixtures that leave the field at zero will start failing, correctly — that is what it caught in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)