### PR TITLE
fix: authenticate CRL records before append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Security
+
+- `FileCRL.revoke()` now verifies a record's signature and signer key ID before mutating its cache or append-only file whenever `trusted_signer_key` is configured. This closes an append-time bypass of the existing load-time trust check.
+
 ## [0.11.0] — 2026-08-11
 
 ### Added

--- a/docs/tutorials/revocation-and-key-rotation.md
+++ b/docs/tutorials/revocation-and-key-rotation.md
@@ -57,15 +57,16 @@ manifest revoke 018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c \
   --output revocation.json
 ```
 
-Append the record to the CRL file and verify the record's own signature before trusting it:
+Configure the trusted revocation authority on the CRL, then append the record.
+`FileCRL.revoke()` verifies both its signature and `signer_key_id` before changing
+the file or in-memory cache:
 
 ```python
-crl = FileCRL("revocations.jsonl")
+crl = FileCRL(
+    "revocations.jsonl",
+    trusted_signer_key=revocation_kp.public_bytes,
+)
 crl.revoke(record)
-
-# Verify the revocation record's signature before trusting it
-verify_revocation_signature(record, revocation_kp.public_bytes)
-# Raises cryptography.exceptions.InvalidSignature if the record was tampered
 
 assert crl.is_revoked(manifest_id)
 print(f"CRL now contains {len(crl.all_records())} record(s)")

--- a/python/src/agent_manifest/_revocation.py
+++ b/python/src/agent_manifest/_revocation.py
@@ -88,11 +88,13 @@ def verify_revocation_signature(
     """
     import base64
     from cryptography.exceptions import InvalidSignature
-    from ._signing import Ed25519Verifier as _Ed25519Verifier
+    from ._signing import Ed25519Verifier as _Ed25519Verifier, _key_id
 
     # CRL-001: null/empty signature must raise InvalidSignature, not ValueError
     if not record.revocation_signature:
         raise InvalidSignature("revocation_signature is absent or null")
+    if record.signer_key_id != _key_id(signer_public_key):
+        raise InvalidSignature("signer_key_id does not identify the trusted signer key")
 
     sig = record.revocation_signature
     if len(sig) < 86:  # Ed25519 sig = 64 bytes = 86 base64url chars (no padding)
@@ -187,6 +189,8 @@ class FileCRL:
 
     def revoke(self, record: SignedRevocationRecord) -> None:
         """Append a revocation record to the CRL file."""
+        if self._trusted_signer_key is not None:
+            verify_revocation_signature(record, self._trusted_signer_key)
         with self._lock:
             self._cache[record.manifest_id] = record
             with open(self._path, "a") as f:

--- a/python/tests/test_revocation.py
+++ b/python/tests/test_revocation.py
@@ -200,6 +200,32 @@ def test_file_crl_signature_survives_roundtrip(tmp_path):
     verify_revocation_signature(loaded, kp.public_bytes)  # must not raise
 
 
+def test_file_crl_rejects_untrusted_record_before_append(tmp_path):
+    trusted = generate_ed25519()
+    untrusted = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl = FileCRL(path, trusted_signer_key=trusted.public_bytes)
+
+    with pytest.raises(InvalidSignature):
+        crl.revoke(sign_revocation(MID, "untrusted", "attacker", untrusted))
+
+    assert not crl.is_revoked(MID)
+    assert not path.exists()
+
+
+def test_revocation_rejects_mismatched_signer_key_id(tmp_path):
+    trusted = generate_ed25519()
+    record = sign_revocation(MID, "test", "admin", trusted).model_copy(
+        update={"signer_key_id": "sha256:" + "0" * 64}
+    )
+    crl = FileCRL(tmp_path / "crl.jsonl", trusted_signer_key=trusted.public_bytes)
+
+    with pytest.raises(InvalidSignature):
+        crl.revoke(record)
+
+    assert not crl.is_revoked(MID)
+
+
 # ---------------------------------------------------------------------------
 # FastAPI CRL router
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make `FileCRL` enforce its configured trust boundary consistently. When `trusted_signer_key` is set, `revoke()` now verifies the record before changing either the in-memory cache or append-only file. Previously signatures were checked only while loading existing records, so an unsigned or attacker-signed record could be accepted for the lifetime of the process and persisted.

The verifier also binds `signer_key_id` to the actual trusted public key, preventing misleading signer metadata.

## Tests

- Added append-time rejection coverage for attacker-signed records
- Asserted rejected records do not mutate cache or disk
- Added signer-key-ID mismatch coverage
- Focused revocation tests: 27 passed
- Full suite: 850 passed, 4 skipped
- mypy: clean
- `git diff --check`: clean

## Documentation

- Updated the revocation tutorial to configure the trusted signer before append
- Added an Unreleased security changelog entry