### PR TITLE
docs(spec): stamp the EU AI Act applicability dates and map Article 50 as a gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Added
+
+**[SPEC] Section 9.1.2 maps EU AI Act Article 50, and maps it as a gap.** Article 50 transparency duties have applied since 2 August 2026: chatbot disclosure, machine-readable marking of synthetic output, emotion-recognition notice. It is the only AI Act obligation in force against an agent deployment today, and no document in this repository mentioned it. The manifest satisfies none of the four paragraphs, so the new subsection says that in those words, notes that Article 50 applies regardless of Annex III classification, and states that a manifest MUST NOT be read as Article 50 evidence. `docs/compliance/eu-ai-act.md` carries the same mapping for auditors. Marking that binds to the attested agent that produced the output, rather than to a strippable metadata field, is the design being pursued; it is not built.
+
 ### Changed
+
+**[SPEC] EU AI Act mappings now carry the date each obligation applies from.** The mappings were written as if the high-risk obligations bind today. Under the current provisional timeline the Digital Omnibus amendments defer Annex III systems to around 2 December 2027 and Annex I to around August 2028, which `docs/compliance/eu-ai-act.md` already recorded and nothing else did. The mappings are correct and unchanged; only the applicability date is added, in section 9.1 (authoritative note), the section 8.1 conformance-level table, the section 8.1 log-retention requirement, `LIMITATIONS.md`, the HITL tutorial and example, `docs/index.md`, `docs/getting-started.md`, and the hardware-attestation tutorial. Where a deployment has an obligation in force today, the docs now lead with it: DORA for financial entities, HIPAA § 164.308(a)(5) for the HITL record.
+
 
 **[SPEC][SDK] BREAKING: the `@context` URI moves to `https://manifest.agentrust-io.com/v0.2/context.json`**, and the specification is republished as v0.2 ([`spec/agent-manifest-spec-v0.2.md`](spec/agent-manifest-spec-v0.2.md), [ADR-0012](docs/adr/0012-context-uri-moved-to-controlled-domain.md)). The v0.1 URI `https://agentmanifest.agentrust.io/v0.1/context.json` named `agentrust.io`, a domain this project has never controlled: registered to a third party behind Domains By Proxy, paid through mid-2027, and it has never resolved. Every manifest issued to date was therefore identified under somebody else's name, which is untenable in an identity specification.
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -29,8 +29,8 @@ The container image digest is measured at TEE startup. Attacks that compromise t
 
 Level 0 (software-only signing) is suitable for development and staging. It does not satisfy:
 
-- EU AI Act Art. 15 (cybersecurity) — requires Level 1+
-- DORA Art. 9 — requires Level 1+ with HITL records
+- DORA Art. 9 (in force today) — requires Level 1+ with HITL records
+- EU AI Act Art. 15 (cybersecurity; applies from around December 2027) — requires Level 1+
 - Any claim of hardware-rooted trust — the signing key is held in software and can be extracted by a privileged operator
 
 ## What the SDK does not do

--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -2,7 +2,26 @@
 
 This page maps agent-manifest capabilities to EU AI Act obligations for high-risk AI systems. It is written for compliance officers and auditors, not developers.
 
