### PR TITLE
test: prevent stale wheels from shadowing checkout code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Agent Manifest are documented here. Format follows [Keep 
 
 ## [Unreleased]
 
+### Fixed
+
+- The Python test harness now pins imports to the checkout's `src` tree and asserts that location, preventing a stale installed `agent-manifest` wheel from producing misleading release-validation results.
+
 ## [0.11.0] — 2026-08-11
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,11 @@ Run tests:
 pytest -v
 ```
 
+Pytest is configured to import `python/src` ahead of any globally installed
+`agent-manifest` wheel. A regression guard fails if the suite resolves the
+package outside the checkout, so local results always exercise the code under
+review.
+
 Run type checking:
 
 ```bash

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -71,6 +71,7 @@ include = ["src/", "tests/", "README.md", "LICENSE"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+pythonpath = ["src"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/python/tests/test_import_environment.py
+++ b/python/tests/test_import_environment.py
@@ -1,0 +1,14 @@
+"""Guard against running the suite against a stale installed wheel."""
+
+from pathlib import Path
+
+import agent_manifest
+
+
+def test_tests_import_the_checkout_source_tree() -> None:
+    package_path = Path(agent_manifest.__file__).resolve()
+    source_tree = (Path(__file__).parents[1] / "src").resolve()
+
+    assert package_path.is_relative_to(source_tree), (
+        f"tests imported agent_manifest from {package_path}, not {source_tree}"
+    )


### PR DESCRIPTION
## Summary

Pin pytest imports to the checkout's `python/src` tree and add an explicit regression guard that fails if `agent_manifest` resolves elsewhere.

During the release audit, a plain local pytest run imported an older installed wheel instead of the code under review. That can produce false failures, false confidence, or allow release validation to exercise the wrong artifact.

## Tests

- Added a source-location regression assertion
- Ran the full suite with no `PYTHONPATH` override: 849 passed, 4 skipped
- mypy: clean
- `git diff --check`: clean

## Documentation

- Documented source-tree import behavior in CONTRIBUTING
- Added an Unreleased fix entry