### PR TITLE
Give the homepage a searchable title

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ---
+title: Verifiable identity and permissions for AI agents
 description: Agent Manifest is an open standard that cryptographically anchors the 10 artifacts defining an AI agent, so a third party can verify the agent running in production is the one that was approved.
 ---
 


### PR DESCRIPTION
The homepage `<title>` was the bare string `Agent Manifest`.

Material uses `site_name` verbatim when a page has no front-matter title, so the
strongest ranking signal on the site carried no keywords.

```
before:  Agent Manifest
after:   Verifiable identity and permissions for AI agents - Agent Manifest
```

One line. Front matter is safe in this repo because `docs/index.md` is the
homepage source and is a different file from the repository `README.md`, so the
GitHub landing page is unaffected. Sibling repos whose `docs_dir` is the
repository root need a `htmltitle` block instead, which is what
agentrust-io/trace-spec#129 and agentrust-io/ca2a#85 do.

Verified with a local `mkdocs build`: root renders the new title.

Part of an audit across the AgenTrust sites. Every spec subdomain was titled with
a bare acronym while `site_description` carried the searchable language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)