### PR TITLE
docs: point contributors at current spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Spec changes follow this process:
 
 1. Open a GitHub issue describing the problem and proposed change. Reference the spec section.
 2. Allow 5 business days for design-partner feedback.
-3. Submit a PR to `spec/agent-manifest-spec-v0.1.md` with the change marked using `<!-- CHANGED: ISSUE-NNN — description -->`.
+3. Submit a PR against the [current specification](spec/README.md) with the change marked using `<!-- CHANGED: ISSUE-NNN — description -->`.
 4. Update conformance tests in `python/tests/` to cover the changed normative text.
 5. Update `CHANGELOG.md`.
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,10 @@
+# Agent Manifest specifications
+
+The current Agent Manifest specification is
+[`agent-manifest-spec-v0.2.md`](agent-manifest-spec-v0.2.md). Its COSE signature
+envelope is specified separately in
+[`agent-manifest-cose-envelope-v0.2.md`](agent-manifest-cose-envelope-v0.2.md).
+
+Spec change proposals should target the applicable current document. When a new
+specification version becomes current, update this index so contribution guidance
+and other stable links do not need to encode a versioned filename.


### PR DESCRIPTION
## Summary

- replace the stale v0.1 spec path in `CONTRIBUTING.md` with a stable spec index
- identify the current manifest and COSE envelope specifications in that index
- document how the index should move forward when the current version changes

## Why

The contribution workflow pointed at `spec/agent-manifest-spec-v0.1.md`, which no longer exists. Contributors following it literally had to guess which current document to edit. A stable index fixes the current link and prevents the same failure on the next version bump.

## Impact

Documentation only. No runtime, schema, dependency, workflow, or security-sensitive behavior changes.

## Validation

- focused path assertions confirm the stale v0.1 reference is absent and every linked spec file exists
- `git diff --check`

Closes #275
