### PR TITLE
release: python-v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-08-11
+
 ### Added
 
 **[SPEC][SDK] Section 3.9 adds an OPTIONAL `intent` field, declared by the issuer.** Runtime governance frameworks (AARM R2/R3 among them) ask that an action be evaluated against the agent's stated intent, and this specification had no such input. The field is one string, `intent.statement`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.10.0"
+version = "0.11.0"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -71,9 +71,6 @@ include = ["src/", "tests/", "README.md", "LICENSE"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-
-[tool.hatch.version]
-path = "src/agent_manifest/__init__.py"
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
Cuts a release so cMCP can consume `intent_hash` from a published wheel instead of duplicating the derivation. cmcp installs agent-manifest from PyPI in CI, and **0.10.1 does not carry it**, so the cMCP half of the AARM work is blocked until this ships.

## Contents since 0.10.x

- v0.2 COSE envelope behind the version gate (#274)
- Agent Plugins boundary + bundle adapter (#286, #287)
- Informative OCSF crosswalk (#285)
- Declared intent, spec §3.9 (#288)

## Two versioning problems found on the way

**The repo was behind PyPI.** `[project] version` said `0.10.0` while PyPI already had `0.10.1`, and the CHANGELOG had no 0.10.1 entry either — so that release went out without a bump.

That matters more than it sounds, because **the publish workflow does not validate the tag against the version**:

```yaml
on:
  push:
    tags: ["python-v*"]
```

Nothing checks that `python-v0.11.0` corresponds to `version = "0.11.0"`. Tagging with pyproject left at 0.10.0 would have built and tried to upload **0.10.0 again**, colliding with what is already published. The bump is mandatory, not cosmetic. Worth considering a tag-vs-version assertion in that workflow as a follow-up.

**Removed a dead `[tool.hatch.version]` block.** It pointed at a `__version__` in `__init__.py` that does not exist and never has — `git log -S"__version__"` returns nothing. hatchling ignores it because `version` is static in `[project]`, so it is inert today and a trap for whoever later adds `dynamic = ["version"]`, at which point the build breaks with no obvious cause.

## Verified against the artifact, not the assumption

Built the wheel and installed it into a **clean venv**, because an editable install would have masked exactly the gap this release exists to close:

```
wheel version: 0.11.0
has intent_hash: True
has DeclaredIntent: True
intent in SIGNED_FIELDS: True
```

## After merge

Tag `python-v0.11.0` on main to trigger the publish workflow, then bump cmcp's floor to `agent-manifest>=0.11` and build the R2 consumption there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)