### PR TITLE
feat(tpm): add type-safe NV certify attestation parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- **[SDK]** `parse_tpm_attest()` now exposes the common signed `TPMS_ATTEST`
+  header and opaque union payload, while `parse_tpm_nv_certify()` enforces the
+  signed type and parses the `TPMS_NV_CERTIFY_INFO` carried by
+  `TPM2_NV_Certify`. This lets cMCP retire its remaining local NV-certify wire
+  parser. Size-prefixed attestations now reject undeclared trailing bytes.
+
 ### Security
 
 - `verify_manifest()` now fails closed when a core identity, validity, or artifact-container claim is missing. A valid signature no longer turns such a structurally incomplete object into a `VALID` manifest; legacy v0.1 issuer omission remains compatible unless issuer authorization is configured.

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -61,8 +61,10 @@ from ._tdx_verify import (
     parse_tdx_quote, parse_tdx_quote_signature, verify_tdx_quote,
 )
 from ._tpm_verify import (
-    TpmQuote, TpmVerificationError, ParsedSignature,
-    parse_tpm_quote, parse_tpmt_signature, verify_tpm_quote,
+    TPM_ST_ATTEST_NV, NvCertifyInfo, ParsedSignature, TpmAttest, TpmNvCertify, TpmQuote,
+    TpmVerificationError,
+    parse_nv_certify_info, parse_tpm_attest, parse_tpm_nv_certify, parse_tpm_quote,
+    parse_tpmt_signature, verify_tpm_quote,
 )
 from ._verify import (
     verify_manifest,
@@ -133,7 +135,8 @@ __all__ = [
     "verify_cert_chain", "CertChainError",
     "TdxQuote", "TdxQuoteSignature", "TdxVerificationError",
     "parse_tdx_quote", "parse_tdx_quote_signature", "verify_tdx_quote",
-    "TpmQuote", "TpmVerificationError", "ParsedSignature",
+    "TPM_ST_ATTEST_NV", "NvCertifyInfo", "ParsedSignature", "TpmAttest", "TpmNvCertify", "TpmQuote",
+    "TpmVerificationError", "parse_nv_certify_info", "parse_tpm_attest", "parse_tpm_nv_certify",
     "parse_tpm_quote", "parse_tpmt_signature", "verify_tpm_quote",
     "verify_manifest", "verify_runtime_report",
     "VerificationContext", "VerificationResult",

--- a/python/src/agent_manifest/_tpm_verify.py
+++ b/python/src/agent_manifest/_tpm_verify.py
@@ -52,6 +52,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 TPM_GENERATED_VALUE = 0xFF544347
+TPM_ST_ATTEST_NV = 0x8014
 TPM_ST_ATTEST_QUOTE = 0x8018
 _CLOCK_INFO_LEN = 17
 _FIRMWARE_VERSION_LEN = 8
@@ -80,6 +81,25 @@ def _read_2b(buf: bytes, pos: int) -> tuple[bytes, int]:
 
 
 @dataclass(frozen=True)
+class TpmAttest:
+    """Common header and type-specific payload of a ``TPMS_ATTEST``.
+
+    The bytes after the common header are intentionally left opaque.  Callers
+    inspect ``attest_type`` before passing ``attested_raw`` to a parser for the
+    corresponding member of the ``TPMU_ATTEST`` union.
+    """
+
+    magic: int
+    attest_type: int
+    qualified_signer: bytes
+    qualifying_data: bytes
+    clock_info: bytes
+    firmware_version: int
+    attested_raw: bytes
+    raw: bytes
+
+
+@dataclass(frozen=True)
 class TpmQuote:
     """The parsed subset of a TPM 2.0 quote (TPMS_ATTEST) that is appraised."""
 
@@ -88,6 +108,23 @@ class TpmQuote:
     qualifying_data: bytes  # extraData: the verifier's nonce
     pcr_digest: bytes  # the platform measurement
     raw: bytes
+
+
+@dataclass(frozen=True)
+class NvCertifyInfo:
+    """The parsed ``TPMS_NV_CERTIFY_INFO`` member of ``TPMU_ATTEST``."""
+
+    index_name: bytes
+    offset: int
+    nv_contents: bytes
+
+
+@dataclass(frozen=True)
+class TpmNvCertify:
+    """A type-checked TPM NV certification and its signed common header."""
+
+    attest: TpmAttest
+    info: NvCertifyInfo
 
 
 def _unwrap_attest(data: bytes) -> bytes:
@@ -105,7 +142,7 @@ def _unwrap_attest(data: bytes) -> bytes:
     if int.from_bytes(data[0:4], "big") == TPM_GENERATED_VALUE:
         return data
     size = int.from_bytes(data[0:2], "big")
-    if 0 < size <= len(data) - 2:
+    if 0 < size == len(data) - 2:
         inner = data[2:2 + size]
         if len(inner) >= 4 and int.from_bytes(inner[0:4], "big") == TPM_GENERATED_VALUE:
             return inner
@@ -115,6 +152,70 @@ def _unwrap_attest(data: bytes) -> bytes:
     )
 
 
+def parse_tpm_attest(attest: bytes) -> TpmAttest:
+    """Parse the common ``TPMS_ATTEST`` header without assuming a union type.
+
+    Accepts the same bare and ``TPM2B_ATTEST`` framings as
+    :func:`parse_tpm_quote`.  ``attested_raw`` starts at the ``TPMU_ATTEST``
+    union, while ``raw`` is the complete inner structure signed by the AK.
+    """
+    attest = _unwrap_attest(attest)
+    if len(attest) < 6:
+        raise TpmVerificationError("TPM attestation too short")
+    magic = int.from_bytes(attest[0:4], "big")
+    attest_type, pos = _read_u16(attest, 4)
+    qualified_signer, pos = _read_2b(attest, pos)
+    qualifying_data, pos = _read_2b(attest, pos)
+    if pos + _CLOCK_INFO_LEN + _FIRMWARE_VERSION_LEN > len(attest):
+        raise TpmVerificationError("TPM attestation truncated reading clock or firmware data")
+    clock_info = bytes(attest[pos:pos + _CLOCK_INFO_LEN])
+    pos += _CLOCK_INFO_LEN
+    firmware_version = int.from_bytes(attest[pos:pos + _FIRMWARE_VERSION_LEN], "big")
+    pos += _FIRMWARE_VERSION_LEN
+    return TpmAttest(
+        magic=magic,
+        attest_type=attest_type,
+        qualified_signer=qualified_signer,
+        qualifying_data=qualifying_data,
+        clock_info=clock_info,
+        firmware_version=firmware_version,
+        attested_raw=bytes(attest[pos:]),
+        raw=bytes(attest),
+    )
+
+
+def parse_nv_certify_info(attested_raw: bytes) -> NvCertifyInfo:
+    """Parse a ``TPMS_NV_CERTIFY_INFO`` union payload.
+
+    The caller must first use :func:`parse_tpm_attest` and require
+    ``attest_type == TPM_ST_ATTEST_NV``.  Keeping the common-header and union
+    parsers separate prevents a quote from being silently interpreted as an NV
+    certify while still allowing consumers to branch on the signed type.
+    """
+    index_name, pos = _read_2b(attested_raw, 0)
+    offset, pos = _read_u16(attested_raw, pos)
+    nv_contents, pos = _read_2b(attested_raw, pos)
+    if pos != len(attested_raw):
+        raise TpmVerificationError(
+            "TPMS_NV_CERTIFY_INFO has trailing bytes after nvContents"
+        )
+    return NvCertifyInfo(
+        index_name=index_name,
+        offset=offset,
+        nv_contents=nv_contents,
+    )
+
+
+def parse_tpm_nv_certify(attest: bytes) -> TpmNvCertify:
+    """Parse a full NV-certify attestation and enforce its signed union type."""
+    common = parse_tpm_attest(attest)
+    if common.attest_type != TPM_ST_ATTEST_NV:
+        raise TpmVerificationError(
+            f"attestation is not an NV certify (type={common.attest_type:#x})"
+        )
+    return TpmNvCertify(attest=common, info=parse_nv_certify_info(common.attested_raw))
+
+
 def parse_tpm_quote(attest: bytes) -> TpmQuote:
     """Parse a quote blob into its appraised fields.
 
@@ -122,31 +223,30 @@ def parse_tpm_quote(attest: bytes) -> TpmQuote:
     returned ``raw`` is always the inner ``TPMS_ATTEST``, which is the byte range
     the attestation key signed and therefore what a signature check must cover.
     """
-    attest = _unwrap_attest(attest)
-    if len(attest) < 6:
-        raise TpmVerificationError("TPM quote too short")
-    magic = int.from_bytes(attest[0:4], "big")
-    attest_type, pos = _read_u16(attest, 4)
-    _qualified_signer, pos = _read_2b(attest, pos)  # TPM2B_NAME
-    qualifying_data, pos = _read_2b(attest, pos)  # extraData / nonce
-    pos += _CLOCK_INFO_LEN + _FIRMWARE_VERSION_LEN
+    common = parse_tpm_attest(attest)
+    if common.attest_type != TPM_ST_ATTEST_QUOTE:
+        raise TpmVerificationError(
+            f"attestation is not a quote (type={common.attest_type:#x})"
+        )
+    attested = common.attested_raw
+    pos = 0
     # TPML_PCR_SELECTION
-    if pos + 4 > len(attest):
+    if pos + 4 > len(attested):
         raise TpmVerificationError("TPM quote truncated reading PCR selection count")
-    count = int.from_bytes(attest[pos:pos + 4], "big")
+    count = int.from_bytes(attested[pos:pos + 4], "big")
     pos += 4
     for _ in range(count):
-        if pos + 3 > len(attest):
+        if pos + 3 > len(attested):
             raise TpmVerificationError("TPM quote truncated reading a PCR selection")
-        size_of_select = attest[pos + 2]
+        size_of_select = attested[pos + 2]
         pos += 3 + size_of_select
-    pcr_digest, _pos = _read_2b(attest, pos)
+    pcr_digest, _pos = _read_2b(attested, pos)
     return TpmQuote(
-        magic=magic,
-        attest_type=attest_type,
-        qualifying_data=qualifying_data,
+        magic=common.magic,
+        attest_type=common.attest_type,
+        qualifying_data=common.qualifying_data,
         pcr_digest=pcr_digest,
-        raw=bytes(attest),
+        raw=common.raw,
     )
 
 

--- a/python/tests/test_tpm_verify.py
+++ b/python/tests/test_tpm_verify.py
@@ -14,8 +14,12 @@ crypto = pytest.importorskip("cryptography")
 
 from agent_manifest._tpm_verify import (  # noqa: E402
     TPM_GENERATED_VALUE,
+    TPM_ST_ATTEST_NV,
     TPM_ST_ATTEST_QUOTE,
     TpmVerificationError,
+    parse_nv_certify_info,
+    parse_tpm_attest,
+    parse_tpm_nv_certify,
     parse_tpm_quote,
     verify_tpm_quote,
 )
@@ -81,6 +85,26 @@ def _build_attest(
     return out
 
 
+def _build_nv_attest(
+    qualifying_data: bytes,
+    index_name: bytes,
+    offset: int,
+    nv_contents: bytes,
+    qualified_signer: bytes = b"",
+) -> bytes:
+    """Construct a minimal ``TPMS_ATTEST`` carrying ``TPMS_NV_CERTIFY_INFO``."""
+    out = TPM_GENERATED_VALUE.to_bytes(4, "big")
+    out += TPM_ST_ATTEST_NV.to_bytes(2, "big")
+    out += len(qualified_signer).to_bytes(2, "big") + qualified_signer
+    out += len(qualifying_data).to_bytes(2, "big") + qualifying_data
+    out += b"\x00" * 17  # clockInfo
+    out += b"\x00" * 8  # firmwareVersion
+    out += len(index_name).to_bytes(2, "big") + index_name
+    out += offset.to_bytes(2, "big")
+    out += len(nv_contents).to_bytes(2, "big") + nv_contents
+    return out
+
+
 def _sign(ak_key, attest):
     if isinstance(ak_key, ec.EllipticCurvePrivateKey):
         return ak_key.sign(attest, ec.ECDSA(hashes.SHA256()))
@@ -107,6 +131,103 @@ def test_parse_extracts_fields():
 def test_parse_rejects_truncated():
     with pytest.raises(TpmVerificationError):
         parse_tpm_quote(b"\xff")
+
+
+def test_common_parser_exposes_union_without_assuming_quote():
+    qualifying_data = b"freshness"
+    index_name = b"\x00\x0b" + b"\x77" * 32
+    nv_contents = b"measured-gateway"
+    signer = b"\x00\x0b" + b"\x22" * 32
+    attest = _build_nv_attest(
+        qualifying_data, index_name, 7, nv_contents, qualified_signer=signer
+    )
+
+    common = parse_tpm_attest(attest)
+    info = parse_nv_certify_info(common.attested_raw)
+
+    assert common.magic == TPM_GENERATED_VALUE
+    assert common.attest_type == TPM_ST_ATTEST_NV
+    assert common.qualifying_data == qualifying_data
+    assert common.qualified_signer == signer
+    assert common.clock_info == b"\x00" * 17
+    assert common.firmware_version == 0
+    assert common.raw == attest
+    assert info.index_name == index_name
+    assert info.offset == 7
+    assert info.nv_contents == nv_contents
+
+
+def test_common_parser_accepts_tpm2b_attest_framing():
+    attest = _build_nv_attest(b"nonce", b"name", 0, b"contents")
+    wrapped = len(attest).to_bytes(2, "big") + attest
+
+    common = parse_tpm_attest(wrapped)
+
+    assert common.raw == attest
+    assert common.attest_type == TPM_ST_ATTEST_NV
+
+
+def test_common_parser_rejects_tpm2b_trailing_data():
+    attest = _build_nv_attest(b"nonce", b"name", 0, b"contents")
+    wrapped = len(attest).to_bytes(2, "big") + attest + b"trailing"
+
+    with pytest.raises(TpmVerificationError, match="no TPM_GENERATED magic"):
+        parse_tpm_attest(wrapped)
+
+
+def test_quote_parser_rejects_nv_certify_union():
+    attest = _build_nv_attest(b"nonce", b"name", 0, b"contents")
+
+    with pytest.raises(TpmVerificationError, match="not a quote"):
+        parse_tpm_quote(attest)
+
+
+def test_type_checked_nv_entry_point_rejects_quote():
+    with pytest.raises(TpmVerificationError, match="not an NV certify"):
+        parse_tpm_nv_certify(_build_attest(NONCE, PCR))
+
+
+def test_type_checked_nv_entry_point_returns_header_and_info():
+    attest = _build_nv_attest(b"nonce", b"name", 65535, b"contents")
+
+    parsed = parse_tpm_nv_certify(attest)
+
+    assert parsed.attest.qualifying_data == b"nonce"
+    assert parsed.info.index_name == b"name"
+    assert parsed.info.offset == 65535
+    assert parsed.info.nv_contents == b"contents"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"",
+        b"\x00\x10short",
+        b"\x00\x01n\x00",
+        b"\x00\x01n\x00\x00\x00\x08short",
+    ],
+    ids=["empty", "truncated_name", "truncated_offset", "truncated_contents"],
+)
+def test_nv_certify_parser_rejects_truncation(payload):
+    with pytest.raises(TpmVerificationError, match="truncated"):
+        parse_nv_certify_info(payload)
+
+
+def test_nv_certify_parser_rejects_trailing_bytes():
+    attest = _build_nv_attest(b"nonce", b"name", 0, b"contents")
+    common = parse_tpm_attest(attest)
+
+    with pytest.raises(TpmVerificationError, match="trailing bytes"):
+        parse_nv_certify_info(common.attested_raw + b"extra")
+
+
+def test_nv_certify_parsers_are_public_api():
+    import agent_manifest
+
+    assert agent_manifest.TPM_ST_ATTEST_NV == TPM_ST_ATTEST_NV
+    assert agent_manifest.parse_tpm_attest is parse_tpm_attest
+    assert agent_manifest.parse_nv_certify_info is parse_nv_certify_info
+    assert agent_manifest.parse_tpm_nv_certify is parse_tpm_nv_certify
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Add a shared `TPMS_ATTEST` dispatch parser and a type-enforcing `TPM_ST_ATTEST_NV` entry point for `TPMS_NV_CERTIFY_INFO`.

