### PR TITLE
feat: add composition-only manifest profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **[SPEC][SDK]** Added the signed `composition-only` profile for repository and
+  pre-execution manifests. Every omitted artifact must be named in
+  `unbound_artifacts`; overlap and undeclared omissions fail closed. These
+  documents verify as `INCOMPLETE` and cannot claim Level 0 or above.
+
 - **[SDK]** `parse_tpm_attest()` now exposes the common signed `TPMS_ATTEST`
   header and opaque union payload, while `parse_tpm_nv_certify()` enforces the
   signed type and parses the `TPMS_NV_CERTIFY_INFO` carried by

--- a/python/README.md
+++ b/python/README.md
@@ -60,6 +60,29 @@ print(sig_block["algorithm"])   # Ed25519
 print(sig_block["key_id"])      # sha256:<hex>
 ```
 
+### Composition-only manifests
+
+Repository scanners can bind the artifacts they know before a model or runtime
+session exists. Set `profile="composition-only"` and explicitly name every
+artifact not bound by the document in `unbound_artifacts`. The verifier returns
+`INCOMPLETE`, not `VALID`, so this narrower document cannot be mistaken for a
+Level 0 agent manifest. Both fields are signature-covered.
+
+```python
+manifest = Manifest(
+    # identity, validity, issuer, and crypto fields omitted here for brevity
+    profile="composition-only",
+    unbound_artifacts=[
+        "tool_manifest", "model_identity", "rag_corpus", "memory_baseline",
+        "decision_trace", "delegation_chain", "supply_chain", "hitl_record",
+    ],
+    artifacts=ArtifactBindings(
+        system_prompt=system_prompt_binding,
+        policy_bundle=policy_bundle_binding,
+    ),
+)
+```
+
 ## The 10 Attested Artifacts
 
 | # | Artifact | What it proves |

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -15,7 +15,8 @@ from .models import (
     RugPullPolicy, TraceType, SbomFormat, SlsaLevel, PoisoningResult,
     ApprovalMethod, ApproverIdentityType, PrincipalType, DataClassification,
     CryptoProfile, SignatureAlgorithm, KeyType, RiskTier,
-    ModelAttestationType, OverrideMechanism, TimeoutAction,
+    ModelAttestationType, ManifestProfile, ArtifactName,
+    OverrideMechanism, TimeoutAction,
 )
 from ._types import HashValue, ManifestId
 from ._canonicalize import canonicalize, canonical_hash
@@ -108,7 +109,8 @@ __all__ = [
     "RugPullPolicy", "TraceType", "SbomFormat", "SlsaLevel", "PoisoningResult",
     "ApprovalMethod", "ApproverIdentityType", "PrincipalType", "DataClassification",
     "CryptoProfile", "SignatureAlgorithm", "KeyType", "RiskTier",
-    "ModelAttestationType", "OverrideMechanism", "TimeoutAction",
+    "ModelAttestationType", "ManifestProfile", "ArtifactName",
+    "OverrideMechanism", "TimeoutAction",
     "HashValue", "ManifestId",
     "canonicalize", "canonical_hash",
     "SIGNED_FIELDS", "signing_pre_image", "intent_hash",

--- a/python/src/agent_manifest/_signing.py
+++ b/python/src/agent_manifest/_signing.py
@@ -134,6 +134,8 @@ SIGNED_FIELDS: tuple[str, ...] = (
     "expires_at",
     "issuer",
     "crypto_profile",
+    "profile",
+    "unbound_artifacts",
     "artifacts",
     "delegation_chain",
     "hitl_record",

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -829,8 +829,13 @@ def verify_manifest(
     elif fields.delegation_chain == DelegationResult.UNVERIFIABLE:
         result.result = OverallResult.UNVERIFIABLE
     elif OverallResult.VALID == result.result:
+        # A composition-only document authenticates a contribution to a future
+        # agent, not a complete agent instance. INCOMPLETE is deliberate: it
+        # can be verified and inspected but cannot be mistaken for Level 0.
+        if manifest.get("profile") == "composition-only":
+            result.result = OverallResult.INCOMPLETE
         # VERIFY-001: bound artifacts with no runtime hashes in strict mode
-        if context.strict_artifact_verification and unverified_bound:
+        elif context.strict_artifact_verification and unverified_bound:
             result.result = OverallResult.INCOMPLETE
         elif context.enforce_attestation and not result.attestation_verified:
             result.result = OverallResult.ATTESTATION_UNAVAILABLE

--- a/python/src/agent_manifest/models.py
+++ b/python/src/agent_manifest/models.py
@@ -54,6 +54,27 @@ class ModelAttestationType(str, Enum):
     provider_asserted = "provider-asserted"
 
 
+class ManifestProfile(str, Enum):
+    """The assurance scope of an Agent Manifest (spec Section 3.1)."""
+
+    composition_only = "composition-only"
+
+
+class ArtifactName(str, Enum):
+    """Names that may be declared outside a composition-only binding."""
+
+    system_prompt = "system_prompt"
+    policy_bundle = "policy_bundle"
+    tool_manifest = "tool_manifest"
+    model_identity = "model_identity"
+    rag_corpus = "rag_corpus"
+    memory_baseline = "memory_baseline"
+    decision_trace = "decision_trace"
+    delegation_chain = "delegation_chain"
+    supply_chain = "supply_chain"
+    hitl_record = "hitl_record"
+
+
 class MemoryType(str, Enum):
     none = "none"
     session = "session"
@@ -632,10 +653,10 @@ class HitlRecord(SpecModel):
 class ArtifactBindings(SpecModel):
     """Container for the 8 artifact bindings that live under `artifacts`."""
 
-    system_prompt: SystemPromptBinding
-    policy_bundle: PolicyBundleBinding
+    system_prompt: Optional[SystemPromptBinding] = None
+    policy_bundle: Optional[PolicyBundleBinding] = None
     tool_manifest: Optional[ToolManifestBinding] = None
-    model_identity: ModelIdentityBinding
+    model_identity: Optional[ModelIdentityBinding] = None
     rag_corpus: Optional[RagCorpusBinding] = None
     memory_baseline: Optional[MemoryBaselineBinding] = None
     decision_trace: Optional[DecisionTraceBinding] = None
@@ -706,6 +727,10 @@ class Manifest(SpecModel):
     expires_at: datetime
     issuer: str  # SPIFFE URI of signing authority
     crypto_profile: CryptoProfile = CryptoProfile.standard
+    # Absent means the original full-binding manifest profile. Keeping the
+    # default absent preserves the signing bytes of every existing manifest.
+    profile: Optional[ManifestProfile] = None
+    unbound_artifacts: Optional[list[ArtifactName]] = None
     artifacts: ArtifactBindings
     # attestation is appended by the TEE at launch - excluded from signature pre-image
     attestation: Optional[dict[str, Any]] = None
@@ -735,6 +760,61 @@ class Manifest(SpecModel):
             raise ValueError("expires_at must be at least 1 hour after issued_at")
         if delta > timedelta(days=365):
             raise ValueError("expires_at must not be more than 365 days after issued_at")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_manifest_profile(self) -> "Manifest":
+        nested_names = {
+            "system_prompt",
+            "policy_bundle",
+            "tool_manifest",
+            "model_identity",
+            "rag_corpus",
+            "memory_baseline",
+            "decision_trace",
+            "supply_chain",
+        }
+        bound = {
+            name for name in nested_names if getattr(self.artifacts, name) is not None
+        }
+        if self.delegation_chain is not None:
+            bound.add("delegation_chain")
+        if self.hitl_record is not None:
+            bound.add("hitl_record")
+
+        if self.profile is None:
+            if self.unbound_artifacts is not None:
+                raise ValueError(
+                    "unbound_artifacts is only valid when profile is 'composition-only'"
+                )
+            required = {"system_prompt", "policy_bundle", "model_identity"}
+            missing = sorted(required - bound)
+            if missing:
+                raise ValueError(
+                    "full-binding manifest is missing required artifacts: "
+                    + ", ".join(missing)
+                )
+            return self
+
+        declared = [name.value for name in self.unbound_artifacts or []]
+        if not declared:
+            raise ValueError(
+                "unbound_artifacts must be non-empty for profile 'composition-only'"
+            )
+        if len(declared) != len(set(declared)):
+            raise ValueError("unbound_artifacts must not contain duplicates")
+        overlap = sorted(bound & set(declared))
+        if overlap:
+            raise ValueError(
+                "artifacts cannot be both bound and declared unbound: "
+                + ", ".join(overlap)
+            )
+        undeclared = sorted({name.value for name in ArtifactName} - bound - set(declared))
+        if undeclared:
+            raise ValueError(
+                "composition-only manifest omits artifacts without declaring them unbound: "
+                + ", ".join(undeclared)
+            )
         return self
 
     @model_validator(mode="after")

--- a/python/tests/test_composition_only.py
+++ b/python/tests/test_composition_only.py
@@ -1,0 +1,139 @@
+"""Composition-only manifest profile conformance and security tests (#256)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from agent_manifest import Manifest, SIGNED_FIELDS
+from agent_manifest._signing import Ed25519Signer, generate_ed25519, signing_pre_image
+from agent_manifest._verify import (
+    FieldResult,
+    OverallResult,
+    RevocationStore,
+    VerificationContext,
+    verify_manifest,
+)
+
+
+NOW = datetime.now(timezone.utc)
+SHA = "sha256:" + "a" * 64
+UNBOUND = [
+    "tool_manifest",
+    "model_identity",
+    "rag_corpus",
+    "memory_baseline",
+    "decision_trace",
+    "delegation_chain",
+    "supply_chain",
+    "hitl_record",
+]
+
+
+def composition_manifest() -> dict:
+    return {
+        "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+        "agent_id": "spiffe://trust.example/composition/repository",
+        "version": "0.1",
+        "issued_at": NOW.isoformat().replace("+00:00", "Z"),
+        "expires_at": (NOW + timedelta(days=30)).isoformat().replace("+00:00", "Z"),
+        "issuer": "spiffe://trust.example/issuer/ci",
+        "crypto_profile": "standard",
+        "profile": "composition-only",
+        "unbound_artifacts": list(UNBOUND),
+        "artifacts": {
+            "system_prompt": {
+                "hash": SHA,
+                "version": "repo-head",
+                "classification": "internal",
+                "bound_at": NOW.isoformat().replace("+00:00", "Z"),
+            },
+            "policy_bundle": {
+                "hash": "sha256:" + "b" * 64,
+                "policy_language": "cedar",
+                "version": "repo-head",
+                "enforcement_mode": "enforce",
+                "bound_at": NOW.isoformat().replace("+00:00", "Z"),
+            },
+        },
+    }
+
+
+def test_composition_only_accepts_an_explicitly_declared_subset() -> None:
+    parsed = Manifest.model_validate(composition_manifest())
+    assert parsed.profile.value == "composition-only"
+    assert parsed.artifacts.model_identity is None
+
+
+@pytest.mark.parametrize("mutation", ["empty", "overlap", "undeclared"])
+def test_composition_only_rejects_ambiguous_coverage(mutation: str) -> None:
+    manifest = composition_manifest()
+    if mutation == "empty":
+        manifest["unbound_artifacts"] = []
+    elif mutation == "overlap":
+        manifest["unbound_artifacts"].append("system_prompt")
+    else:
+        manifest["unbound_artifacts"].remove("model_identity")
+
+    with pytest.raises(ValidationError):
+        Manifest.model_validate(manifest)
+
+
+def test_full_binding_default_still_rejects_a_missing_model() -> None:
+    manifest = composition_manifest()
+    manifest.pop("profile")
+    manifest.pop("unbound_artifacts")
+    with pytest.raises(ValidationError, match="model_identity"):
+        Manifest.model_validate(manifest)
+
+
+def test_profile_limitations_are_signature_covered() -> None:
+    manifest = composition_manifest()
+    assert "profile" in SIGNED_FIELDS
+    assert "unbound_artifacts" in SIGNED_FIELDS
+    original = signing_pre_image(manifest)
+    manifest["unbound_artifacts"].remove("model_identity")
+    assert signing_pre_image(manifest) != original
+
+
+def test_absent_profile_preserves_legacy_signing_bytes() -> None:
+    manifest = composition_manifest()
+    manifest.pop("profile")
+    manifest.pop("unbound_artifacts")
+    with_explicit_nulls = dict(manifest, profile=None, unbound_artifacts=None)
+    assert signing_pre_image(with_explicit_nulls) == signing_pre_image(manifest)
+
+
+def test_reordering_signed_unbound_declaration_invalidates_signature() -> None:
+    manifest = composition_manifest()
+    key = generate_ed25519()
+    manifest["signature"] = Ed25519Signer(key).sign(manifest)
+    manifest["unbound_artifacts"] = list(reversed(manifest["unbound_artifacts"]))
+
+    result = verify_manifest(
+        manifest,
+        VerificationContext(trusted_keys={key.key_id: key.public_b64url()}),
+        RevocationStore(),
+    )
+    assert result.result == OverallResult.MISMATCH
+    assert any(detail.field == "signature" for detail in result.mismatch_details)
+
+
+def test_composition_only_verifies_as_incomplete_with_declared_not_bound_fields() -> None:
+    manifest = composition_manifest()
+    key = generate_ed25519()
+    manifest["signature"] = Ed25519Signer(key).sign(manifest)
+    result = verify_manifest(
+        manifest,
+        VerificationContext(
+            system_prompt_hash=SHA,
+            policy_bundle_hash="sha256:" + "b" * 64,
+            trusted_keys={key.key_id: key.public_b64url()},
+        ),
+        RevocationStore(),
+    )
+    assert result.result == OverallResult.INCOMPLETE
+    assert result.signature_verified is True
+    assert result.fields_verified.system_prompt == FieldResult.MATCH
+    assert result.fields_verified.model_identity == FieldResult.NOT_BOUND
+    assert result.mismatch_details == []

--- a/python/tests/test_signing.py
+++ b/python/tests/test_signing.py
@@ -316,6 +316,8 @@ def test_signed_fields_match_spec_coverage_table():
         "expires_at",
         "issuer",
         "crypto_profile",
+        "profile",
+        "unbound_artifacts",
         "artifacts",
         "delegation_chain",
         "hitl_record",

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -198,6 +198,8 @@ An Agent Manifest is a JSON-LD document conforming to the following schema. All 
   "expires_at": "<string, ISO 8601 UTC - REQUIRED, default issued_at + 90 days>",
   "issuer": "<string, SPIFFE URI of signing authority - REQUIRED>",
   "crypto_profile": "<string, 'standard' | 'post-quantum' - REQUIRED>",
+  "profile": "<string, 'composition-only' - OPTIONAL; absence means full binding>",
+  "unbound_artifacts": "<non-empty array of artifact names - REQUIRED for composition-only>",
   "artifacts": "<object - REQUIRED, see section 3.2>",
   "attestation": "<object - REQUIRED for Level 1+, see section 3.3>",
   "delegation_chain": "<array - REQUIRED if agent is spawned by another agent, see section 3.4>",
@@ -220,6 +222,8 @@ Field cardinality table
 | `expires_at` | string (ISO 8601 UTC) | REQUIRED | Default: `issued_at` + 90 days. MUST NOT be more than 365 days after `issued_at` for Level 1+. MUST NOT be less than 1 hour after `issued_at`. |
 | `issuer` | string (SPIFFE URI) | REQUIRED | |
 | `crypto_profile` | string enum | REQUIRED | `"standard"` or `"post-quantum"`. |
+| `profile` | string enum | OPTIONAL | `"composition-only"`. Absence preserves the full-binding behavior defined before this field existed. |
+| `unbound_artifacts` | array of artifact-name strings | CONDITIONALLY REQUIRED | REQUIRED and non-empty for `composition-only`; otherwise MUST be absent. |
 | `artifacts` | object | REQUIRED | |
 | `attestation` | object | REQUIRED for Level 1+ | MUST be omitted (not null) at Level 0. |
 | `delegation_chain` | array | CONDITIONALLY REQUIRED | REQUIRED when agent is spawned by another agent. Empty array is invalid - omit the field entirely if no delegation. |
@@ -258,6 +262,33 @@ Artifact-to-field mapping (for Level 2 "all 10 artifacts bound" conformance):
 | 10 | HITL Approvals | `hitl_record` (top-level object) |
 
 For Level 2, "all 10 artifacts bound" means artifacts 1-7 and 9 MUST be present in `artifacts`; `delegation_chain` MUST be a non-empty array if the agent is spawned by another agent; and `hitl_record.required` MUST be `true` with at least one approval present.
+
+#### 3.1.1 Composition-only profile
+
+A repository, policy gate, or marketplace scanner can know the composition it contributes before
+a model or execution session exists. Such a producer MAY issue a manifest with
+`profile: "composition-only"`. This profile authenticates a contribution to a future agent; it
+does not describe an agent instance and is not eligible for conformance Level 0 or above. A
+verifier that otherwise authenticates it MUST return `INCOMPLETE`, while still returning the
+per-artifact verification results it was able to compute.
+
+`unbound_artifacts` MUST be present and non-empty on a composition-only manifest. Its values are
+the ten artifact field names in the mapping above:
+`system_prompt`, `policy_bundle`, `tool_manifest`, `model_identity`, `rag_corpus`,
+`memory_baseline`, `decision_trace`, `delegation_chain`, `supply_chain`, and `hitl_record`.
+Every artifact not present in the manifest MUST be named in `unbound_artifacts`, and an artifact
+MUST NOT be both present and named as unbound. Values MUST NOT repeat. A verifier MUST reject an
+omission that is not declared and a bound/unbound contradiction as a schema mismatch.
+
+For each declared name, the verification result MUST be `NOT_BOUND`. `NOT_BOUND` says only that
+this manifest deliberately makes no claim about that artifact; it MUST NOT be interpreted as a
+match, a measured zero, or permission to run without the artifact. A later full manifest can bind
+the completed agent instance.
+
+Both `profile` and `unbound_artifacts` are in the signing pre-image. A party that removes the
+profile, narrows the unbound list, or rewrites its entries after issuance MUST invalidate the
+signature. When `profile` is absent, `unbound_artifacts` MUST also be absent and the original
+full-binding cardinality rules apply, preserving all existing manifests and signatures.
 
 ### 3.2 Artifact Bindings
 
@@ -862,7 +893,7 @@ Each `approval_signature` is produced by the approver's hardware-backed key (FID
   "key_id": "<key identifier>  -- REQUIRED",
   "key_type": "software | hsm | tee-sealed  -- REQUIRED",
   "signed_at": "<ISO 8601 UTC>  -- REQUIRED",
-  "signed_fields": ["@context", "@type", "manifest_id", "previous_manifest_id", "agent_id", "version", "min_verifier_version", "issued_at", "expires_at", "issuer", "crypto_profile", "artifacts", "delegation_chain", "hitl_record", "prior_transparency_log_entry", "log_retention", "data_scope", "operational_lifecycle"],
+  "signed_fields": ["@context", "@type", "manifest_id", "previous_manifest_id", "agent_id", "version", "min_verifier_version", "issued_at", "expires_at", "issuer", "crypto_profile", "profile", "unbound_artifacts", "artifacts", "delegation_chain", "hitl_record", "prior_transparency_log_entry", "log_retention", "data_scope", "operational_lifecycle", "intent"],
   "signature_value": "<base64url-encoded signature over RFC 8785 canonical JSON>  -- CONDITIONALLY REQUIRED: REQUIRED when algorithm is Ed25519 or ML-DSA-65",
   "classical_signature": "<base64url-encoded Ed25519 signature>  -- CONDITIONALLY REQUIRED: REQUIRED when algorithm is hybrid-Ed25519-ML-DSA-65",
   "pq_signature": "<base64url-encoded ML-DSA-65 signature>  -- CONDITIONALLY REQUIRED: REQUIRED when algorithm is hybrid-Ed25519-ML-DSA-65"
@@ -886,6 +917,8 @@ Signing coverage table (normative)
 | `expires_at` | Signed | |
 | `issuer` | Signed | |
 | `crypto_profile` | Signed | |
+| `profile` | Signed | Prevents stripping the `composition-only` limitation. |
+| `unbound_artifacts` | Signed | Prevents rewriting which artifacts the issuer explicitly did not bind. |
 | `artifacts` | Signed | |
 | `attestation` | NOT signed | Appended post-signing by hardware (section 3.3). |
 | `delegation_chain` | Signed | |


### PR DESCRIPTION
Closes #256.

## What changed

- adds the signed `composition-only` manifest profile for repository scanners, policy gates, and other pre-execution producers
- requires a non-empty, exhaustive `unbound_artifacts` declaration for every artifact the document does not bind
- rejects duplicate names, undeclared omissions, and any artifact declared both bound and unbound
- returns `NOT_BOUND` for declared omissions and an overall `INCOMPLETE` result, so the document cannot be mistaken for Level 0+
- keeps the absent-profile path byte-compatible with existing signatures
- exports `ManifestProfile` and `ArtifactName` through the public SDK
- adds normative specification text, SDK guidance, and adversarial tests

## Security properties

`profile` and `unbound_artifacts` are both in the signing pre-image. Stripping the narrower profile, rewriting coverage, or reordering the signed declaration after issuance invalidates the signature. Schema validation runs before signature appraisal, so overlap and undeclared omissions fail closed.

The profile authenticates a contribution to a future agent, not an agent instance. Even with a valid signature and matching supplied artifacts, verification returns `INCOMPLETE` rather than `VALID`.

## Verification

- `python -m pytest -q`: 881 passed, 6 skipped
- `python -m mypy src`: success, no issues in 22 source files
- `python -m bandit -c pyproject.toml -r src -q`: exit 0
- `git diff --check`: clean

The one pytest warning is a pre-existing FastAPI/Starlette deprecation warning.
