### PR TITLE
spec+sdk: declared intent, and the issuer is the one who declares it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ### Added
 
+**[SPEC][SDK] Section 3.9 adds an OPTIONAL `intent` field, declared by the issuer.** Runtime governance frameworks (AARM R2/R3 among them) ask that an action be evaluated against the agent's stated intent, and this specification had no such input. The field is one string, `intent.statement`.
+
+**The issuer declares it, and that is the whole design.** An intent the governed agent asserts about itself cannot support the check it exists for: an agent that intends to do X declares X, and the comparison becomes a formality. `intent` is therefore inside the signing pre-image, fixed before the agent runs, and the spec says an `intent` supplied outside the signed manifest — on a per-call request field, say — MUST NOT be accepted as satisfying the section.
+
+Adding a field to `SIGNED_FIELDS` would normally be a compatibility break and is not one here: `signing_pre_image` omits fields absent from the manifest rather than serializing them as `null`, so a manifest without `intent` produces byte-identical pre-image to before and its signature still verifies. A test asserts that against the exact bytes, and it fails if absent fields are ever materialized.
+
+No digest is stored beside the statement. `intent_hash()` derives `sha256:<hex>` over the canonical `intent` object on demand, so a runtime can bind the intent into a per-call receipt without a second representation that can be made to disagree with the first. It returns None when no intent is declared, which is a distinct answer from a digest over an empty statement.
+
+Section 3.9.1 states what the field does **not** give: it is an input, not an analysis. Nothing here measures whether an action is semantically consistent with the declared intent, that would need a model whose own execution would have to be attested, and an implementation MUST NOT present the presence of `intent` as evidence such a measurement happened. A structural proxy is not a semantic measure and MUST NOT be labelled as one.
+
 **[SPEC] Section 6.5 states the boundary with Agent Plugins** (#281). Agent Plugins 1.0.0 shipped as a packaging format for Agent Skills and MCP server configuration, backed by a multi-vendor steering committee, and the obvious reading from outside is that this project is a second format for the same job. It is not, and the specification had nowhere that said so.
 
 The boundary in one sentence: Agent Plugins describes what a client should install, a manifest describes what actually ran. A plugin bundle is an input to a manifest.

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -10,7 +10,7 @@ from .models import (
     Sbom, McpServer,
     EscalationPolicy, HitlRuntime,
     TransparencyLogEntry, InclusionProof,
-    LogRetention, DataScope, OperationalLifecycle,
+    LogRetention, DataScope, OperationalLifecycle, DeclaredIntent,
     PolicyLanguage, EnforcementMode, DeploymentType, MemoryType, DriftPolicy,
     RugPullPolicy, TraceType, SbomFormat, SlsaLevel, PoisoningResult,
     ApprovalMethod, ApproverIdentityType, PrincipalType, DataClassification,
@@ -21,6 +21,7 @@ from ._types import HashValue, ManifestId
 from ._canonicalize import canonicalize, canonical_hash
 from ._signing import (
     SIGNED_FIELDS,
+    intent_hash,
     signing_pre_image,
     generate_ed25519, Ed25519KeyPair, Ed25519Signer, Ed25519Verifier,
 )
@@ -100,7 +101,7 @@ __all__ = [
     "Sbom", "McpServer",
     "EscalationPolicy", "HitlRuntime",
     "TransparencyLogEntry", "InclusionProof",
-    "LogRetention", "DataScope", "OperationalLifecycle",
+    "LogRetention", "DataScope", "OperationalLifecycle", "DeclaredIntent",
     "PolicyLanguage", "EnforcementMode", "DeploymentType", "MemoryType", "DriftPolicy",
     "RugPullPolicy", "TraceType", "SbomFormat", "SlsaLevel", "PoisoningResult",
     "ApprovalMethod", "ApproverIdentityType", "PrincipalType", "DataClassification",
@@ -108,7 +109,7 @@ __all__ = [
     "ModelAttestationType", "OverrideMechanism", "TimeoutAction",
     "HashValue", "ManifestId",
     "canonicalize", "canonical_hash",
-    "SIGNED_FIELDS", "signing_pre_image",
+    "SIGNED_FIELDS", "signing_pre_image", "intent_hash",
     "generate_ed25519", "Ed25519KeyPair", "Ed25519Signer", "Ed25519Verifier",
     "COSE_MANIFEST_VERSION", "COSE_SIGN1_TAG", "COSE_SIGN_TAG",
     "ALG_EDDSA", "ALG_ML_DSA_65",

--- a/python/src/agent_manifest/_signing.py
+++ b/python/src/agent_manifest/_signing.py
@@ -141,6 +141,13 @@ SIGNED_FIELDS: tuple[str, ...] = (
     "log_retention",
     "data_scope",
     "operational_lifecycle",
+    # Spec 3.9. Adding a field here is normally a compatibility break, and is
+    # not one in this case: signing_pre_image omits fields absent from the
+    # manifest, so a manifest with no `intent` produces byte-identical
+    # pre-image to before and its signature still verifies. The field has to
+    # be in this tuple rather than outside it, because an intent the signature
+    # does not cover is an intent anyone downstream can rewrite.
+    "intent",
 )
 
 
@@ -176,6 +183,25 @@ def _b64url_decode(s: str) -> bytes:
 def _key_id(public_key_bytes: bytes) -> str:
     """sha256 hex of raw public key bytes."""
     return hashlib.sha256(public_key_bytes).hexdigest()
+
+
+def intent_hash(manifest_dict: dict[str, Any]) -> str | None:
+    """Return ``sha256:<hex>`` over the manifest's declared intent, or None.
+
+    Derived rather than stored (spec 3.9). A runtime that wants to bind the
+    intent into a per-call receipt references this digest instead of copying the
+    statement, and because it is computed from the manifest on demand there is
+    no second representation that can be made to disagree with the first.
+
+    Computed over the RFC 8785 canonical form of the whole ``intent`` object, so
+    a field added to it in a later revision is covered without changing this
+    function. Returns None when the manifest declares no intent, which is a
+    distinct answer from a digest over an empty statement.
+    """
+    intent = manifest_dict.get("intent")
+    if intent is None:
+        return None
+    return "sha256:" + hashlib.sha256(canonicalize(intent)).hexdigest()
 
 
 def signing_pre_image(manifest_dict: dict[str, Any]) -> bytes:

--- a/python/src/agent_manifest/models.py
+++ b/python/src/agent_manifest/models.py
@@ -347,6 +347,23 @@ class DataScope(SpecModel):
     dpia_reference: Optional[str] = None
 
 
+class DeclaredIntent(SpecModel):
+    """What the agent is for, declared by the issuer - spec Section 3.9.
+
+    Carried in the signing pre-image, which is the whole point: the issuer
+    declares the intent before the agent runs, so the running agent cannot
+    choose or revise it. An intent the governed agent asserts about itself
+    proves nothing, because an agent that wants to do X simply declares X.
+
+    ``statement`` is the only field. There is deliberately no stored hash
+    alongside it: two representations of one value can be made to disagree, and
+    a consumer that needs a stable reference derives it with
+    :func:`agent_manifest.intent_hash`.
+    """
+
+    statement: str = Field(min_length=1)
+
+
 class OperationalLifecycle(SpecModel):
     """EU AI Act Art. 13(3)(c)/(e) lifecycle disclosures - spec Section 9.4."""
 
@@ -702,6 +719,10 @@ class Manifest(SpecModel):
     log_retention: Optional[LogRetention] = None
     data_scope: Optional[DataScope] = None
     operational_lifecycle: Optional[OperationalLifecycle] = None
+    # OPTIONAL. Absent on every manifest issued before spec 3.9, and absent
+    # fields are omitted from the signing pre-image, so adding this field left
+    # every existing signature verifying unchanged.
+    intent: Optional[DeclaredIntent] = None
     signature: Optional[ManifestSignature] = None
     # Populated after transparency log submission (spec 3.6 ordering rules);
     # NOT covered by the signature.

--- a/python/tests/test_declared_intent.py
+++ b/python/tests/test_declared_intent.py
@@ -1,0 +1,169 @@
+"""Spec 3.9: declared intent, and why it is the issuer who declares it.
+
+The requirement this exists for (AARM R2/R3) wants the action evaluated against
+the agent's stated intent. The load-bearing decision is *who states it*. An
+intent the governed agent asserts about itself proves nothing, because an agent
+that wants to do X declares X. So intent is carried inside the issuer's signature,
+where the running agent cannot choose or revise it.
+
+Two properties are tested hardest:
+
+1. **It is covered by the signature.** An intent the signature does not cover is
+   an intent anyone downstream can rewrite, which would make the whole field
+   decorative.
+2. **Adding it broke nothing.** `signing_pre_image` omits absent fields, so a
+   manifest with no `intent` must produce byte-identical pre-image to before the
+   field existed, and its signature must still verify.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from agent_manifest import (
+    SIGNED_FIELDS,
+    DeclaredIntent,
+    intent_hash,
+    signing_pre_image,
+)
+
+STATEMENT = "Reconcile supplier invoices against the general ledger."
+
+
+def _manifest(**extra: object) -> dict:
+    manifest = {
+        "@context": "https://manifest.agentrust-io.com/v0.2/context.json",
+        "@type": "AgentManifest",
+        "manifest_id": "0197739a-8c00-7000-8000-000000000001",
+        "agent_id": "spiffe://trust.example/agent/reconciler/prod",
+        "version": "0.2",
+        "issued_at": "2026-08-11T00:00:00Z",
+        "expires_at": "2099-01-01T00:00:00Z",
+        "issuer": "spiffe://trust.example/manifest-authority",
+        "crypto_profile": "standard",
+        "artifacts": {
+            "policy_bundle": {"hash": "sha256:" + "ab" * 32, "policy_language": "cedar"},
+        },
+    }
+    manifest.update(extra)
+    return manifest
+
+
+# --------------------------------------------------------------------------
+# The signature must cover it
+# --------------------------------------------------------------------------
+
+
+def test_intent_is_in_the_signed_field_set() -> None:
+    assert "intent" in SIGNED_FIELDS
+
+
+def test_intent_reaches_the_signing_pre_image() -> None:
+    pre = signing_pre_image(_manifest(intent={"statement": STATEMENT}))
+    assert STATEMENT.encode() in pre
+
+
+def test_rewriting_the_intent_changes_the_pre_image() -> None:
+    """The property that makes the field worth having: an intent the issuer did
+    not sign cannot be substituted for one it did."""
+    honest = signing_pre_image(_manifest(intent={"statement": STATEMENT}))
+    tampered = signing_pre_image(_manifest(intent={"statement": "Do anything."}))
+    assert honest != tampered
+
+
+def test_a_tampered_intent_fails_signature_verification() -> None:
+    """End to end, through the real signing path rather than the pre-image alone."""
+    private = Ed25519PrivateKey.generate()
+    public = private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+    manifest = _manifest(intent={"statement": STATEMENT})
+    signature = private.sign(signing_pre_image(manifest))
+
+    # As issued: verifies.
+    private.public_key().verify(signature, signing_pre_image(manifest))
+
+    # Someone downstream broadens the intent and keeps the issuer's signature.
+    manifest["intent"] = {"statement": "Do anything the operator asks."}
+    from cryptography.exceptions import InvalidSignature
+
+    with pytest.raises(InvalidSignature):
+        private.public_key().verify(signature, signing_pre_image(manifest))
+    assert public  # the key identity is unchanged; only the intent moved
+
+
+# --------------------------------------------------------------------------
+# Adding the field broke nothing
+# --------------------------------------------------------------------------
+
+
+def test_a_manifest_without_intent_is_unchanged_by_the_new_field() -> None:
+    """Absent fields are omitted from the pre-image, so every signature issued
+    before spec 3.9 still verifies. Asserted against the exact bytes rather than
+    trusting the mechanism."""
+    manifest = _manifest()
+    assert "intent" not in manifest
+    pre = signing_pre_image(manifest)
+    assert b"intent" not in pre
+
+    parsed = json.loads(pre)
+    assert set(parsed) <= set(SIGNED_FIELDS)
+    assert "intent" not in parsed
+
+
+def test_an_explicit_null_intent_is_also_omitted() -> None:
+    """canonicalize excludes nulls, so `intent: null` and an absent intent
+    produce the same bytes and neither disturbs an old signature."""
+    assert signing_pre_image(_manifest(intent=None)) == signing_pre_image(_manifest())
+
+
+# --------------------------------------------------------------------------
+# The derived digest
+# --------------------------------------------------------------------------
+
+
+def test_intent_hash_is_none_when_no_intent_is_declared() -> None:
+    """Distinct from a digest over an empty statement: nothing was declared."""
+    assert intent_hash(_manifest()) is None
+
+
+def test_intent_hash_is_stable_and_prefixed() -> None:
+    manifest = _manifest(intent={"statement": STATEMENT})
+    first = intent_hash(manifest)
+    assert first is not None
+    assert first.startswith("sha256:")
+    assert len(first) == len("sha256:") + 64
+    assert intent_hash(_manifest(intent={"statement": STATEMENT})) == first
+
+
+def test_intent_hash_changes_with_the_statement() -> None:
+    a = intent_hash(_manifest(intent={"statement": STATEMENT}))
+    b = intent_hash(_manifest(intent={"statement": STATEMENT + " Only."}))
+    assert a != b
+
+
+def test_intent_hash_covers_the_whole_object_not_just_the_statement() -> None:
+    """So a field added to intent in a later revision is covered without this
+    function changing."""
+    a = intent_hash(_manifest(intent={"statement": STATEMENT}))
+    b = intent_hash(_manifest(intent={"statement": STATEMENT, "scope": "invoices"}))
+    assert a != b
+
+
+# --------------------------------------------------------------------------
+# The model
+# --------------------------------------------------------------------------
+
+
+def test_statement_is_required_and_non_empty() -> None:
+    with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError
+        DeclaredIntent(statement="")
+
+
+def test_intent_carries_no_stored_hash() -> None:
+    """A stored digest beside the statement is two representations of one value
+    that can be made to disagree; the digest is derived instead."""
+    assert set(DeclaredIntent.model_fields) == {"statement"}

--- a/python/tests/test_signing.py
+++ b/python/tests/test_signing.py
@@ -323,6 +323,7 @@ def test_signed_fields_match_spec_coverage_table():
         "log_retention",
         "data_scope",
         "operational_lifecycle",
+        "intent",
     )
 
 

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -892,6 +892,7 @@ Signing coverage table (normative)
 | `log_retention` | Signed | Prevents post-signing weakening of the declared retention policy (section 8.1). |
 | `data_scope` | Signed | Prevents post-signing alteration of declared GDPR processing scope (section 9.3). |
 | `operational_lifecycle` | Signed | Prevents post-signing alteration of Art. 13 lifecycle disclosures (section 9.4). |
+| `intent` | Signed | The declared intent must be the issuer's, not the running agent's (section 3.9). An intent outside the signature is one any downstream party can rewrite, which would make the field decorative. |
 | `signature` | NOT signed | The signing object itself. |
 | `transparency_log_entry` | NOT signed | Populated after log submission (see ordering rules below). |
 
@@ -991,6 +992,32 @@ Key rotation procedure:
 7. Revoke the old signing key in the key management system
 
 Implementations MUST NOT re-use the old `manifest_id` for the rotated manifest - a new UUID v7 MUST be generated. The old manifest_id MAY be referenced in the new manifest's metadata for continuity tracing.
+
+### 3.9 Declared Intent <!-- CHANGED: new OPTIONAL top-level field; AARM R2/R3 input -->
+
+An OPTIONAL top-level `intent` object states what the agent is for.
+
+```json
+"intent": {
+  "statement": "<what this agent is for>  -- REQUIRED, non-empty>"
+}
+```
+
+**The issuer declares it, and that is the entire point.** Runtime governance frameworks increasingly ask that an action be evaluated against the agent's stated intent. An intent the governed agent asserts about itself cannot support that: an agent that intends to do X declares X, and the check becomes a formality. Because `intent` is inside the signing pre-image (section 3.6), it is fixed by the issuing authority before the agent runs, and the running agent can neither choose nor revise it. A verifier that finds an intent which does not match the issuer's signature has found tampering, not a change of plan.
+
+`intent` MUST be covered by the issuer signature. An implementation MUST NOT accept an `intent` supplied outside the signed manifest — for example on a per-call request field — as satisfying this section, because such a value is self-asserted by the party being governed.
+
+**One field, and no stored digest.** A consumer that needs a stable reference to the intent, such as a runtime binding it into a per-call receipt, derives it as the `sha256:` digest of the RFC 8785 canonical form of the whole `intent` object. That digest is computed on demand and MUST NOT be stored inside the manifest beside the statement: two representations of one value can be made to disagree, and the signature already makes the statement tamper-evident.
+
+**Compatibility.** `intent` is OPTIONAL, and a manifest that omits it is unaffected. Per the null-omission rule in section 2.3 and the signing coverage table in section 3.6, a signed field absent from the manifest is omitted from the pre-image rather than serialized as `null`, so every signature issued before this section existed verifies unchanged.
+
+#### 3.9.1 What this does not provide
+
+This section defines an input, not an analysis. It specifies no way to measure whether an action is *semantically* consistent with the declared intent, and an implementation MUST NOT present the presence of `intent` as evidence that such a measurement was performed.
+
+Measuring semantic distance from a stated intent requires comparing meaning, which needs a model, and the trustworthiness of that comparison then depends on which model ran and whether its execution was itself attested. That is out of scope here and is deliberately left unclaimed rather than approximated. A structural proxy — scope overlap, tool category distance — is not a semantic measure and MUST NOT be labelled as one.
+
+What the field does give is a signed, pre-execution statement of purpose that a verifier can read, bind to a receipt, and compare across manifests for the same agent.
 
 ## 4. Cryptographic Protocols
 


### PR DESCRIPTION
First half of the AARM R2/R3 work (cmcp#457). This adds the input; cMCP consuming it follows separately.

## The decision that matters is who declares it

AARM R2 and R3 want an action evaluated against the agent's stated intent, and this spec had no such input. The obvious cheap route is a per-call field the caller sets — cMCP already has `_cmcp.workflow_id` and, pending cmcp#498, `_cmcp.data_class`, so the pattern exists.

**That route cannot support the check it exists for.** An intent the governed agent asserts about itself is worthless against an adversary: an agent that intends to do X declares X, and the comparison becomes a formality. `_cmcp.data_class` gets away with self-assertion only because #498 makes a declaration able to *raise* sensitivity and never lower it. Intent has no equivalent monotonic escape hatch.

So `intent` goes in the signed manifest, fixed by the issuing authority before the agent runs:

```json
"intent": { "statement": "Reconcile supplier invoices against the general ledger." }
```

The spec states it explicitly: an `intent` supplied outside the signed manifest MUST NOT be accepted as satisfying section 3.9. A verifier that finds an intent not matching the issuer's signature has found tampering, not a change of plan.

## Adding to SIGNED_FIELDS without breaking a single signature

`SIGNED_FIELDS` is declared "fixed and normative", and adding to it would normally invalidate every signature ever issued. It does not here:

```python
subset = {k: manifest_dict[k] for k in SIGNED_FIELDS if k in manifest_dict}
```

Absent fields are omitted, so a manifest without `intent` produces **byte-identical** pre-image to before. Asserted against the actual bytes rather than trusting the mechanism.

I mutation-tested it, and the first attempt was a dud worth reporting: defaulting absent keys to `None` did **not** fail the test, because `canonicalize` strips nulls anyway. Defaulting them to `""` does fail it, on both compatibility tests. So the property has two independent guards and the test genuinely catches a byte-level change.

The spec's own rule ("a future spec version that introduces a new top-level field MUST add it to this table") is satisfied, and `test_signed_fields_match_spec_coverage_table` caught me before I forgot — it pins the code tuple against the §3.6 table.

## No stored digest

`intent_hash()` derives `sha256:<hex>` over the canonical `intent` object on demand, so a runtime can bind intent into a per-call receipt without a second copy of the statement. Storing a digest beside the text would be two representations of one value that can be made to disagree — the same reasoning that kept `runtime_correlation_key` out of cMCP and a stored hash out of the OCSF crosswalk. It returns `None` when nothing was declared, which is a distinct answer from a digest over an empty string.

## §3.9.1 — what this deliberately does not do

It is an input, not an analysis. Nothing here measures whether an action is *semantically* consistent with the declared intent, and the spec forbids presenting the field's presence as evidence that it was. Doing it properly needs a model, and the trust in that comparison then rests on which model ran and whether its execution was attested — out of scope, and left unclaimed rather than approximated.

**AARM R7 is therefore not claimed.** The issue itself warns that catalog rug-pull and injection detection are a different thing and easy to mistake for R7; a structural proxy MUST NOT be labelled as a semantic measure.

## Tests

12 new tests, including the tamper case end-to-end through the real signing path. Suite: **843 passed, 6 skipped**. `ruff`, `mypy` and `bandit` clean.

## Next, not here

- cMCP: consume `intent` for R2/R3 context, and a named conformance profile making manifest binding mandatory to close R6 without breaking the developer default.
- R9 stays documented as partial (deny-based rather than scope-based credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)