## Why

This addresses the NV-certify consolidation scope added in #255. cMCP currently carries a local parser because `parse_tpm_quote()` assumes the quote union and rejects `TPM_ST_ATTEST_NV`. The new API lets consumers inspect the signed common header and safely parse a full NV certify without reimplementing TPM wire offsets.

The high-level `parse_tpm_nv_certify()` checks the signed attestation type before interpreting the union. The lower-level union parser remains available for callers that already dispatched on `TpmAttest.attest_type`. Size-prefixed `TPM2B_ATTEST` input must consume the full outer buffer; undeclared trailing bytes now fail closed.

This is the NV-certify portion of #255 only. It does not claim to close the remaining digest-agility or verification work.

## Spec impact

None. SDK-only; no normative or conformance-level change.

## Test plan

- [x] `pytest -q tests` - 874 passed, 6 skipped
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src tests --select E,F,W --ignore E501` passes
- [x] `bandit -r src/agent_manifest -c pyproject.toml` passes
- [x] New tests cover bare and TPM2B framing, a non-empty qualified signer, type confusion rejection, truncation, trailing bytes, public exports, and the maximum UINT16 offset
- [x] `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).

## Author name correction

My full name is **Noah Ingwers** (`@noah-ing`). The original commit [`0d32ed8`](https://github.com/agentrust-io/agent-manifest/commit/0d32ed8fab639fa004ae691727e18a8393a84a93) incorrectly used `Noah Ing` in its author, committer, and `Signed-off-by` fields. Those entries refer to me, Noah Ingwers.