-**Status:** GPAI model obligations apply since **August 2025**. Under the current provisional legislative timeline (the digital omnibus amendments), high-risk AI system obligations are expected to apply from around **December 2027**, and AI systems embedded in regulated products from around **August 2028**. These dates remain subject to the legislative process - verify against the [official AI Act timeline](https://artificialintelligenceact.eu/implementation-timeline/) before relying on them. Obligations already in force today (e.g. DORA for financial entities, HIPAA for US healthcare) are unaffected by this timeline.
+**Status:** GPAI model obligations apply since **August 2025**, and **Article 50 transparency duties since 2 August 2026** (see below - the manifest does not satisfy them). Under the current provisional legislative timeline (the digital omnibus amendments), high-risk AI system obligations are expected to apply from around **December 2027**, and AI systems embedded in regulated products from around **August 2028**. These dates remain subject to the legislative process - verify against the [official AI Act timeline](https://artificialintelligenceact.eu/implementation-timeline/) before relying on them. Obligations already in force today (e.g. DORA for financial entities, HIPAA for US healthcare) are unaffected by this timeline.
+
+Everything on this page below Article 50 maps to the **high-risk** obligations, which are the deferred ones. Article 50 is the one in force now.
+
+---
+
+## Article 50  -  Transparency obligations *(in force since 2 August 2026)*
+
+> *AI systems intended to interact directly with natural persons shall be designed so that the person is informed they are interacting with an AI system, unless obvious. Providers of systems generating synthetic content shall mark the output in a machine-readable form.*
+
+**What agent-manifest provides: nothing yet.** This is stated plainly because Article 50 is the obligation an auditor can hold a deployment to today, and a mapping page that quietly omits it reads as coverage.
+
+| Article 50 paragraph | Obligation | Status |
+|----------------------|------------|--------|
+| 50(1) | Inform persons they are interacting with an AI system | No manifest field. Disclosure is delivered at runtime; AGT's `agent_os.transparency` interceptor enforces it at the tool-call boundary. |
+| 50(2) | Mark synthetic output as artificially generated, machine-readably | No manifest field. A mark any party can strip does not meet the requirement, so binding the mark to the attested agent that produced the output is the intended design. Not built. |
+| 50(3) | Inform persons exposed to emotion recognition or biometric categorisation | No manifest field. Enforced at runtime by the same AGT interceptor. A manifest whose approved scope covers biometric tooling is evidence the deployment is in scope. |
+| 50(4) | Deepfake and public-interest text disclosure | No manifest field. Same gap as 50(2). |
+
+Article 50 applies regardless of whether the system is high-risk under Annex III. Do not present a manifest as Article 50 evidence.
 
 ---
 
@@ -137,6 +156,7 @@ For high-risk AI systems under Article 6(2), Annex III, **Level 2 or above is re
 
 | EU AI Act Article | Obligation | agent-manifest capability |
 |-------------------|------------|---------------------------|
+| Article 50 *(in force)* | Transparency and synthetic-content marking | **None.** Runtime disclosure via AGT; marking not built |
 | Article 9 | Risk management record | `approved_scope.risk_tier` (approver-signed) |
 | Article 12 | Automatic logging | Merkle `audit_chain_root` |
 | Article 13 | Transparency to deployers | Signed identity + artifact hashes |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -214,7 +214,7 @@ freshness proof on a cadence you choose.
 
 ## Level 1  -  TPM attestation
 
-Level 1 adds hardware attestation, which binds the manifest hash to a TEE measurement that cannot be forged by the operator. Required for EU AI Act Art. 15 (cybersecurity) and enterprise production deployments.
+Level 1 adds hardware attestation, which binds the manifest hash to a TEE measurement that cannot be forged by the operator. Required for enterprise production deployments, and for EU AI Act Art. 15 (cybersecurity) when that obligation applies from around December 2027.
 
 ### Prerequisites
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ Provider auto-selects based on available hardware: `OPAQUE → SEV-SNP → TDX �
 | Level | Requirements | Use case |
 |-------|-------------|---------|
 | Level 0 | Software signing, all artifact bindings | Development, staging |
-| Level 1 | + TEE attestation, `audit_key_sealed: true` | Enterprise production, EU AI Act Art. 15 |
+| Level 1 | + TEE attestation, `audit_key_sealed: true` | Enterprise production; EU AI Act Art. 15 from ~Dec 2027 |
 | Level 2 | + All 10 artifacts, HITL approvals, Phase 2 cMCP | Regulated industries, DORA |
 | Level 3 | + ML-DSA-65, ML-KEM-768, SHAKE-256 | Sovereign, classified, long-horizon financial |
 

--- a/docs/tutorials/hardware-attestation.md
+++ b/docs/tutorials/hardware-attestation.md
@@ -195,7 +195,7 @@ The `audit_chain_root` anchors every decision the agent made to a Merkle chain h
 |----------|------------------|---------|
 | Development and local testing | 0 | `SoftwareProvider` |
 | Enterprise internal deployment | 1 | `TPMProvider` |
-| EU AI Act Art. 15 (cybersecurity) | 2 | `SEVSNPProvider` or `TDXProvider` |
+| EU AI Act Art. 15 (cybersecurity, from ~Dec 2027) | 2 | `SEVSNPProvider` or `TDXProvider` |
 | Financial services, regulated workloads | 2+ | `SEVSNPProvider` / `TDXProvider` |
 | Full audit chain, OPAQUE-managed trust | 3 | `OPAQUEProvider` |
 | Unknown environment, pick best available | any | `select_provider(level=N)` |

--- a/docs/tutorials/hitl-approval-workflows.md
+++ b/docs/tutorials/hitl-approval-workflows.md
@@ -1,6 +1,6 @@
 # HITL Approval Workflows
 
-Human-in-the-loop (HITL) approval lets an agent record that a human explicitly authorised a high-risk action and cryptographically binds that authorisation to the manifest. The EU AI Act Article 14 requires "appropriate human oversight measures" for high-risk AI systems; a signed HITL record is one concrete way to demonstrate compliance.
+Human-in-the-loop (HITL) approval lets an agent record that a human explicitly authorised a high-risk action and cryptographically binds that authorisation to the manifest. The EU AI Act Article 14 requires "appropriate human oversight measures" for high-risk AI systems; a signed HITL record is one concrete way to demonstrate compliance. That obligation applies from around December 2027 for Annex III systems under the current provisional timeline (see the [EU AI Act mapping](../compliance/eu-ai-act.md)); HIPAA § 164.308(a)(5) documented human review is in force today and the same record satisfies it.
 
 After this tutorial you will be able to:
 
@@ -244,7 +244,7 @@ if result.fields_verified.hitl_record == HitlResult.APPROVED:
 | Multiple approvers | Add one entry per approver to `approvals`; each is independently signed and verified |
 | Approval duration | 1-4 hours; require re-approval for long-running jobs rather than extending the window |
 | Audit trail | Log each `approval_signature` and `evidence_uri` in your SIEM alongside the manifest ID |
-| EU AI Act Art. 14 | Document that `approved_scope` maps to the specific AI system output that was reviewed |
+| EU AI Act Art. 14 (from ~Dec 2027) | Document that `approved_scope` maps to the specific AI system output that was reviewed |
 
 ---
 

--- a/examples/hitl/README.md
+++ b/examples/hitl/README.md
@@ -52,8 +52,8 @@ The `approval_expiry` in `approved_scope` is an additional bound within the mani
 ## For auditors
 
 This record satisfies:
-- EU AI Act Article 14 (human oversight)
-- HIPAA § 164.308(a)(5) (documented human review)
-- GDPR Article 25 (data protection by design)
+- HIPAA § 164.308(a)(5) (documented human review) — in force today
+- GDPR Article 25 (data protection by design) — in force today
+- EU AI Act Article 14 (human oversight) — applies to Annex III high-risk systems from around December 2027 under the current provisional timeline
 
 See [Compliance: EU AI Act](../../docs/compliance/eu-ai-act.md) for the full mapping.

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -1417,7 +1417,7 @@ The following threats are explicitly out of scope for this specification:
 | Level | Name | Requirements | Use Case |
 |---|---|---|---|
 | Level 0 | Software-only | All artifact bindings. Standard crypto profile. Transparency log publication. No TEE requirement. | Development, staging, non-regulated environments. |
-| Level 1 | TEE-attested | Level 0 plus: TEE attestation block. `audit_key_sealed: true`. `container_image_digest` verified by hardware. | Enterprise production. Satisfies EU AI Act Art. 15 (cybersecurity). |
+| Level 1 | TEE-attested | Level 0 plus: TEE attestation block. `audit_key_sealed: true`. `container_image_digest` verified by hardware. | Enterprise production. Satisfies EU AI Act Art. 15 (cybersecurity), which applies from around December 2027 (section 9.1). |
 | Level 2 | Full stack | Level 1 plus: All 10 artifacts bound (per section 3.1 mapping table). HITL approvals present. Delegation chain for multi-agent. Phase 2 cMCP for all MCP servers. `log_retention.minimum_retention_days >= 180`. `drift_policy: deny-on-drift` or `alert-on-drift`. | Regulated industries. Satisfies DORA Art. 9, GDPR Art. 32 (when `data_scope` fields are populated for EU personal data processing). |
 | Level 3 | Post-quantum | Level 2 plus: ML-DSA-65 signatures. ML-KEM-768 key exchange. SHAKE-256 hashing. Private Sigstore instance supporting ML-DSA-65. | Sovereign deployments, classified, financial services with long-horizon sensitivity. |
 
@@ -1431,7 +1431,7 @@ Log retention requirement <!-- CHANGED: REG-002 -->: Level 2 conformance require
 }
 ```
 
-The EU AI Act (Art. 26 via Art. 12 and recital obligations) requires a minimum of 180 days (six months) log retention. Financial entities subject to DORA Art. 25(1) may require up to 1825 days (five years). `minimum_retention_days` MUST be at least 180 for EU AI Act compliance.
+The EU AI Act (Art. 26 via Art. 12 and recital obligations) requires a minimum of 180 days (six months) log retention; that obligation applies from around December 2027 (section 9.1). Financial entities subject to DORA Art. 25(1) may require up to 1825 days (five years), and DORA is in force today. `minimum_retention_days` MUST be at least 180 for EU AI Act compliance and SHOULD be set from the strictest framework the deployment is actually subject to now.
 
 ### 8.2 Conformance Test Suite
 
@@ -1451,7 +1451,9 @@ Total: 197 conformance tests. The test suite is published as an open-source repo
 
 ### 9.1 EU AI Act
 
-<!-- CHANGED: REG-001 - corrected Art. 14 mapping to distinguish pre-deployment and runtime obligations; CRYPTO-008/REG-006 - added model attestation type note; REG-009 - added Art. 13(3)(c)(e) operational lifecycle fields; REG-005 - added Art. 22 note; REG-006 - added Annex III classification guidance subsection -->
+<!-- CHANGED: REG-001 - corrected Art. 14 mapping to distinguish pre-deployment and runtime obligations; CRYPTO-008/REG-006 - added model attestation type note; REG-009 - added Art. 13(3)(c)(e) operational lifecycle fields; REG-005 - added Art. 22 note; REG-006 - added Annex III classification guidance subsection; REG-010 - added applicability dates and Art. 50 subsection -->
+
+**When these obligations apply.** GPAI model-provider obligations (Arts. 51-53) have applied since 2 August 2025. Article 50 transparency duties have applied since 2 August 2026 (see section 9.1.2). The high-risk obligations mapped in the table below (Arts. 12-15, 26) are deferred under the current provisional legislative timeline (the Digital Omnibus amendments): Annex III systems from around 2 December 2027, and Annex I systems (AI embedded in regulated products) from around August 2028. These dates remain subject to the legislative process; implementers MUST verify against the [official implementation timeline](https://artificialintelligenceact.eu/implementation-timeline/) before asserting a compliance deadline. The mappings themselves are unaffected by the deferral. Obligations already in force under other frameworks - DORA for financial entities (section 9.2), HIPAA for US healthcare (section 9.3) - are unaffected.
 
 | Article | Requirement | Agent Manifest Satisfaction |
 |---|---|---|
@@ -1481,6 +1483,21 @@ Decision guidance: If the agent deployment falls within one of the above categor
 GPAI model providers (Anthropic, OpenAI, Google, etc.) are subject to separate obligations under Arts. 51-53 of the EU AI Act. These are distinct from the high-risk system obligations described here, which apply to operators deploying agents built on top of GPAI models.
 
 Operators in financial services should note that agents performing creditworthiness assessment or risk scoring for life and health insurance (Annex III Point 5(b)) are likely high-risk regardless of the underlying model provider.
+
+Article 50 is the exception to this subsection: its transparency duties attach to the interaction and the output, not to an Annex III classification, so they apply to agent deployments that are not high-risk. See section 9.1.2.
+
+#### 9.1.2 EU AI Act Article 50 - Transparency Obligations <!-- CHANGED: REG-010 - new subsection -->
+
+Article 50 applies from **2 August 2026** and is the only EU AI Act obligation in force against agent deployments today. It is independent of the Annex III high-risk classification in section 9.1.1: an operator whose agent is out of Annex III scope is still subject to it.
+
+| Article 50 paragraph | Obligation | Agent Manifest Satisfaction |
+|---|---|---|
+| Art. 50(1) | Natural persons must be informed they are interacting with an AI system, unless obvious | **Not satisfied.** The manifest has no field declaring the disclosure or binding it to the agent. Disclosure delivery is a runtime concern; AGT's `agent_os.transparency` interceptor enforces it at the tool-call boundary and is the current answer. |
+| Art. 50(2) | Providers of systems generating synthetic audio, image, video or text must mark outputs as artificially generated, in a machine-readable form | **Not satisfied.** No marking field exists. A marking that any party can strip does not survive the obligation's machine-readable requirement, which is why binding the mark to the attested agent that produced the output is the intended design rather than a metadata field. Tracked for a future revision. |
+| Art. 50(3) | Deployers of emotion recognition or biometric categorisation systems must inform exposed persons | **Not satisfied** in the manifest. Enforced at runtime by AGT's `agent_os.transparency` interceptor. Note that a manifest whose `hitl_record.approvals[].approved_scope` covers biometric tooling is evidence the deployment is in Art. 50(3) scope. |
+| Art. 50(4) | Deepfake and public-interest text disclosure | **Not satisfied.** Same gap as Art. 50(2). |
+
+Implementers MUST NOT read the manifest as evidence of Article 50 compliance. Where the deployment is in Article 50 scope, the disclosure and marking controls are separate and must be documented separately.
 
 ### 9.2 DORA (EU) and Financial Sector Guidance
 


### PR DESCRIPTION
Response-plan list 1, the agent-manifest items (P0 dates, P0 Article 50).

## What was wrong

The EU AI Act mappings read as if the high-risk obligations bind today. Under the current provisional timeline the Digital Omnibus amendments defer Annex III systems to around 2 December 2027 and Annex I to around August 2028. `docs/compliance/eu-ai-act.md` already carried that correction. The spec, `LIMITATIONS.md`, the tutorials and the examples did not.

Article 50 was the larger omission: in force since 2 August 2026, the only AI Act obligation an auditor can hold an agent deployment to this year, and not mentioned anywhere in the repo.

## What changed

**Dates.** Every AI Act mapping now carries the date it applies from. The mappings themselves are unchanged and still correct. Where an obligation is in force today, the doc leads with it instead: DORA Art. 9 in `LIMITATIONS.md`, HIPAA § 164.308(a)(5) in the HITL tutorial and example. Section 9.1 carries the authoritative note that the rest point back to.

**Article 50 (new section 9.1.2).** Maps all four paragraphs and records that the manifest satisfies none of them, because there is no disclosure field and no marking field. Two things a reader would otherwise get wrong are stated explicitly: Article 50 attaches to the interaction and the output rather than to an Annex III classification, so it reaches deployments that are not high-risk; and a manifest MUST NOT be presented as Article 50 evidence. `docs/compliance/eu-ai-act.md` carries the same mapping for auditors, placed above the high-risk articles since it is the one in force.

Where the gap is covered elsewhere, the mapping points there rather than claiming it here: AGT's `agent_os.transparency` interceptor enforces 50(1) and 50(3) at the tool-call boundary. For 50(2) and 50(4), marking bound to the attested agent that produced the output — rather than a metadata field anyone can strip — is the design being pursued and is not built.

## Files

| File | Change |
|---|---|
| `spec/agent-manifest-spec-v0.2.md` | §9.1 applicability note, new §9.1.2, §8.1 level table, §8.1 retention requirement, §9.1.1 cross-reference |
| `docs/compliance/eu-ai-act.md` | Article 50 section and summary row; status block notes Art. 50 in force |
| `LIMITATIONS.md`, `docs/index.md`, `docs/getting-started.md`, `docs/tutorials/hardware-attestation.md`, `docs/tutorials/hitl-approval-workflows.md`, `examples/hitl/README.md` | Date stamps |
| `CHANGELOG.md` | `[SPEC]` entries under Unreleased |

Editorial only. No schema, field, or code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
