### PR TITLE
spec: state the boundary with Agent Plugins (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ### Added
 
+**[SPEC] Section 6.5 states the boundary with Agent Plugins** (#281). Agent Plugins 1.0.0 shipped as a packaging format for Agent Skills and MCP server configuration, backed by a multi-vendor steering committee, and the obvious reading from outside is that this project is a second format for the same job. It is not, and the specification had nowhere that said so.
+
+The boundary in one sentence: Agent Plugins describes what a client should install, a manifest describes what actually ran. A plugin bundle is an input to a manifest.
+
+The section argues that from the format's own documents rather than by assertion. `plugin.json` requires two fields, `$schema` and `name`, `version` is an unconstrained string, and there is no integrity, signature or provenance field in the 1.0.0 schema. `FUTURE_CONSIDERATIONS.md` states that v1.0.0 "does not define a trust model, permission system, or sandboxing requirements for plugins" and "does not specify how clients or users can verify the origin or integrity of a plugin", and lists attestation chains linking a published plugin to its source repository and build as possible future work.
+
+Of the ten artifacts, Agent Plugins carries two, and carries both as declarations rather than as resolutions: `skills/*/SKILL.md` holds instruction material, and `mcp.json` declares which servers to start without enumerating the tools those servers exposed. That declared-versus-resolved gap is the boundary in miniature.
+
+It stays informative for the same reason 6.4 does. Binding to `plugin.json` now would fix a field layout in a 1.0.0 format whose own roadmap anticipates adding provenance, so it would have to be revised rather than refined once that lands. The `extensions` object, keyed by reverse-domain namespace, is noted as sufficient to carry a manifest reference without any change to the format.
+
 **[SPEC] Section 6.4 is an informative crosswalk to OCSF runtime evidence** (#269). There was no defined join key between a manifest and the OCSF events emitted under it, so a consumer holding both could not tell they described the same agent without an out-of-band convention, and implementers were left to invent a second identity mechanism for a job this specification already does. The new section records the intended correspondence and deliberately requires nothing.
 
 Three things it gets right that a normative version could not yet: it is written against the **`ai_operation` profile**, which is what actually contributes `ai_agent`, rather than against an event class (the `Agent Inventory Info [5050]` class proposed for this does not exist in OCSF — there is no `agent_inventory_info.json` and no occurrence of `5050` anywhere in `ocsf-schema`); it maps `ai_agent.uid` to the durable identity and `instance_uid` to the session-scoped one, which is what OCSF's own definitions ask for, instead of collapsing both onto `agent_id`; and it notes that `session_uid` is not an `ai_agent` attribute at all.
@@ -15,6 +25,10 @@ It stays informative because `agent_id` is one field serving both roles, and sec
 The section also records a correspondence worth more than the identity one: OCSF's `delegation` object (`uid`, `parent_uid`, forming a re-delegation DAG) is structurally the delegation chain of section 3.4. It does not map today, because a section 3.4 hop has no per-hop durable identifier to populate `delegation.uid`, and OCSF wants that identifier issued by a trusted authority rather than self-asserted by the delegator. Closing that is a data-model change, not a crosswalk, and is not proposed here.
 
 **[SPEC] Section 9.1.2 maps EU AI Act Article 50, and maps it as a gap.** Article 50 transparency duties have applied since 2 August 2026: chatbot disclosure, machine-readable marking of synthetic output, emotion-recognition notice. It is the only AI Act obligation in force against an agent deployment today, and no document in this repository mentioned it. The manifest satisfies none of the four paragraphs, so the new subsection says that in those words, notes that Article 50 applies regardless of Annex III classification, and states that a manifest MUST NOT be read as Article 50 evidence. `docs/compliance/eu-ai-act.md` carries the same mapping for auditors. Marking that binds to the attested agent that produced the output, rather than to a strippable metadata field, is the design being pursued; it is not built.
+
+### Fixed
+
+**[SPEC] The README pointed at a specification file that does not exist.** Three links and the spec badge referenced `spec/agent-manifest-spec-v0.1.md`, superseded by v0.2. All four now resolve.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="spec/agent-manifest-spec-v0.1.md">Specification</a> &nbsp;|&nbsp;
+  <a href="spec/agent-manifest-spec-v0.2.md">Specification</a> &nbsp;|&nbsp;
   <a href="docs/getting-started.md">Getting Started</a> &nbsp;|&nbsp;
   <a href="examples/">Examples</a> &nbsp;|&nbsp;
   <a href="CHANGELOG.md">Changelog</a>
@@ -22,7 +22,7 @@
 [![CI](https://github.com/agentrust-io/agent-manifest/actions/workflows/ci.yml/badge.svg)](https://github.com/agentrust-io/agent-manifest/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/agent-manifest?label=PyPI)](https://pypi.org/project/agent-manifest/)
-[![Spec](https://img.shields.io/badge/Spec-v0.1_·_197_tests-0ea5e9)](spec/agent-manifest-spec-v0.1.md)
+[![Spec](https://img.shields.io/badge/Spec-v0.2_·_197_tests-0ea5e9)](spec/agent-manifest-spec-v0.2.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white&style=flat)](https://discord.gg/9JWNpH7E)
 
 > **Developer Preview.** Launched at Confidential Computing Summit, June 23 2026.
@@ -70,11 +70,19 @@ signed = sign_manifest(manifest, key=signing_key)
 | | |
 |---|---|
 | 📖 Full documentation | [manifest.agentrust-io.com](https://manifest.agentrust-io.com) |
-| 📄 Specification | [spec/agent-manifest-spec-v0.1.md](spec/agent-manifest-spec-v0.1.md) |
+| 📄 Specification | [spec/agent-manifest-spec-v0.2.md](spec/agent-manifest-spec-v0.2.md) |
 | 📦 PyPI | [agent-manifest](https://pypi.org/project/agent-manifest/) |
 | 🔗 TRACE integration | [trace-spec](https://github.com/agentrust-io/trace-spec) |
 | 💬 Discussions | [GitHub Discussions](https://github.com/orgs/agentrust-io/discussions) |
 | 📋 Changelog | [CHANGELOG.md](CHANGELOG.md) |
+
+## Relationship to Agent Plugins
+
+Agent Manifest is not a package format and does not compete with one.
+
+[Agent Plugins 1.0](https://agent-plugins.org) defines how Agent Skills and MCP server configuration are packaged and moved between clients. Its `FUTURE_CONSIDERATIONS.md` leaves provenance verification, trust model and permissions to future versions. Agent Manifest starts where that stops: it binds what was actually loaded at deployment, including the resolved tool schemas rather than the declared servers, to hardware, so a third party can check that the agent that ran is the agent that was published.
+
+Put briefly, Agent Plugins describes what a client should install and a manifest describes what actually ran. A plugin bundle is an input to a manifest. See [specification section 6.5](spec/agent-manifest-spec-v0.2.md#65-relationship-to-agent-plugins).
 
 ## Standards alignment
 

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -1423,6 +1423,49 @@ The resolution is to decide whether `agent_id` splits into a stable identifier a
 
 Per section 3.1, the CoSAI WS4 working stream already owns the canonical `@context` URL for this specification. An OCSF correlation mapping belongs in the same venue, alongside the `agent_id` question above, rather than being settled here first.
 
+### 6.5 Relationship to Agent Plugins <!-- CHANGED: #281 - informative boundary statement, no normative binding -->
+
+> **This section is informative.** It defines no conformance requirement and uses no MUST. It states where this specification stops and where a packaging format starts, so that implementers do not read the two as competing descriptions of the same thing.
+
+[Agent Plugins 1.0.0](https://agent-plugins.org) is a packaging format for Agent Skills and MCP server configuration, maintained by a technical steering committee drawn from several client vendors. It is not a competitor to this specification and this specification is not a package format.
+
+The distinction in one sentence: **Agent Plugins describes what a client should install, and a manifest describes what actually ran.** Packaging is design time and portable across clients. A manifest is deployment time and bound to the environment that loaded it. A plugin bundle is therefore an input to a manifest rather than an alternative to one.
+
+#### 6.5.1 What Agent Plugins 1.0.0 leaves open
+
+The boundary is not an interpretation. It is stated in the format's own documents.
+
+`plugin.json` requires two fields, `$schema` and `name`. `version` is an unconstrained string. There is no integrity, signature or provenance field in the 1.0.0 schema.
+
+`FUTURE_CONSIDERATIONS.md` records, as non-normative future work rather than as conformance requirements:
+
+| Area | Status in 1.0.0, as stated by the format |
+|---|---|
+| Permission and approval | "v1.0.0 does not define a trust model, permission system, or sandboxing requirements for plugins." |
+| Provenance verification | "v1.0.0 does not specify how clients or users can verify the origin or integrity of a plugin." Listed future work includes signature verification and attestation chains linking a published plugin to its source repository and build. |
+| Enterprise controls | Allowlists by publisher or signature, organisation-scoped registries and compliance reporting are unspecified. |
+| Audit trail | A lifecycle event schema covering actor, action and outcome is unspecified. |
+
+The specification text further states that distribution, installation, permissions and client-specific capabilities remain under each client's control.
+
+#### 6.5.2 Artifact overlap
+
+Of the ten artifacts in section 3, Agent Plugins carries two, and carries both as declarations rather than as resolutions.
+
+| Artifact | Agent Plugins 1.0.0 |
+|---|---|
+| System prompt | Partly. `skills/*/SKILL.md` carries instruction material. |
+| Tool schemas | Partly. `mcp.json` declares which servers to start. It does not enumerate the tools those servers exposed. |
+| Policy bundle, model identity, RAG corpus, memory state, decision trace, delegation chain, supply chain provenance, human-in-the-loop approvals | Not addressed. |
+
+The declared-versus-resolved distinction is the boundary in miniature. A bundle states an intended composition. A manifest attests the composition that was actually loaded, which is the only one an incident is ever about.
+
+#### 6.5.3 Why this is not normative
+
+Binding this specification to `plugin.json` would fix a field layout in a format at 1.0.0 whose own roadmap anticipates adding provenance. A binding written now would have to be revised rather than refined once that lands.
+
+`plugin.json` carries an `extensions` object keyed by reverse-domain namespace for client-specific data, which is sufficient to carry a manifest reference without any change to the format. Whether such a reference becomes a defined profile here, or is proposed to the format's own governance process, is deferred.
+
 ## 7. Threat Model
 
 ### 7.1 Threat Classes Addressed


### PR DESCRIPTION
Closes #281.

Adds section 6.5 to the spec and a matching section to the README, saying where this specification stops and where a packaging format starts.

The boundary in one sentence: **Agent Plugins describes what a client should install, a manifest describes what actually ran.** A plugin bundle is an input to a manifest.

Informative, in the same shape as 6.4, with the `> **This section is informative.**` blockquote and no MUST.

### Why it argues rather than asserts

Everything load-bearing comes from Agent Plugins' own documents, so this does not depend on my reading of their intent:

- `plugin.json` requires two fields, `$schema` and `name`. `version` is an unconstrained string. No integrity, signature or provenance field exists in the 1.0.0 schema.
- `FUTURE_CONSIDERATIONS.md`: v1.0.0 "does not define a trust model, permission system, or sandboxing requirements for plugins" and "does not specify how clients or users can verify the origin or integrity of a plugin". Listed future work includes attestation chains linking a published plugin to its source repository and build.
- The spec text: distribution, installation, permissions and client capabilities remain under each client's control.

### The artifact table

Of the ten artifacts, Agent Plugins carries two, and carries both as declarations rather than resolutions. `mcp.json` declares which servers to start, not which tools those servers exposed. That declared-versus-resolved gap is the whole boundary in miniature, and it is the sentence I would keep if the rest were cut.

### Why not normative

Binding to `plugin.json` now fixes a field layout in a 1.0.0 format whose own roadmap anticipates adding provenance, so it would need revising rather than refining once that lands. The section notes that `extensions`, keyed by reverse-domain namespace, can already carry a manifest reference with no change to the format, and defers whether that becomes a profile here or a proposal to their governance process. That is #283 and #284.

### One thing outside the scope of the issue

Three README links and the spec badge pointed at `spec/agent-manifest-spec-v0.1.md`, which was superseded by v0.2 and does not exist. Every link to the specification from the front page was dead. Fixed here because I was editing the README anyway and adding a fourth link beside three broken ones seemed worse than the scope creep. Happy to split it out if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)