### PR TITLE
fix(deps): allow cryptography 50 so pip-audit passes

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   "pydantic>=2.7,<3",
-  "cryptography>=42,<50",
+  "cryptography>=42,<51",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`pip-audit` fails on every open PR:

```
Found 1 known vulnerability in 1 package
cryptography 49.0.0  PYSEC-2026-3552  Fix: 50.0.0
```

The pin was `cryptography>=42,<50`, which excludes the fixed release. `main` last ran CI on 2026-08-03, before the advisory landed, so this is not a regression from any one PR — it blocks all of them (#277, #274, #270).

Cap widened to `<51`. The floor stays at 42 deliberately: raising it forces the bump on every consumer for an advisory whose impact on this package has not been assessed. If it turns out to matter here, the floor is a separate and deliberate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)