### PR TITLE
fix: require core claims before manifest appraisal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- `verify_manifest()` now fails closed when a core identity, validity, or artifact-container claim is missing. A valid signature no longer turns such a structurally incomplete object into a `VALID` manifest; legacy v0.1 issuer omission remains compatible unless issuer authorization is configured.
+
 All notable changes to Agent Manifest are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Spec changes are marked **[SPEC]**; SDK changes are marked **[SDK]**.
 
 ## [Unreleased]

--- a/docs/tutorials/server-side-verification.md
+++ b/docs/tutorials/server-side-verification.md
@@ -55,6 +55,13 @@ if result.result != OverallResult.VALID:
 
 Pass hashes for any artifacts you can observe at runtime. Fields left as `None` in the context are skipped and return `FieldResult.NOT_BOUND`, not a mismatch.
 
+`NOT_BOUND` applies only to observations omitted from the trusted runtime
+context. It does not make required claims optional in the signed manifest:
+`verify_manifest()` rejects a manifest missing `manifest_id`, `agent_id`,
+`issued_at`, `expires_at`, or `artifacts` as a schema mismatch before appraisal.
+For legacy v0.1 compatibility, a missing `issuer` is rejected when
+`trusted_key_issuers` authorization is configured.
+
 ```python
 import hashlib
 

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -278,14 +278,11 @@ def _signature_key_issuer_mismatch(
 def _strict_schema_violations(manifest: dict[str, Any]) -> list[tuple[str, str]]:
     """Run the manifest through the Pydantic schema and return fail-closed errors.
 
-    Returns a list of (location, message) tuples for every validation error
-    that is NOT a tolerated "missing required field" error. An empty list
-    means the manifest carries no disqualifying schema violation.
-
-    Tolerated: ``missing`` errors only. Disqualifying: unknown fields
-    (``extra_forbidden``), type errors, bad enums, unparseable or
-    out-of-window timestamps, and any ``value_error`` raised by a model
-    validator (e.g. the expiry-window rule).
+    Returns a list of (location, message) tuples for every validation error,
+    except legacy omissions inside individual artifact-binding objects. The
+    verifier historically appraises those incomplete bindings as ``NOT_BOUND``;
+    that compatibility does not extend to the required top-level claims that
+    define the manifest's identity, authority, validity, and signed contents.
     """
     from pydantic import ValidationError
 
@@ -303,9 +300,12 @@ def _strict_schema_violations(manifest: dict[str, Any]) -> list[tuple[str, str]]
     except ValidationError as exc:
         violations: list[tuple[str, str]] = []
         for err in exc.errors():
-            if err.get("type") == "missing":
+            loc_parts = err.get("loc", ())
+            if err.get("type") == "missing" and (
+                len(loc_parts) > 1 or loc_parts == ("issuer",)
+            ):
                 continue
-            loc = ".".join(str(p) for p in err.get("loc", ()))
+            loc = ".".join(str(p) for p in loc_parts)
             violations.append((loc, err.get("msg", "schema error")))
         return violations
     return []
@@ -366,12 +366,9 @@ def verify_manifest(
     # the verify path. A malformed expires_at is a schema failure here, not a
     # silently non-expiring manifest.
     #
-    # Only pure "missing required field" errors are tolerated: the engine
-    # treats absent artifact bindings and metadata as NOT_BOUND and degrades
-    # safely, and requiring every business field would reject otherwise
-    # well-formed manifests the engine can still evaluate. Every other class of
-    # error (unknown field, wrong type, bad enum, unparseable/out-of-window
-    # timestamp, or any value_error from a model validator) fails closed.
+    # Required top-level claims fail closed. Missing runtime observations in the
+    # VerificationContext still produce NOT_BOUND; legacy omissions nested in
+    # individual artifact bindings retain that same compatibility behavior.
     schema_violations = _strict_schema_violations(manifest)
     if schema_violations:
         result.result = OverallResult.MISMATCH

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -2,6 +2,8 @@
 import hashlib
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from agent_manifest import _signing
 from agent_manifest._signing import Ed25519Signer, _b64url_encode, generate_ed25519
 from agent_manifest._verify import (
@@ -86,6 +88,24 @@ def test_valid_all_match():
     assert result.fields_verified.system_prompt == FieldResult.MATCH
     assert result.fields_verified.policy_bundle == FieldResult.MATCH
     assert result.mismatch_details == []
+
+
+@pytest.mark.parametrize(
+    "required_field",
+    ["manifest_id", "agent_id", "issued_at", "expires_at", "artifacts"],
+)
+def test_signed_manifest_missing_required_claim_is_not_valid(required_field):
+    manifest = base_manifest()
+    manifest.pop(required_field)
+    sign(manifest)
+
+    result = verify_manifest(manifest, base_context(), store())
+
+    assert result.result == OverallResult.MISMATCH
+    assert any(
+        detail.field == f"schema:{required_field}"
+        for detail in result.mismatch_details
+    )
 
 
 def test_valid_unbound_fields_not_mismatch():


### PR DESCRIPTION
## Summary

Fail closed when a signed manifest omits a core top-level claim used for identity, validity, or artifact appraisal (`manifest_id`, `agent_id`, `issued_at`, `expires_at`, or `artifacts`). Previously, Pydantic `missing` errors were universally ignored, allowing a correctly signed but structurally incomplete object to reach `VALID`.

Legacy v0.1 manifests that omit `issuer` remain compatible unless `trusted_key_issuers` authorization is configured. Missing fields inside legacy artifact bindings also retain their existing `NOT_BOUND` behavior.

## Tests

- Added a parameterized regression test covering every enforced core claim
- Full suite: 853 passed, 4 skipped
- mypy: clean
- Bandit: clean
- `git diff --check`: clean

## Documentation

- Documented the distinction between missing signed claims and missing trusted runtime observations
- Added an Unreleased security changelog entry