### PR TITLE
fix: enforce the complete manifest validity window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Security
+
+- `verify_manifest()` now rejects manifests whose `issued_at` is in the future and treats `expires_at` as an exclusive upper bound, enforcing the specification's full `issued_at <= now < expires_at` validity window.
+
 ## [0.11.0] — 2026-08-11
 
 ### Added

--- a/docs/tutorials/server-side-verification.md
+++ b/docs/tutorials/server-side-verification.md
@@ -21,7 +21,7 @@ pip install "agent-manifest[server]"
 The verifier checks six things in order, stopping at the first hard failure:
 
 1. **Revocation**  -  is this manifest ID in the revocation store?
-2. **Expiry**  -  is `expires_at` in the past?
+2. **Validity window**  -  does the current time satisfy `issued_at <= now < expires_at`?
 3. **Artifact hashes**  -  do the hashes in the manifest match what is actually running?
 4. **Delegation chain**  -  is every hop signed by its parent?
 5. **HITL record**  -  if approval was required, is a valid, unexpired one present?

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -396,12 +396,23 @@ def verify_manifest(
         result.result = OverallResult.REVOKED
         return result
 
-    # --- Expiry check
+    # --- Validity-window check (spec 5.3: issued_at <= now < expires_at)
+    issued_at = manifest.get("issued_at")
     expires_at = manifest.get("expires_at")
-    if expires_at:
+    if issued_at and expires_at:
         try:
+            issued = datetime.fromisoformat(issued_at.replace("Z", "+00:00"))
             exp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
-            if exp < datetime.now(timezone.utc):
+            now = datetime.now(timezone.utc)
+            if issued > now:
+                result.result = OverallResult.MISMATCH
+                result.mismatch_details = [MismatchDetail(
+                    field="validity.issued_at",
+                    expected_hash="<issued_at at or before verification time>",
+                    actual_hash=f"<{issued_at}>",
+                )]
+                return result
+            if exp <= now:
                 result.result = OverallResult.EXPIRED
                 return result
         except (ValueError, AttributeError):

--- a/python/tests/test_am_verify.py
+++ b/python/tests/test_am_verify.py
@@ -217,6 +217,22 @@ def test_expired_returns_early_no_field_checks():
     assert r.result == OverallResult.EXPIRED
     assert r.mismatch_details == []
 
+def test_future_issued_manifest_is_not_valid():
+    issued_at = (datetime.now(timezone.utc) + timedelta(days=1))
+    expires_at = issued_at + timedelta(days=1)
+
+    r = verify_manifest(
+        manifest(
+            issued_at=issued_at.isoformat().replace("+00:00", "Z"),
+            expires_at=expires_at.isoformat().replace("+00:00", "Z"),
+        ),
+        ctx(),
+        store(),
+    )
+
+    assert r.result == OverallResult.MISMATCH
+    assert [detail.field for detail in r.mismatch_details] == ["validity.issued_at"]
+
 def test_memory_baseline_expired():
     m = manifest()
     m["artifacts"]["memory_baseline"] = {


### PR DESCRIPTION
## Summary

Enforce the normative validity condition `issued_at <= now < expires_at`. Previously the verifier checked only whether `expires_at` was in the past, so a correctly signed manifest with a future `issued_at` could be accepted as `VALID`.

Future-issued manifests now fail closed with a `validity.issued_at` mismatch. The expiry boundary is also exclusive as specified.

## Tests

- Added a regression test for a correctly signed future-issued manifest
- Focused verification tests: 51 passed
- Full suite: 849 passed, 4 skipped
- mypy: clean
- `git diff --check`: clean

## Documentation

- Updated the server verification tutorial to describe the complete validity-window check
- Added an Unreleased security changelog entry