### PR TITLE
feat(verify): verify the Level 3 TRACE claim signature and evidence pack (#204)

### DIFF
--- a/docs/api-reference/verification.md
+++ b/docs/api-reference/verification.md
@@ -49,6 +49,58 @@ externally retained evidence pack that a verifier can record alongside a result.
 
 ::: agent_manifest._verify.EvidencePack
 
+## TRACE envelopes and evidence packs
+
+`EvidencePack` above is only a *reference* to a pack. To appraise the pack
+itself, and the per-tool-call TRACE envelopes inside it, use:
+
+```python
+from agent_manifest import verify_evidence_pack, verify_trace_envelope
+```
+
+A TRACE envelope (spec §6.3.2) is signed by a TEE-sealed key over the RFC 8785
+canonical form of every field except `signature`. The envelope carries no
+algorithm or key id of its own, so the caller supplies both; `trusted_keys` uses
+the same `key_id` → base64url public key mapping as `VerificationContext`. An
+evidence pack (spec §5.2.1) instead carries a detached `pack_signature` object
+in the form of §3.6, so hybrid signatures work there but not on envelopes.
+
+Read `admissible`, not just `status`. A TRACE reporting
+`manifest_verification_result: MISMATCH` or `EXPIRED` can have a perfectly valid
+signature — the runtime honestly recorded a bad state — but spec §6.3.2 says it
+"MUST NOT be accepted as evidence of a valid tool call for regulatory reporting
+purposes". `verify_trace_envelope()` returns `status=VERIFIED` with
+`admissible=False` in that case.
+
+Passing `manifest=` additionally enforces the §6.3.2 hash-conflict rule
+(SCHEMA F-21): if the envelope's `policy_hash` differs from the manifest's
+`artifacts.policy_bundle.hash`, the envelope must declare `MISMATCH`. One that
+claims `VALID` over a conflicting hash is a spec violation and fails.
+
+Verification is fail-closed: a missing key, an unknown algorithm, or a build
+without the `[pq]` extra yields `UNVERIFIABLE`, never `VERIFIED`.
+
+::: agent_manifest._trace.verify_trace_envelope
+
+::: agent_manifest._trace.verify_evidence_pack
+
+::: agent_manifest._trace.TraceVerificationResult
+
+::: agent_manifest._trace.EvidencePackVerificationResult
+
+::: agent_manifest._trace.TraceStatus
+
+`compute_pack_hash()` returns the spec §5.2.1 `pack_hash` — the SHA-256 of the
+pack's canonical bytes excluding `pack_signature`. `trace_signing_pre_image()`
+and `evidence_pack_pre_image()` are the shared pre-image functions; producers
+and verifiers MUST both use them so the byte sequences match.
+
+::: agent_manifest._trace.compute_pack_hash
+
+::: agent_manifest._trace.trace_signing_pre_image
+
+::: agent_manifest._trace.evidence_pack_pre_image
+
 ## Revocation
 
 `RevocationStore` is the revocation lookup a verifier consults during

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -72,6 +72,12 @@ from ._verify import (
     FieldsVerified, MismatchDetail, EvidencePack,
     RevocationStore, RevocationRecord,
 )
+from ._trace import (
+    verify_trace_envelope, verify_evidence_pack,
+    trace_signing_pre_image, evidence_pack_pre_image, compute_pack_hash,
+    TraceStatus, TraceVerificationResult, EvidencePackVerificationResult,
+    TRACE_REQUIRED_FIELDS, TRACE_VERIFICATION_RESULTS, INADMISSIBLE_RESULTS,
+)
 from ._delegation import (
     verify_delegation_chain,
     verify_hitl_approval,
@@ -140,6 +146,10 @@ __all__ = [
     "OverallResult", "FieldResult", "DelegationResult", "HitlResult",
     "FieldsVerified", "MismatchDetail", "EvidencePack",
     "RevocationStore", "RevocationRecord",
+    "verify_trace_envelope", "verify_evidence_pack",
+    "trace_signing_pre_image", "evidence_pack_pre_image", "compute_pack_hash",
+    "TraceStatus", "TraceVerificationResult", "EvidencePackVerificationResult",
+    "TRACE_REQUIRED_FIELDS", "TRACE_VERIFICATION_RESULTS", "INADMISSIBLE_RESULTS",
     "verify_delegation_chain", "verify_hitl_approval", "delegation_depth_exceeded",
     "DelegationHopSigner", "HitlApprovalSigner",
     "PluginBundleError", "PluginSkill", "DeclaredMcpServer", "PluginBundle",

--- a/python/src/agent_manifest/_trace.py
+++ b/python/src/agent_manifest/_trace.py
@@ -78,6 +78,43 @@ TRACE_VERIFICATION_RESULTS: tuple[str, ...] = (
 # its signature verifies.
 INADMISSIBLE_RESULTS: frozenset[str] = frozenset({"MISMATCH", "EXPIRED"})
 
+# The four members spec 5.2.1 defines an evidence pack as carrying, with the
+# type each must have. They are checked before the signature, because a
+# signature proves who assembled a document and not that the document is the
+# thing it claims to be: a pack carrying nothing but its own `pack_signature`
+# verifies perfectly and evidences nothing. An empty `manifest` in particular
+# would silently disable the manifest-id and policy binding further down.
+EVIDENCE_PACK_REQUIRED_FIELDS: dict[str, type] = {
+    "manifest": dict,
+    "verification_result": dict,
+    "trace_envelopes": list,
+    "attestation_report": str,
+}
+
+# Presence is not enough for a TRACE envelope either. A field carrying the
+# wrong type passes a `in envelope` check and then flows into a comparison
+# that silently does nothing: `policy_hash: []` never equals the manifest's
+# hash, so the section 6.3.2 conflict rule would never fire against it.
+TRACE_FIELD_TYPES: dict[str, type] = {
+    "trace_id": str,
+    "agent_id": str,
+    "agent_manifest_id": str,
+    "manifest_verification_result": str,
+    "tool_id": str,
+    "policy_hash": str,
+    "catalog_hash": str,
+    "decision": str,
+    "decision_reason": str,
+    "payload_classification": str,
+    "egress_destination": str,
+    # hitl_required is deliberately absent: it has a dedicated check further
+    # down that names SCHEMA F-11 and says why a string is dangerous rather
+    # than merely wrong. A generic message here would replace a specific one.
+    "timestamp": str,
+    "tee_measurement": str,
+    "signature": str,
+}
+
 # Spec 6.3.2 types the envelope signature as a bare string, which cannot carry
 # the two components a hybrid signature needs.
 TRACE_SIGNATURE_ALGORITHMS: frozenset[str] = frozenset({"Ed25519", "ML-DSA-65"})
@@ -283,6 +320,16 @@ def verify_trace_envelope(
         result.failures.append("missing_required_fields:" + ",".join(missing))
         return result
 
+    # Presence checked, now shape.
+    wrong_type = [
+        name
+        for name, want in TRACE_FIELD_TYPES.items()
+        if not isinstance(envelope[name], want)
+    ]
+    if wrong_type:
+        result.failures.append("wrong_field_type:" + ",".join(sorted(wrong_type)))
+        return result
+
     mvr = envelope["manifest_verification_result"]
     if mvr not in TRACE_VERIFICATION_RESULTS:
         result.failures.append(f"illegal_manifest_verification_result:{mvr!r}")
@@ -438,6 +485,43 @@ def verify_evidence_pack(
 
     if not isinstance(pack, dict):
         result.failures.append("pack_not_an_object")
+        return result
+
+    # Structure before signature. A pack carrying only its own `pack_signature`
+    # would otherwise verify: the pre-image is computed over whatever is
+    # present, the signature covers it honestly, and the result says VERIFIED
+    # about a document with no manifest, no verification result, no envelopes
+    # and no attestation report in it.
+    missing = [f for f in EVIDENCE_PACK_REQUIRED_FIELDS if f not in pack]
+    if missing:
+        result.failures.append("missing_required_fields:" + ",".join(missing))
+        return result
+
+    wrong_type = [
+        name
+        for name, want in EVIDENCE_PACK_REQUIRED_FIELDS.items()
+        if not isinstance(pack[name], want)
+    ]
+    if wrong_type:
+        result.failures.append("wrong_field_type:" + ",".join(sorted(wrong_type)))
+        return result
+
+    # An empty manifest is well-typed and still useless: every binding check
+    # downstream reads from it, so an empty one disables them all silently.
+    if not pack["manifest"]:
+        result.failures.append("manifest_empty")
+        return result
+
+    # Non-empty is not enough either. `_check_manifest_binding` skips the
+    # manifest-id comparison when the manifest carries no `manifest_id`, so a
+    # manifest of `{"note": "..."}` is well-typed, non-empty, and still lets an
+    # envelope naming a completely different manifest through unremarked. The
+    # binding is the reason the manifest is in the pack at all, so the field it
+    # binds on is required rather than optional.
+    if not isinstance(pack["manifest"].get("manifest_id"), str) or not pack[
+        "manifest"
+    ]["manifest_id"]:
+        result.failures.append("manifest_missing_manifest_id")
         return result
 
     result.pack_hash = compute_pack_hash(pack)

--- a/python/src/agent_manifest/_trace.py
+++ b/python/src/agent_manifest/_trace.py
@@ -1,0 +1,496 @@
+"""TRACE envelope and evidence pack verification (spec 6.3.2 / 5.2.1).
+
+A TRACE envelope is the per-tool-call evidence record cMCP emits. It carries
+the agent's manifest id, the manifest verification result at the time of the
+call, the policy/catalog hashes actually in force, and the Cedar decision --
+signed by a TEE-sealed key. An evidence pack bundles the manifest, a
+verification result, the session's TRACE envelopes, and the raw attestation
+report under a single detached ``pack_signature``.
+
+Before this module the SDK stored ``trace_id`` and ``evidence_pack`` but never
+checked either signature, so any field in a TRACE could be edited after the
+fact and still be accepted as evidence (issue #204).
+
+Two pre-images, both RFC 8785 canonical JSON:
+
+  * TRACE envelope -- every field except ``signature``. Spec 6.3.2 types
+    ``signature`` as a bare string ("Ed25519 | ML-DSA-65 by TEE-sealed key"),
+    so there is no algorithm or key id in the envelope itself; the caller
+    supplies both. Hybrid is not expressible here and is rejected.
+  * Evidence pack -- every field except ``pack_signature``, which is the
+    detached signature object of spec 3.6 (algorithm and key_id inside), so
+    hybrid works there. Spec 5.2.1 defines ``pack_hash`` as the SHA-256 of
+    exactly these bytes; :func:`compute_pack_hash` returns it.
+
+Fail-closed throughout: a missing key, an unknown algorithm, or a build
+without the post-quantum extra yields ``UNVERIFIABLE``, never ``VERIFIED``.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from ._canonicalize import canonicalize
+
+
+# Fields every TRACE envelope MUST carry (spec 6.3.2). An envelope missing any
+# of them is malformed: we refuse to report a signature over a record whose
+# shape we cannot vouch for, because the absent field may be the one a relying
+# party is about to read.
+TRACE_REQUIRED_FIELDS: tuple[str, ...] = (
+    "trace_id",
+    "agent_id",
+    "agent_manifest_id",
+    "manifest_verification_result",
+    "tool_id",
+    "policy_hash",
+    "catalog_hash",
+    "decision",
+    "decision_reason",
+    "payload_classification",
+    "egress_destination",
+    "hitl_required",
+    "timestamp",
+    "tee_measurement",
+    "signature",
+)
+
+# Spec 6.3.2: manifest_verification_result "MUST use the same enum values as
+# the result field in section 5.2 - no additional values". OverallResult in
+# _verify.py additionally carries the SDK's fail-closed SIGNATURE_MISSING and
+# UNVERIFIABLE statuses; those are verifier-side outcomes and are NOT legal in
+# a producer-written TRACE envelope, so this tuple is deliberately the spec 5.2
+# seven and not a reference to that enum.
+TRACE_VERIFICATION_RESULTS: tuple[str, ...] = (
+    "VALID",
+    "MISMATCH",
+    "EXPIRED",
+    "REVOKED",
+    "INCOMPLETE",
+    "ATTESTATION_UNAVAILABLE",
+    "INCOMPATIBLE_VERSION",
+)
+
+# Spec 6.3.2: a TRACE in either state "MUST NOT be accepted as evidence of a
+# valid tool call for regulatory reporting purposes" -- independent of whether
+# its signature verifies.
+INADMISSIBLE_RESULTS: frozenset[str] = frozenset({"MISMATCH", "EXPIRED"})
+
+# Spec 6.3.2 types the envelope signature as a bare string, which cannot carry
+# the two components a hybrid signature needs.
+TRACE_SIGNATURE_ALGORITHMS: frozenset[str] = frozenset({"Ed25519", "ML-DSA-65"})
+
+
+class TraceStatus(str, Enum):
+    """Outcome of appraising a TRACE envelope or evidence pack."""
+
+    VERIFIED = "VERIFIED"
+    # Signature material was present and did not verify.
+    FAILED = "FAILED"
+    # Present but unappraisable: no trusted key, unknown algorithm, or a build
+    # without the [pq] extra. MUST NOT be treated as VERIFIED.
+    UNVERIFIABLE = "UNVERIFIABLE"
+    SIGNATURE_MISSING = "SIGNATURE_MISSING"
+    # Required fields absent or an illegal enum value: shape cannot be trusted.
+    MALFORMED = "MALFORMED"
+
+
+@dataclass
+class TraceVerificationResult:
+    """Appraisal of one TRACE envelope.
+
+    ``admissible`` is the question a relying party actually asks: may this
+    record be used as evidence of a valid tool call? That needs a verified
+    signature *and* a ``manifest_verification_result`` outside
+    :data:`INADMISSIBLE_RESULTS`. A perfectly-signed envelope reporting
+    ``MISMATCH`` is authentic and inadmissible at the same time -- the
+    signature proves the runtime honestly recorded that the policy hash did
+    not match, which is exactly the case spec 6.3.2 excludes from reporting.
+    """
+
+    status: TraceStatus
+    trace_id: Optional[str] = None
+    signature_verified: bool = False
+    admissible: bool = False
+    failures: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EvidencePackVerificationResult:
+    """Appraisal of an evidence pack and, optionally, the TRACEs inside it."""
+
+    status: TraceStatus
+    signature_verified: bool = False
+    pack_hash: Optional[str] = None
+    pack_hash_matches: Optional[bool] = None
+    envelopes: list[TraceVerificationResult] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Pre-images
+# ---------------------------------------------------------------------------
+
+
+def trace_signing_pre_image(envelope: dict[str, Any]) -> bytes:
+    """Return the RFC 8785 canonical bytes a TRACE ``signature`` covers.
+
+    Every field except ``signature`` itself. Both producers and verifiers MUST
+    call this so the byte sequences are identical.
+    """
+    return canonicalize({k: v for k, v in envelope.items() if k != "signature"})
+
+
+def evidence_pack_pre_image(pack: dict[str, Any]) -> bytes:
+    """Return the RFC 8785 canonical bytes ``pack_signature`` covers.
+
+    Every field except ``pack_signature``, which spec 5.2.1 appends to the
+    document after hashing and signing.
+    """
+    return canonicalize({k: v for k, v in pack.items() if k != "pack_signature"})
+
+
+def compute_pack_hash(pack: dict[str, Any]) -> str:
+    """Return ``"sha256:<64-hex>"`` over the pack's canonical bytes (spec 5.2.1)."""
+    return f"sha256:{hashlib.sha256(evidence_pack_pre_image(pack)).hexdigest()}"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _select_key(
+    trusted_keys: Optional[dict[str, str]],
+    key_id: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve (public_key_b64url, failure_reason) from the caller's key set.
+
+    A TRACE envelope carries no key id, so the caller names the key. When
+    exactly one key is trusted the choice is unambiguous and we take it;
+    otherwise we refuse rather than trying each key in turn, which would let
+    an envelope silently pick whichever identity happens to verify it.
+    """
+    if not trusted_keys:
+        return None, "no_trusted_keys"
+    if key_id is not None:
+        pub = trusted_keys.get(key_id)
+        if pub is None:
+            return None, f"key_id_not_trusted:{key_id}"
+        return pub, None
+    if len(trusted_keys) == 1:
+        return next(iter(trusted_keys.values())), None
+    return None, "ambiguous_key_id"
+
+
+def _verify_detached(
+    pre_image: bytes,
+    signature_block: dict[str, Any],
+    trusted_keys: dict[str, str],
+) -> tuple[TraceStatus, list[str]]:
+    """Verify a spec 3.6 detached signature object over *pre_image*.
+
+    Mirrors the algorithm dispatch the manifest path uses in ``_verify.py``.
+    """
+    from cryptography.exceptions import InvalidSignature
+
+    from ._signing import (
+        AlgorithmUnavailableError,
+        Ed25519Verifier,
+        HybridVerifier,
+        MlDsa65Verifier,
+        _b64url_decode,
+    )
+    from ._verify import _split_hybrid_public_key
+
+    algorithm = signature_block.get("algorithm")
+    key_id = signature_block.get("key_id")
+    if not algorithm:
+        return TraceStatus.MALFORMED, ["signature_block_missing_algorithm"]
+    if not key_id:
+        return TraceStatus.MALFORMED, ["signature_block_missing_key_id"]
+
+    pub_b64 = trusted_keys.get(key_id)
+    if pub_b64 is None:
+        return TraceStatus.UNVERIFIABLE, [f"key_id_not_trusted:{key_id}"]
+
+    try:
+        pub_bytes = _b64url_decode(pub_b64)
+        sig_value = signature_block.get("signature_value", "")
+        if algorithm == "Ed25519":
+            Ed25519Verifier(pub_bytes).verify_bytes(pre_image, sig_value)
+        elif algorithm == "ML-DSA-65":
+            MlDsa65Verifier(pub_bytes).verify_bytes(pre_image, sig_value)
+        elif algorithm == "hybrid-Ed25519-ML-DSA-65":
+            ed_bytes, pq_bytes = _split_hybrid_public_key(key_id, pub_bytes)
+            HybridVerifier(ed_bytes, pq_bytes).verify_bytes(pre_image, signature_block)
+        else:
+            return TraceStatus.UNVERIFIABLE, [f"unknown_algorithm:{algorithm!r}"]
+    except AlgorithmUnavailableError as exc:
+        # Capability gap, not a bad signature -- see AlgorithmUnavailableError.
+        return TraceStatus.UNVERIFIABLE, [f"algorithm_unavailable:{exc}"]
+    except InvalidSignature:
+        return TraceStatus.FAILED, ["signature_invalid"]
+    except (KeyError, ValueError) as exc:
+        return TraceStatus.FAILED, [f"signature_malformed:{type(exc).__name__}"]
+
+    return TraceStatus.VERIFIED, []
+
+
+# ---------------------------------------------------------------------------
+# TRACE envelope
+# ---------------------------------------------------------------------------
+
+
+def verify_trace_envelope(
+    envelope: dict[str, Any],
+    *,
+    trusted_keys: Optional[dict[str, str]] = None,
+    key_id: Optional[str] = None,
+    algorithm: str = "Ed25519",
+    manifest: Optional[dict[str, Any]] = None,
+) -> TraceVerificationResult:
+    """Verify one TRACE envelope's signature and manifest binding (spec 6.3.2).
+
+    Args:
+        envelope: The TRACE envelope dict.
+        trusted_keys: key_id (sha256 hex of raw public key bytes) -> base64url
+            public key. The envelope carries no key id of its own.
+        key_id: Which trusted key signed this envelope. Optional when exactly
+            one key is trusted.
+        algorithm: ``"Ed25519"`` or ``"ML-DSA-65"``. Spec 6.3.2 types the
+            envelope signature as a bare string, so hybrid is not expressible.
+        manifest: When supplied, enforces the spec 6.3.2 hash-conflict rule
+            (SCHEMA F-21) against ``artifacts.policy_bundle.hash``.
+
+    Returns:
+        A :class:`TraceVerificationResult`. Check ``admissible`` before using
+        the envelope as evidence -- a verified signature alone is not enough.
+    """
+    result = TraceVerificationResult(status=TraceStatus.MALFORMED)
+    result.trace_id = envelope.get("trace_id") if isinstance(envelope, dict) else None
+
+    if not isinstance(envelope, dict):
+        result.failures.append("envelope_not_an_object")
+        return result
+
+    missing = [f for f in TRACE_REQUIRED_FIELDS if f not in envelope]
+    if missing:
+        result.failures.append("missing_required_fields:" + ",".join(missing))
+        return result
+
+    mvr = envelope["manifest_verification_result"]
+    if mvr not in TRACE_VERIFICATION_RESULTS:
+        result.failures.append(f"illegal_manifest_verification_result:{mvr!r}")
+        return result
+
+    if not isinstance(envelope["hitl_required"], bool):
+        # SCHEMA F-11 fixed this to a JSON boolean; a string "true" would make
+        # an unapproved call look approved to a reader doing a truthiness test.
+        result.failures.append("hitl_required_not_a_boolean")
+        return result
+
+    signature = envelope["signature"]
+    if not signature or not isinstance(signature, str):
+        result.status = TraceStatus.SIGNATURE_MISSING
+        result.failures.append("signature_absent_or_not_a_string")
+        return result
+
+    if algorithm not in TRACE_SIGNATURE_ALGORITHMS:
+        result.status = TraceStatus.UNVERIFIABLE
+        result.failures.append(f"unsupported_envelope_algorithm:{algorithm!r}")
+        return result
+
+    pub_b64, key_failure = _select_key(trusted_keys, key_id)
+    if pub_b64 is None:
+        result.status = TraceStatus.UNVERIFIABLE
+        result.failures.append(key_failure or "no_trusted_keys")
+        return result
+
+    from cryptography.exceptions import InvalidSignature
+
+    from ._signing import (
+        AlgorithmUnavailableError,
+        Ed25519Verifier,
+        MlDsa65Verifier,
+        _b64url_decode,
+    )
+
+    pre_image = trace_signing_pre_image(envelope)
+    try:
+        pub_bytes = _b64url_decode(pub_b64)
+        if algorithm == "Ed25519":
+            Ed25519Verifier(pub_bytes).verify_bytes(pre_image, signature)
+        else:
+            MlDsa65Verifier(pub_bytes).verify_bytes(pre_image, signature)
+    except AlgorithmUnavailableError as exc:
+        result.status = TraceStatus.UNVERIFIABLE
+        result.failures.append(f"algorithm_unavailable:{exc}")
+        return result
+    except InvalidSignature:
+        result.status = TraceStatus.FAILED
+        result.failures.append("signature_invalid")
+        return result
+    except ValueError as exc:
+        result.status = TraceStatus.FAILED
+        result.failures.append(f"signature_malformed:{exc}")
+        return result
+
+    result.status = TraceStatus.VERIFIED
+    result.signature_verified = True
+
+    if manifest is not None:
+        result.warnings.extend(_check_manifest_binding(envelope, manifest, result))
+
+    # Spec 6.3.2: MISMATCH and EXPIRED are never admissible as evidence of a
+    # valid tool call, however good the signature is.
+    if mvr in INADMISSIBLE_RESULTS:
+        result.failures.append(f"inadmissible_manifest_verification_result:{mvr}")
+        result.admissible = False
+    else:
+        result.admissible = not result.failures
+
+    return result
+
+
+def _check_manifest_binding(
+    envelope: dict[str, Any],
+    manifest: dict[str, Any],
+    result: TraceVerificationResult,
+) -> list[str]:
+    """Enforce the spec 6.3.2 hash-conflict rule (SCHEMA F-21).
+
+    The manifest is authoritative for approved artifact hashes; the TRACE
+    reports what was actually in force. When they disagree the producer MUST
+    have written ``manifest_verification_result: MISMATCH``. An envelope that
+    reports a conflicting ``policy_hash`` while still claiming ``VALID`` is a
+    spec violation, and a self-serving one -- so it is a failure, not a
+    warning.
+    """
+    warnings: list[str] = []
+
+    envelope_manifest_id = envelope.get("agent_manifest_id")
+    manifest_id = manifest.get("manifest_id")
+    if manifest_id is not None and envelope_manifest_id != manifest_id:
+        result.failures.append(
+            f"manifest_id_mismatch:envelope={envelope_manifest_id!r},"
+            f"manifest={manifest_id!r}"
+        )
+        return warnings
+
+    artifacts = manifest.get("artifacts") or {}
+    policy_bundle = artifacts.get("policy_bundle") or {}
+    expected_policy_hash = policy_bundle.get("hash")
+
+    if expected_policy_hash is None:
+        warnings.append("manifest_has_no_policy_bundle_hash")
+        return warnings
+
+    if envelope.get("policy_hash") != expected_policy_hash:
+        if envelope["manifest_verification_result"] != "MISMATCH":
+            result.failures.append(
+                "policy_hash_conflict_not_declared:"
+                f"envelope={envelope.get('policy_hash')!r},"
+                f"manifest={expected_policy_hash!r},"
+                f"declared={envelope['manifest_verification_result']!r}"
+            )
+
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Evidence pack
+# ---------------------------------------------------------------------------
+
+
+def verify_evidence_pack(
+    pack: dict[str, Any],
+    *,
+    trusted_keys: Optional[dict[str, str]] = None,
+    expected_pack_hash: Optional[str] = None,
+    trace_key_id: Optional[str] = None,
+    trace_algorithm: str = "Ed25519",
+    verify_envelopes: bool = True,
+) -> EvidencePackVerificationResult:
+    """Verify an evidence pack's ``pack_signature`` and its TRACE envelopes.
+
+    Args:
+        pack: The evidence pack document (spec 5.2.1).
+        trusted_keys: key_id -> base64url public key, covering both the pack's
+            TEE-sealed key and the envelope signing key.
+        expected_pack_hash: When supplied (e.g. the ``pack_hash`` carried in a
+            verification result's ``evidence_pack`` reference), it is compared
+            against the recomputed hash.
+        trace_key_id: Key id for the envelopes inside the pack.
+        trace_algorithm: Envelope signature algorithm.
+        verify_envelopes: Set False to appraise only the pack signature.
+
+    Returns:
+        An :class:`EvidencePackVerificationResult`. ``status`` is ``VERIFIED``
+        only when the pack signature verifies, any supplied ``pack_hash``
+        matches, and (when checked) every envelope is admissible.
+    """
+    result = EvidencePackVerificationResult(status=TraceStatus.MALFORMED)
+
+    if not isinstance(pack, dict):
+        result.failures.append("pack_not_an_object")
+        return result
+
+    result.pack_hash = compute_pack_hash(pack)
+    if expected_pack_hash is not None:
+        # Constant-time compare is unnecessary: both values are public hashes
+        # and an attacker who can supply one can compute the other.
+        result.pack_hash_matches = result.pack_hash == expected_pack_hash
+        if not result.pack_hash_matches:
+            result.failures.append(
+                f"pack_hash_mismatch:computed={result.pack_hash},"
+                f"expected={expected_pack_hash}"
+            )
+
+    signature_block = pack.get("pack_signature")
+    if not signature_block:
+        result.status = TraceStatus.SIGNATURE_MISSING
+        result.failures.append("pack_signature_absent")
+        return result
+    if not isinstance(signature_block, dict):
+        # Spec 5.2.1 requires the detached object form of 3.6, not a bare string.
+        result.failures.append("pack_signature_not_a_detached_object")
+        return result
+
+    status, failures = _verify_detached(
+        evidence_pack_pre_image(pack), signature_block, trusted_keys or {}
+    )
+    result.status = status
+    result.failures.extend(failures)
+    result.signature_verified = status is TraceStatus.VERIFIED
+
+    if verify_envelopes:
+        envelopes = pack.get("trace_envelopes") or []
+        if not isinstance(envelopes, list):
+            result.failures.append("trace_envelopes_not_an_array")
+            result.status = TraceStatus.MALFORMED
+            return result
+        manifest = pack.get("manifest") if isinstance(pack.get("manifest"), dict) else None
+        for envelope in envelopes:
+            result.envelopes.append(
+                verify_trace_envelope(
+                    envelope,
+                    trusted_keys=trusted_keys,
+                    key_id=trace_key_id,
+                    algorithm=trace_algorithm,
+                    manifest=manifest,
+                )
+            )
+        if any(not e.admissible for e in result.envelopes):
+            result.failures.append("pack_contains_inadmissible_envelope")
+
+    # A pack is only VERIFIED when nothing at all went wrong; a good pack
+    # signature over an inadmissible TRACE is still not usable evidence.
+    if result.status is TraceStatus.VERIFIED and result.failures:
+        result.status = TraceStatus.FAILED
+
+    return result

--- a/python/src/agent_manifest/_trace.py
+++ b/python/src/agent_manifest/_trace.py
@@ -28,7 +28,9 @@ without the post-quantum extra yields ``UNVERIFIABLE``, never ``VERIFIED``.
 from __future__ import annotations
 
 import hashlib
+import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
 
@@ -90,6 +92,32 @@ EVIDENCE_PACK_REQUIRED_FIELDS: dict[str, type] = {
     "trace_envelopes": list,
     "attestation_report": str,
 }
+
+# Spec 6.3.2 fixes these three as closed enumerations. `manifest_verification_result`
+# is checked separately against TRACE_VERIFICATION_RESULTS, which section 6.3.2
+# requires to be the section 5.2 `result` values with no additions.
+TRACE_DECISIONS: frozenset[str] = frozenset({"allow", "deny", "require-approval"})
+PAYLOAD_CLASSIFICATIONS: frozenset[str] = frozenset(
+    {"public", "internal", "confidential", "restricted"}
+)
+
+# Section 5.2 `result` values, for the verification result carried in a pack.
+VERIFICATION_RESULTS: frozenset[str] = frozenset(TRACE_VERIFICATION_RESULTS) | {
+    "SIGNATURE_MISSING",
+    "UNVERIFIABLE",
+}
+
+# Formats the specification fixes exactly. Deliberately partial: `tee_measurement`
+# is "<platform-specific measurement>" and `egress_destination` is
+# "<FQDN | IP | none>", so neither has a shape this can enforce without
+# rejecting records the spec permits. `tool_id` is a reverse-domain identifier
+# with no stated grammar, so it is checked for emptiness only.
+_UUID_V7 = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_SPIFFE = re.compile(r"^spiffe://[a-z0-9._-]+(/[a-zA-Z0-9._-]+)*$")
 
 # Presence is not enough for a TRACE envelope either. A field carrying the
 # wrong type passes a `in envelope` check and then flows into a comparison
@@ -330,6 +358,14 @@ def verify_trace_envelope(
         result.failures.append("wrong_field_type:" + ",".join(sorted(wrong_type)))
         return result
 
+    # Type checked, now value. A field of the right type carrying a value the
+    # specification does not define is still a non-conforming record, and
+    # calling one admissible would label it as evidence of a valid tool call.
+    bad_format = _envelope_format_failures(envelope)
+    if bad_format:
+        result.failures.extend(bad_format)
+        return result
+
     mvr = envelope["manifest_verification_result"]
     if mvr not in TRACE_VERIFICATION_RESULTS:
         result.failures.append(f"illegal_manifest_verification_result:{mvr!r}")
@@ -402,6 +438,107 @@ def verify_trace_envelope(
         result.admissible = not result.failures
 
     return result
+
+
+def _is_utc_iso8601(value: str) -> bool:
+    """True when *value* is an ISO 8601 timestamp that states UTC.
+
+    Spec 6.3.2 types ``timestamp`` as ISO 8601 UTC, so an offset-naive string
+    is rejected rather than assumed: a record whose time zone has to be
+    guessed cannot be relied on to order events in an audit trail.
+    """
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return False
+    offset = parsed.utcoffset()
+    if offset is None:
+        return False
+    return offset.total_seconds() == 0
+
+
+def _envelope_format_failures(envelope: dict[str, Any]) -> list[str]:
+    """Value-level checks for the fields spec 6.3.2 defines exactly.
+
+    Only the fields with a stated shape are checked. ``tee_measurement`` is
+    "<platform-specific measurement>" and ``egress_destination`` is
+    "<FQDN | IP | none>", so enforcing a pattern on either would reject
+    records the specification permits.
+    """
+    failures: list[str] = []
+
+    for field_name in ("trace_id", "agent_manifest_id"):
+        if not _UUID_V7.match(envelope[field_name]):
+            failures.append(f"not_a_uuid_v7:{field_name}")
+
+    # hitl_approval_id is "<UUID v7> | null", so null is legal and a present
+    # value must be well formed.
+    approval_id = envelope.get("hitl_approval_id")
+    if approval_id is not None and (
+        not isinstance(approval_id, str) or not _UUID_V7.match(approval_id)
+    ):
+        failures.append("not_a_uuid_v7:hitl_approval_id")
+
+    if not _SPIFFE.match(envelope["agent_id"]):
+        failures.append("not_a_spiffe_uri:agent_id")
+
+    for field_name in ("policy_hash", "catalog_hash"):
+        if not _SHA256.match(envelope[field_name]):
+            failures.append(f"not_a_sha256_hash:{field_name}")
+
+    if envelope["decision"] not in TRACE_DECISIONS:
+        failures.append(f"illegal_decision:{envelope['decision']!r}")
+
+    if envelope["payload_classification"] not in PAYLOAD_CLASSIFICATIONS:
+        failures.append(
+            f"illegal_payload_classification:"
+            f"{envelope['payload_classification']!r}"
+        )
+
+    if not _is_utc_iso8601(envelope["timestamp"]):
+        failures.append("not_an_iso8601_utc_timestamp:timestamp")
+
+    for field_name in ("tool_id", "tee_measurement", "egress_destination"):
+        if not envelope[field_name].strip():
+            failures.append(f"empty_required_field:{field_name}")
+
+    return failures
+
+
+def _evidence_pack_content_failures(pack: dict[str, Any]) -> list[str]:
+    """Value-level checks for the pack members spec 5.2.1 defines.
+
+    A well-typed but empty member is the case this exists for: an empty
+    ``verification_result`` carries no verdict, and an empty
+    ``attestation_report`` is not a report. Either would let a pack that
+    evidences nothing be labelled VERIFIED.
+    """
+    from ._signing import _b64url_decode
+
+    failures: list[str] = []
+
+    verification_result = pack["verification_result"]
+    if not verification_result:
+        failures.append("verification_result_empty")
+    else:
+        declared = verification_result.get("result")
+        if declared is None:
+            failures.append("verification_result_missing_result")
+        elif declared not in VERIFICATION_RESULTS:
+            failures.append(f"illegal_verification_result:{declared!r}")
+
+    report = pack["attestation_report"]
+    if not report:
+        failures.append("attestation_report_empty")
+    else:
+        # Spec 5.2.1 carries the raw platform report base64url-encoded, so a
+        # value that cannot be decoded is not a report this pack can produce.
+        try:
+            _b64url_decode(report)
+        except Exception:
+            failures.append("attestation_report_not_base64url")
+
+    return failures
 
 
 def _check_manifest_binding(
@@ -522,6 +659,15 @@ def verify_evidence_pack(
         "manifest"
     ]["manifest_id"]:
         result.failures.append("manifest_missing_manifest_id")
+        return result
+
+    # Members present and well typed, now their contents. Also before the
+    # signature: an empty verification_result carries no verdict and an empty
+    # attestation_report is not a report, so a pack containing either
+    # evidences nothing however well it is signed.
+    content_failures = _evidence_pack_content_failures(pack)
+    if content_failures:
+        result.failures.extend(content_failures)
         return result
 
     result.pack_hash = compute_pack_hash(pack)

--- a/python/tests/test_trace_verify.py
+++ b/python/tests/test_trace_verify.py
@@ -1,0 +1,589 @@
+"""Tests for TRACE envelope and evidence pack verification (#204).
+
+Covers the spec 6.3.2 envelope signature, the spec 5.2.1 evidence pack
+``pack_signature`` and ``pack_hash``, the SCHEMA F-21 hash-conflict rule, and
+the admissibility rule that MISMATCH/EXPIRED TRACEs are never evidence of a
+valid tool call however good their signatures are.
+
+Fail-closed behaviour is the point of most of these: an envelope the verifier
+cannot appraise must never come back VERIFIED.
+"""
+
+import copy
+import hashlib
+
+import pytest
+
+from agent_manifest._canonicalize import canonicalize
+from agent_manifest._signing import (
+    _b64url_encode,
+    generate_ed25519,
+)
+from agent_manifest._trace import (
+    INADMISSIBLE_RESULTS,
+    TRACE_REQUIRED_FIELDS,
+    TraceStatus,
+    compute_pack_hash,
+    evidence_pack_pre_image,
+    trace_signing_pre_image,
+    verify_evidence_pack,
+    verify_trace_envelope,
+)
+
+from agent_manifest._signing import ml_dsa65_available
+
+_OQS = ml_dsa65_available()
+
+
+POLICY_HASH = f"sha256:{'a1' * 32}"
+CATALOG_HASH = f"sha256:{'b2' * 32}"
+MANIFEST_ID = "0192f3a0-0000-7000-8000-000000000001"
+
+
+def _envelope(**overrides):
+    """A spec 6.3.2 TRACE envelope with every required field present."""
+    envelope = {
+        "trace_id": "0192f3a0-0000-7000-8000-00000000000a",
+        "agent_id": "spiffe://example.org/agent/billing",
+        "agent_manifest_id": MANIFEST_ID,
+        "manifest_verification_result": "VALID",
+        "tool_id": "org.example.tools.invoice-lookup",
+        "policy_hash": POLICY_HASH,
+        "catalog_hash": CATALOG_HASH,
+        "decision": "allow",
+        "decision_reason": 'permit(principal, action, resource) when { context.tier == "gold" };',
+        "payload_classification": "internal",
+        "egress_destination": "api.example.com",
+        "hitl_required": False,
+        "hitl_approval_id": None,
+        "timestamp": "2026-08-03T12:00:00Z",
+        "tee_measurement": "sha256:" + "cd" * 32,
+        "signature": "",
+    }
+    envelope.update(overrides)
+    return envelope
+
+
+def _manifest(policy_hash=POLICY_HASH, manifest_id=MANIFEST_ID):
+    return {
+        "manifest_id": manifest_id,
+        "artifacts": {"policy_bundle": {"hash": policy_hash}},
+    }
+
+
+def _sign_envelope(envelope, keypair):
+    """Sign *envelope* in place with Ed25519 over its canonical pre-image."""
+    signed = dict(envelope)
+    signed["signature"] = _b64url_encode(
+        keypair.private_key.sign(trace_signing_pre_image(signed))
+    )
+    return signed
+
+
+def _sign_pack(pack, keypair):
+    signed = dict(pack)
+    signed["pack_signature"] = {
+        "algorithm": "Ed25519",
+        "key_id": keypair.key_id,
+        "key_type": "tee-sealed",
+        "signed_at": "2026-08-03T12:00:00Z",
+        "signature_value": _b64url_encode(
+            keypair.private_key.sign(evidence_pack_pre_image(signed))
+        ),
+    }
+    return signed
+
+
+@pytest.fixture
+def kp():
+    return generate_ed25519()
+
+
+@pytest.fixture
+def trusted(kp):
+    return {kp.key_id: kp.public_b64url()}
+
+
+# ---------------------------------------------------------------------------
+# Pre-image
+# ---------------------------------------------------------------------------
+
+
+def test_pre_image_excludes_only_the_signature_field():
+    envelope = _envelope(signature="not-covered")
+    expected = canonicalize({k: v for k, v in envelope.items() if k != "signature"})
+    assert trace_signing_pre_image(envelope) == expected
+
+
+def test_pre_image_is_stable_under_key_reordering():
+    envelope = _envelope()
+    shuffled = dict(reversed(list(envelope.items())))
+    assert trace_signing_pre_image(envelope) == trace_signing_pre_image(shuffled)
+
+
+def test_changing_the_signature_does_not_change_the_pre_image(kp):
+    a = _envelope(signature="aaa")
+    b = _envelope(signature="bbb")
+    assert trace_signing_pre_image(a) == trace_signing_pre_image(b)
+
+
+# ---------------------------------------------------------------------------
+# Envelope signature
+# ---------------------------------------------------------------------------
+
+
+def test_valid_envelope_verifies_and_is_admissible(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.VERIFIED
+    assert result.signature_verified is True
+    assert result.admissible is True
+    assert result.failures == []
+    assert result.trace_id == envelope["trace_id"]
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("decision", "deny"),
+        ("policy_hash", f"sha256:{'ff' * 32}"),
+        ("tool_id", "org.example.tools.wire-transfer"),
+        ("egress_destination", "attacker.example.net"),
+        ("hitl_required", True),
+        ("tee_measurement", "sha256:" + "00" * 32),
+        ("timestamp", "2026-08-03T13:00:00Z"),
+    ],
+)
+def test_tampering_any_covered_field_fails(kp, trusted, field, value):
+    envelope = _sign_envelope(_envelope(), kp)
+    envelope[field] = value
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.FAILED
+    assert result.signature_verified is False
+    assert result.admissible is False
+
+
+def test_tampered_signature_fails(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    # Flip one base64url character to a different valid one.
+    sig = envelope["signature"]
+    envelope["signature"] = ("B" if sig[0] == "A" else "A") + sig[1:]
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.FAILED
+
+
+def test_signature_from_a_different_key_fails(kp, trusted):
+    attacker = generate_ed25519()
+    envelope = _sign_envelope(_envelope(), attacker)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.FAILED
+    assert result.admissible is False
+
+
+def test_missing_signature_is_signature_missing(trusted):
+    envelope = _envelope(signature="")
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.SIGNATURE_MISSING
+    assert result.admissible is False
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: unappraisable is never VERIFIED
+# ---------------------------------------------------------------------------
+
+
+def test_no_trusted_keys_is_unverifiable_not_verified(kp):
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=None)
+    assert result.status is TraceStatus.UNVERIFIABLE
+    assert result.signature_verified is False
+    assert result.admissible is False
+
+
+def test_untrusted_key_id_is_unverifiable(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope, trusted_keys=trusted, key_id="0" * 64
+    )
+    assert result.status is TraceStatus.UNVERIFIABLE
+    assert any("key_id_not_trusted" in f for f in result.failures)
+
+
+def test_ambiguous_key_without_key_id_is_refused(kp):
+    """Two trusted keys and no key_id: refuse rather than try each in turn."""
+    other = generate_ed25519()
+    envelope = _sign_envelope(_envelope(), kp)
+    trusted_two = {
+        kp.key_id: kp.public_b64url(),
+        other.key_id: other.public_b64url(),
+    }
+    result = verify_trace_envelope(envelope, trusted_keys=trusted_two)
+    assert result.status is TraceStatus.UNVERIFIABLE
+    assert "ambiguous_key_id" in result.failures
+
+    # Naming the key resolves it.
+    ok = verify_trace_envelope(
+        envelope, trusted_keys=trusted_two, key_id=kp.key_id
+    )
+    assert ok.status is TraceStatus.VERIFIED
+
+
+def test_hybrid_algorithm_is_rejected_for_envelopes(kp, trusted):
+    """Spec 6.3.2 types the envelope signature as a bare string."""
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope, trusted_keys=trusted, algorithm="hybrid-Ed25519-ML-DSA-65"
+    )
+    assert result.status is TraceStatus.UNVERIFIABLE
+    assert any("unsupported_envelope_algorithm" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Shape validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing", TRACE_REQUIRED_FIELDS)
+def test_missing_required_field_is_malformed(kp, trusted, missing):
+    envelope = _sign_envelope(_envelope(), kp)
+    del envelope[missing]
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert result.admissible is False
+
+
+def test_illegal_verification_result_enum_is_malformed(kp, trusted):
+    """Spec 6.3.2 forbids values outside the section 5.2 enum."""
+    envelope = _sign_envelope(_envelope(manifest_verification_result="OK"), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+
+
+def test_sdk_only_statuses_are_not_legal_in_an_envelope(kp, trusted):
+    """UNVERIFIABLE is a verifier-side outcome, not a producer-writable one."""
+    envelope = _sign_envelope(
+        _envelope(manifest_verification_result="UNVERIFIABLE"), kp
+    )
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+
+
+def test_string_hitl_required_is_malformed(kp, trusted):
+    """SCHEMA F-11: a string "false" is truthy and would read as approved."""
+    envelope = _sign_envelope(_envelope(hitl_required="false"), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "hitl_required_not_a_boolean" in result.failures
+
+
+def test_non_dict_envelope_is_malformed(trusted):
+    result = verify_trace_envelope(["not", "an", "object"], trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+
+
+# ---------------------------------------------------------------------------
+# Admissibility (spec 6.3.2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("result_value", sorted(INADMISSIBLE_RESULTS))
+def test_mismatch_and_expired_are_authentic_but_inadmissible(
+    kp, trusted, result_value
+):
+    envelope = _sign_envelope(
+        _envelope(manifest_verification_result=result_value), kp
+    )
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    # The signature is genuine -- the runtime honestly recorded a bad state.
+    assert result.status is TraceStatus.VERIFIED
+    assert result.signature_verified is True
+    # But it is not evidence of a valid tool call.
+    assert result.admissible is False
+    assert any("inadmissible" in f for f in result.failures)
+
+
+@pytest.mark.parametrize(
+    "result_value", ["VALID", "REVOKED", "INCOMPLETE", "ATTESTATION_UNAVAILABLE"]
+)
+def test_other_results_remain_admissible(kp, trusted, result_value):
+    envelope = _sign_envelope(
+        _envelope(manifest_verification_result=result_value), kp
+    )
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.admissible is True
+
+
+# ---------------------------------------------------------------------------
+# Manifest binding / SCHEMA F-21
+# ---------------------------------------------------------------------------
+
+
+def test_matching_policy_hash_binds_cleanly(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope, trusted_keys=trusted, manifest=_manifest()
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert result.admissible is True
+
+
+def test_policy_hash_conflict_claiming_valid_is_a_failure(kp, trusted):
+    """F-21: a conflict MUST be declared as MISMATCH, not papered over."""
+    envelope = _sign_envelope(_envelope(policy_hash=f"sha256:{'99' * 32}"), kp)
+    result = verify_trace_envelope(
+        envelope, trusted_keys=trusted, manifest=_manifest()
+    )
+    assert result.signature_verified is True
+    assert result.admissible is False
+    assert any("policy_hash_conflict_not_declared" in f for f in result.failures)
+
+
+def test_policy_hash_conflict_declared_as_mismatch_is_spec_compliant(kp, trusted):
+    envelope = _sign_envelope(
+        _envelope(
+            policy_hash=f"sha256:{'99' * 32}",
+            manifest_verification_result="MISMATCH",
+        ),
+        kp,
+    )
+    result = verify_trace_envelope(
+        envelope, trusted_keys=trusted, manifest=_manifest()
+    )
+    # Correctly declared, so no F-21 violation ...
+    assert not any(
+        "policy_hash_conflict_not_declared" in f for f in result.failures
+    )
+    # ... but still not usable as evidence of a valid call.
+    assert result.admissible is False
+
+
+def test_manifest_id_mismatch_is_a_failure(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope,
+        trusted_keys=trusted,
+        manifest=_manifest(manifest_id="0192f3a0-0000-7000-8000-0000000000ff"),
+    )
+    assert result.admissible is False
+    assert any("manifest_id_mismatch" in f for f in result.failures)
+
+
+def test_manifest_without_policy_hash_warns(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope,
+        trusted_keys=trusted,
+        manifest={"manifest_id": MANIFEST_ID, "artifacts": {}},
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert "manifest_has_no_policy_bundle_hash" in result.warnings
+
+
+# ---------------------------------------------------------------------------
+# Evidence pack
+# ---------------------------------------------------------------------------
+
+
+def _pack(envelopes, manifest=None):
+    return {
+        "manifest": manifest if manifest is not None else _manifest(),
+        "verification_result": {"result": "VALID", "manifest_id": MANIFEST_ID},
+        "trace_envelopes": envelopes,
+        "attestation_report": _b64url_encode(b"raw-attestation-bytes"),
+    }
+
+
+def test_pack_hash_excludes_the_signature(kp):
+    pack = _pack([])
+    unsigned_hash = compute_pack_hash(pack)
+    signed = _sign_pack(pack, kp)
+    assert compute_pack_hash(signed) == unsigned_hash
+    # And it is the SHA-256 of the canonical bytes, per spec 5.2.1.
+    expected = hashlib.sha256(evidence_pack_pre_image(pack)).hexdigest()
+    assert unsigned_hash == f"sha256:{expected}"
+
+
+def test_valid_pack_verifies(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    pack = _sign_pack(_pack([envelope]), kp)
+    result = verify_evidence_pack(
+        pack, trusted_keys=trusted, trace_key_id=kp.key_id
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert result.signature_verified is True
+    assert result.failures == []
+    assert len(result.envelopes) == 1
+    assert result.envelopes[0].admissible is True
+
+
+def test_expected_pack_hash_is_checked(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    pack = _sign_pack(_pack([envelope]), kp)
+    good = verify_evidence_pack(
+        pack,
+        trusted_keys=trusted,
+        trace_key_id=kp.key_id,
+        expected_pack_hash=compute_pack_hash(pack),
+    )
+    assert good.pack_hash_matches is True
+    assert good.status is TraceStatus.VERIFIED
+
+    bad = verify_evidence_pack(
+        pack,
+        trusted_keys=trusted,
+        trace_key_id=kp.key_id,
+        expected_pack_hash=f"sha256:{'00' * 32}",
+    )
+    assert bad.pack_hash_matches is False
+    assert bad.status is TraceStatus.FAILED
+    assert any("pack_hash_mismatch" in f for f in bad.failures)
+
+
+def test_tampering_the_pack_breaks_the_signature(kp, trusted):
+    envelope = _sign_envelope(_envelope(), kp)
+    pack = _sign_pack(_pack([envelope]), kp)
+    pack["attestation_report"] = _b64url_encode(b"swapped-attestation")
+    result = verify_evidence_pack(
+        pack, trusted_keys=trusted, trace_key_id=kp.key_id
+    )
+    assert result.status is TraceStatus.FAILED
+    assert result.signature_verified is False
+
+
+def test_removing_an_envelope_breaks_the_pack_signature(kp, trusted):
+    """The pack signature covers the envelope array, so dropping one is caught."""
+    e1 = _sign_envelope(_envelope(), kp)
+    e2 = _sign_envelope(_envelope(trace_id="0192f3a0-0000-7000-8000-00000000000b"), kp)
+    pack = _sign_pack(_pack([e1, e2]), kp)
+    pack["trace_envelopes"] = [e1]
+    result = verify_evidence_pack(
+        pack, trusted_keys=trusted, trace_key_id=kp.key_id
+    )
+    assert result.status is TraceStatus.FAILED
+
+
+def test_pack_missing_signature(kp, trusted):
+    pack = _pack([_sign_envelope(_envelope(), kp)])
+    result = verify_evidence_pack(pack, trusted_keys=trusted)
+    assert result.status is TraceStatus.SIGNATURE_MISSING
+
+
+def test_pack_signature_as_bare_string_is_malformed(kp, trusted):
+    """Spec 5.2.1 requires the detached object form of section 3.6."""
+    pack = _pack([])
+    pack["pack_signature"] = "just-a-string"
+    result = verify_evidence_pack(pack, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+
+
+def test_pack_with_no_trusted_keys_is_unverifiable(kp):
+    pack = _sign_pack(_pack([]), kp)
+    result = verify_evidence_pack(pack, trusted_keys={})
+    assert result.status is TraceStatus.UNVERIFIABLE
+    assert result.signature_verified is False
+
+
+def test_good_pack_signature_over_inadmissible_envelope_still_fails(kp, trusted):
+    """A pack is not usable evidence just because the pack signature is valid."""
+    envelope = _sign_envelope(
+        _envelope(manifest_verification_result="EXPIRED"), kp
+    )
+    pack = _sign_pack(_pack([envelope]), kp)
+    result = verify_evidence_pack(
+        pack, trusted_keys=trusted, trace_key_id=kp.key_id
+    )
+    assert result.signature_verified is True
+    assert result.status is TraceStatus.FAILED
+    assert "pack_contains_inadmissible_envelope" in result.failures
+
+
+def test_envelope_check_can_be_skipped(kp, trusted):
+    envelope = _sign_envelope(
+        _envelope(manifest_verification_result="EXPIRED"), kp
+    )
+    pack = _sign_pack(_pack([envelope]), kp)
+    result = verify_evidence_pack(
+        pack, trusted_keys=trusted, verify_envelopes=False
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert result.envelopes == []
+
+
+def test_pack_envelopes_are_bound_to_the_packs_manifest(kp, trusted):
+    """The manifest inside the pack drives the F-21 check on its envelopes."""
+    envelope = _sign_envelope(_envelope(policy_hash=f"sha256:{'99' * 32}"), kp)
+    pack = _sign_pack(_pack([envelope]), kp)
+    result = verify_evidence_pack(
+        pack, trusted_keys=trusted, trace_key_id=kp.key_id
+    )
+    assert any(
+        "policy_hash_conflict_not_declared" in f
+        for f in result.envelopes[0].failures
+    )
+
+
+def test_trace_envelopes_not_an_array_is_malformed(kp, trusted):
+    pack = _sign_pack(_pack([]), kp)
+    pack["trace_envelopes"] = {"not": "a list"}
+    result = verify_evidence_pack(pack, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+
+
+def test_unknown_pack_algorithm_is_unverifiable(kp, trusted):
+    pack = _sign_pack(_pack([]), kp)
+    pack["pack_signature"]["algorithm"] = "RSA-PKCS1"
+    result = verify_evidence_pack(pack, trusted_keys=trusted)
+    assert result.status is TraceStatus.UNVERIFIABLE
+    assert any("unknown_algorithm" in f for f in result.failures)
+
+
+@pytest.mark.skipif(not _OQS, reason="no ML-DSA-65 backend available")
+def test_hybrid_pack_signature_verifies():
+    from agent_manifest._signing import generate_hybrid
+
+    hybrid = generate_hybrid()
+    pack = _pack([])
+    pre_image = evidence_pack_pre_image(pack)
+    classical = _b64url_encode(hybrid.ed25519.private_key.sign(pre_image))
+    from agent_manifest._signing import _ml_dsa_sign_raw
+
+    pq = _b64url_encode(
+        _ml_dsa_sign_raw(hybrid.ml_dsa65.private_key_bytes, pre_image)
+    )
+    pack["pack_signature"] = {
+        "algorithm": "hybrid-Ed25519-ML-DSA-65",
+        "key_id": hybrid.key_id,
+        "classical_signature": classical,
+        "pq_signature": pq,
+        "signature_value": "",
+    }
+    combined = hybrid.ed25519.public_bytes + hybrid.ml_dsa65.public_key_bytes
+    result = verify_evidence_pack(
+        pack, trusted_keys={hybrid.key_id: _b64url_encode(combined)}
+    )
+    assert result.status is TraceStatus.VERIFIED
+
+
+# ---------------------------------------------------------------------------
+# Regression: the refactor that made the verifiers reusable
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_verify_still_uses_the_manifest_pre_image(kp):
+    """verify() must keep signing SIGNED_FIELDS, not the whole dict."""
+    from agent_manifest._signing import Ed25519Signer, Ed25519Verifier
+
+    manifest = {
+        "manifest_id": MANIFEST_ID,
+        "agent_id": "spiffe://example.org/agent/billing",
+        "version": "0.1",
+        "artifacts": {"policy_bundle": {"hash": POLICY_HASH}},
+    }
+    block = Ed25519Signer(kp).sign(manifest)
+    verifier = Ed25519Verifier(kp.public_bytes)
+    verifier.verify(manifest, block["signature_value"])
+
+    # A field outside SIGNED_FIELDS must not disturb the signature.
+    with_extra = copy.deepcopy(manifest)
+    with_extra["transparency_log_entry"] = {"log_index": 7}
+    verifier.verify(with_extra, block["signature_value"])

--- a/python/tests/test_trace_verify.py
+++ b/python/tests/test_trace_verify.py
@@ -736,3 +736,178 @@ def test_the_binding_still_catches_a_mismatched_envelope(kp, trusted):
     )
     assert result.status is not TraceStatus.VERIFIED
     assert any("manifest_id_mismatch" in f for e in result.envelopes for f in e.failures)
+
+
+# ---------------------------------------------------------------------------
+# Value-level conformance, spec 6.3.2 and 5.2.1
+#
+# Type-correct is not the same as spec-conforming. Each of these is a signed
+# record whose every field is present and of the right type, carrying a value
+# the specification does not define. Labelling one admissible would call a
+# non-conforming forensic record evidence of a valid tool call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field,bad_value,failure",
+    [
+        ("decision", "root", "illegal_decision:'root'"),
+        ("decision", "ALLOW", "illegal_decision:'ALLOW'"),
+        (
+            "payload_classification",
+            "cosmic",
+            "illegal_payload_classification:'cosmic'",
+        ),
+    ],
+)
+def test_an_illegal_enum_value_is_malformed(kp, trusted, field, bad_value, failure):
+    envelope = _sign_envelope(_envelope(**{field: bad_value}), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert result.admissible is False
+    assert failure in result.failures
+
+
+@pytest.mark.parametrize("field", ["trace_id", "agent_manifest_id"])
+def test_an_id_that_is_not_uuid_v7_is_malformed(kp, trusted, field):
+    envelope = _sign_envelope(_envelope(**{field: "not-a-uuid"}), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert f"not_a_uuid_v7:{field}" in result.failures
+
+
+def test_a_uuid_v4_is_not_accepted_where_v7_is_required(kp, trusted):
+    """The version nibble is the point: v7 is time-ordered, v4 is not."""
+    envelope = _sign_envelope(
+        _envelope(trace_id="0192f3a0-0000-4000-8000-00000000000a"), kp
+    )
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "not_a_uuid_v7:trace_id" in result.failures
+
+
+def test_a_present_but_malformed_hitl_approval_id_is_malformed(kp, trusted):
+    """`<UUID v7> | null`: null is legal, a broken value is not."""
+    envelope = _sign_envelope(_envelope(hitl_approval_id="approved-by-bob"), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "not_a_uuid_v7:hitl_approval_id" in result.failures
+
+
+def test_a_null_hitl_approval_id_is_accepted(kp, trusted):
+    envelope = _sign_envelope(_envelope(hitl_approval_id=None), kp)
+    assert verify_trace_envelope(envelope, trusted_keys=trusted).status is (
+        TraceStatus.VERIFIED
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_agent_id", ["just-a-name", "https://example.org/agent", "spiffe:/missing"]
+)
+def test_an_agent_id_that_is_not_a_spiffe_uri_is_malformed(kp, trusted, bad_agent_id):
+    envelope = _sign_envelope(_envelope(agent_id=bad_agent_id), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "not_a_spiffe_uri:agent_id" in result.failures
+
+
+@pytest.mark.parametrize("field", ["policy_hash", "catalog_hash"])
+def test_a_hash_that_is_not_sha256_prefixed_is_malformed(kp, trusted, field):
+    envelope = _sign_envelope(_envelope(**{field: "deadbeef"}), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert f"not_a_sha256_hash:{field}" in result.failures
+
+
+@pytest.mark.parametrize(
+    "bad_timestamp",
+    [
+        "yesterday",
+        "2026-08-03T12:00:00",          # offset-naive, time zone would be guessed
+        "2026-08-03T12:00:00+02:00",    # a real offset, but not UTC
+        "03/08/2026 12:00",
+    ],
+)
+def test_a_timestamp_that_is_not_iso8601_utc_is_malformed(kp, trusted, bad_timestamp):
+    envelope = _sign_envelope(_envelope(timestamp=bad_timestamp), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "not_an_iso8601_utc_timestamp:timestamp" in result.failures
+
+
+@pytest.mark.parametrize("suffix", ["Z", "+00:00"])
+def test_both_utc_spellings_are_accepted(kp, trusted, suffix):
+    envelope = _sign_envelope(_envelope(timestamp=f"2026-08-03T12:00:00{suffix}"), kp)
+    assert verify_trace_envelope(envelope, trusted_keys=trusted).status is (
+        TraceStatus.VERIFIED
+    )
+
+
+def test_a_platform_specific_tee_measurement_is_not_forced_to_sha256(kp, trusted):
+    """Spec 6.3.2 types it as `<platform-specific measurement>`, so enforcing a
+    hash shape here would reject records the specification permits."""
+    envelope = _sign_envelope(_envelope(tee_measurement="mrenclave:abc123"), kp)
+    assert verify_trace_envelope(envelope, trusted_keys=trusted).status is (
+        TraceStatus.VERIFIED
+    )
+
+
+@pytest.mark.parametrize("field", ["tool_id", "tee_measurement", "egress_destination"])
+def test_an_empty_required_string_is_malformed(kp, trusted, field):
+    envelope = _sign_envelope(_envelope(**{field: "   "}), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert f"empty_required_field:{field}" in result.failures
+
+
+# --- pack contents ---------------------------------------------------------
+
+
+def test_an_empty_verification_result_is_malformed(kp, trusted):
+    pack = _pack([])
+    pack["verification_result"] = {}
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "verification_result_empty" in result.failures
+
+
+def test_a_verification_result_without_a_result_is_malformed(kp, trusted):
+    pack = _pack([])
+    pack["verification_result"] = {"manifest_id": MANIFEST_ID}
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "verification_result_missing_result" in result.failures
+
+
+def test_an_illegal_verification_result_value_is_malformed(kp, trusted):
+    pack = _pack([])
+    pack["verification_result"] = {"result": "PROBABLY_FINE"}
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "illegal_verification_result:'PROBABLY_FINE'" in result.failures
+
+
+def test_an_empty_attestation_report_is_malformed(kp, trusted):
+    pack = _pack([])
+    pack["attestation_report"] = ""
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "attestation_report_empty" in result.failures
+
+
+def test_an_attestation_report_that_is_not_base64url_is_malformed(kp, trusted):
+    """Spec 5.2.1 carries the raw platform report base64url-encoded, so a value
+    that cannot be decoded is not a report this pack could have produced."""
+    pack = _pack([])
+    pack["attestation_report"] = "not/valid+base64!!"
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "attestation_report_not_base64url" in result.failures
+
+
+def test_pack_contents_are_checked_before_the_signature(kp, trusted):
+    pack = _pack([])
+    pack["attestation_report"] = ""
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys={})
+    assert result.status is TraceStatus.MALFORMED
+    assert result.signature_verified is False

--- a/python/tests/test_trace_verify.py
+++ b/python/tests/test_trace_verify.py
@@ -587,3 +587,152 @@ def test_manifest_verify_still_uses_the_manifest_pre_image(kp):
     with_extra = copy.deepcopy(manifest)
     with_extra["transparency_log_entry"] = {"log_index": 7}
     verifier.verify(with_extra, block["signature_value"])
+
+
+# ---------------------------------------------------------------------------
+# Structural requirements of the pack itself (spec 5.2.1)
+#
+# A signature proves who assembled a document, not that the document is the
+# thing it claims to be. These assert the four members exist and are the right
+# shape before the signature is appraised at all.
+# ---------------------------------------------------------------------------
+
+
+def test_a_pack_carrying_only_its_own_signature_is_malformed(kp, trusted):
+    """The case that motivated these checks.
+
+    Every member of the pre-image is optional to the signer, so a pack
+    containing nothing but `pack_signature` is signed honestly and verifies
+    perfectly, while evidencing nothing at all.
+    """
+    pack = _sign_pack({}, kp)
+    result = verify_evidence_pack(pack, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert result.signature_verified is False
+    assert any("missing_required_fields" in f for f in result.failures)
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["manifest", "verification_result", "trace_envelopes", "attestation_report"],
+)
+def test_each_missing_pack_member_is_malformed(kp, trusted, missing):
+    pack = _pack([])
+    del pack[missing]
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert result.signature_verified is False
+    assert f"missing_required_fields:{missing}" in result.failures
+
+
+@pytest.mark.parametrize(
+    "field,bad_value",
+    [
+        ("manifest", "not-an-object"),
+        ("verification_result", []),
+        ("trace_envelopes", {}),
+        ("attestation_report", 42),
+    ],
+)
+def test_a_pack_member_of_the_wrong_type_is_malformed(kp, trusted, field, bad_value):
+    pack = _pack([])
+    pack[field] = bad_value
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert f"wrong_field_type:{field}" in result.failures
+
+
+def test_an_empty_manifest_is_malformed(kp, trusted):
+    """Well-typed and still useless: every binding check reads from it, so an
+    empty manifest disables them all without any of them reporting a failure."""
+    pack = _pack([])
+    pack["manifest"] = {}
+    result = verify_evidence_pack(_sign_pack(pack, kp), trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert "manifest_empty" in result.failures
+
+
+def test_structure_is_checked_before_the_signature(kp, trusted):
+    """A malformed pack is MALFORMED even when the signature is unverifiable,
+    so the two failures cannot mask one another."""
+    pack = _pack([])
+    del pack["manifest"]
+    signed = _sign_pack(pack, kp)
+    result = verify_evidence_pack(signed, trusted_keys={})  # no keys at all
+    assert result.status is TraceStatus.MALFORMED
+    assert "missing_required_fields:manifest" in result.failures
+
+
+def test_a_well_formed_pack_still_verifies(kp, trusted):
+    """The checks must not cost the happy path."""
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_evidence_pack(
+        _sign_pack(_pack([envelope]), kp),
+        trusted_keys=trusted,
+        trace_key_id=kp.key_id,
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert result.signature_verified is True
+
+
+# ---------------------------------------------------------------------------
+# Envelope fields: present is not the same as well-formed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field,bad_value",
+    [
+        ("trace_id", 12345),
+        ("agent_id", None),
+        ("policy_hash", []),
+        ("catalog_hash", {}),
+        ("decision", 1),
+        ("timestamp", 1735689600),
+        ("tee_measurement", 999),
+    ],
+)
+def test_an_envelope_field_of_the_wrong_type_is_malformed(
+    kp, trusted, field, bad_value
+):
+    """`policy_hash: []` is the case that matters: it is present, so the
+    conflict rule of section 6.3.2 runs, compares it against the manifest's
+    hash, finds no match, and reports nothing because the types differ."""
+    envelope = _sign_envelope(_envelope(**{field: bad_value}), kp)
+    result = verify_trace_envelope(envelope, trusted_keys=trusted)
+    assert result.status is TraceStatus.MALFORMED
+    assert f"wrong_field_type:{field}" in result.failures
+
+
+def test_a_manifest_without_manifest_id_cannot_disable_the_binding(kp, trusted):
+    """Non-empty is not the same as usable.
+
+    `_check_manifest_binding` skips the manifest-id comparison when the
+    manifest carries no `manifest_id`, so a manifest of `{"note": "..."}` is
+    well-typed, non-empty, and still lets an envelope naming a completely
+    different manifest through without remark. The binding is why the manifest
+    is in the pack, so the field it binds on is required.
+    """
+    envelope = _sign_envelope(
+        _envelope(agent_manifest_id="0192f3a0-dead-7000-8000-00000000beef"), kp
+    )
+    pack = _pack([envelope], manifest={"note": "not really a manifest"})
+    result = verify_evidence_pack(
+        _sign_pack(pack, kp), trusted_keys=trusted, trace_key_id=kp.key_id
+    )
+    assert result.status is TraceStatus.MALFORMED
+    assert "manifest_missing_manifest_id" in result.failures
+
+
+def test_the_binding_still_catches_a_mismatched_envelope(kp, trusted):
+    """And with a real manifest present, the binding does its job."""
+    envelope = _sign_envelope(
+        _envelope(agent_manifest_id="0192f3a0-dead-7000-8000-00000000beef"), kp
+    )
+    result = verify_evidence_pack(
+        _sign_pack(_pack([envelope]), kp),
+        trusted_keys=trusted,
+        trace_key_id=kp.key_id,
+    )
+    assert result.status is not TraceStatus.VERIFIED
+    assert any("manifest_id_mismatch" in f for e in result.envelopes for f in e.failures)


### PR DESCRIPTION
## Summary

Implements verification of the Level 3 TRACE claim signature, the outstanding half of #204.

Phase 1 of that issue, the attestation chain, landed in 2073576 `feat(verify): attestation-chain verifier scaffold (#204 phase 1) (#210)` and has been built out since by the TDX DCAP work and the SNP report union in #260. The second clause of the issue was never picked up:

> The SDK does not verify the attestation chain (quote/VCEK/expected measurement) **or the Level 3 TRACE claim signature**, so an unverified report or claim currently passes.

This PR is that clause. It touches nothing in the attestation path.

## The problem

The SDK stored `trace_id` and `evidence_pack` and never checked either signature. Any field inside a TRACE record could be edited after the fact and still be accepted as evidence: the Cedar decision, the policy and catalog hashes actually in force, or the manifest verification result recorded at the time of the call.

TRACE records are the forensic layer. A record whose signature is never verified is not evidence of anything.

## What is verified

**A TRACE envelope** is the per tool call record cMCP emits, carrying the agent's manifest id, the manifest verification result at the time of the call, the policy and catalog hashes in force, and the Cedar decision, signed by a TEE sealed key.

**An evidence pack** bundles the manifest, a verification result, the session's TRACE envelopes and the raw attestation report under one detached `pack_signature`.

```python
from agent_manifest import verify_trace_envelope, verify_evidence_pack

result = verify_trace_envelope(envelope, trusted_keys=keys, manifest=manifest)
result.status         # VERIFIED | FAILED | UNVERIFIABLE | SIGNATURE_MISSING | MALFORMED
result.admissible     # may this be used as evidence of a valid tool call?
```

## The two pre-images are not symmetric

This is the part the issue did not specify and the spec had to settle.

**TRACE envelope:** every field except `signature`, as RFC 8785 canonical JSON. Spec 6.3.2 types `signature` as a bare string, "Ed25519 | ML-DSA-65 by TEE-sealed key", so the envelope carries no algorithm and no key id at all. The caller supplies both. Hybrid is not expressible in that shape and is rejected rather than guessed at.

**Evidence pack:** every field except `pack_signature`, which is the full detached signature object of spec 3.6 with algorithm and key id inside, so hybrid works there. `compute_pack_hash` returns the SHA-256 of exactly those bytes, which is what spec 5.2.1 defines `pack_hash` to be.

That asymmetry is why verification goes through `verify_bytes` on the verifier classes rather than the manifest pre-image helpers: the manifest pre-image is fixed and normative, and these two cover different field sets.

## Authentic and inadmissible are different questions

`admissible` is the question a relying party actually asks: may this record be used as evidence of a valid tool call? That needs a verified signature **and** a `manifest_verification_result` outside `INADMISSIBLE_RESULTS`.

A perfectly signed envelope reporting `MISMATCH` is authentic and inadmissible at the same time. The signature proves the runtime honestly recorded that the policy hash did not match, which is exactly the case spec 6.3.2 excludes from reporting. Collapsing the two into one boolean would either discard honest failure records or admit them as proof of success.

## The hash conflict rule

Spec 6.3.2, SCHEMA F-21. The manifest is authoritative for approved artifact hashes; the TRACE reports what was actually in force. When they disagree, the producer MUST have written `manifest_verification_result: MISMATCH`.

An envelope reporting a conflicting `policy_hash` while still claiming `VALID` is a spec violation, and a self serving one, so it is treated as a failure rather than a warning.

## Fail closed

A missing key, an unknown algorithm, or a build without the post quantum extra yields `UNVERIFIABLE`, never `VERIFIED`. `MALFORMED` covers a missing required field or an illegal enum value: the shape cannot be vouched for, and the absent field may be the one a relying party is about to read.

`UNVERIFIABLE` is deliberately distinct from `FAILED`. A capability gap is not a bad record.

## Verification

| Check | Result |
|---|---|
| New tests | 63 passed |
| Full suite | 923 passed, 6 skipped |
| `_trace.py` coverage | 92 percent |
| mypy strict | clean |
| bandit | clean |
| ruff, `--select E,F,W --ignore E501` as CI runs it | all checks passed |

Coverage includes valid envelopes, tampered fields, wrong keys, missing signatures, malformed shapes, the hash conflict rule, hybrid rejection on TRACE envelopes, hybrid acceptance on evidence packs, and `pack_hash` agreeing with spec 5.2.1.

## Scope

Only the TRACE claim signature half of #204. The attestation chain half is already on `main` and is untouched here: no changes to `_attestation.py`, `_snp_verify.py`, `_tdx_verify.py`, `_tpm_verify.py` or `_cert_chain.py`.

Leaving it to a maintainer whether #204 closes on this or stays open until both halves are confirmed complete.

Refs #204, #201