### PR TITLE
spec: VALID is provenance, not permission (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@
   was rewritten; it does not establish that every action produced an entry, and
   the section says so.
 
+- **[SPEC]** Added section 5.3.2, what `VALID` does not establish (issue #272).
+  Section 5.3 defined behaviour on `MISMATCH` and none on `VALID`, so a gateway
+  reading it literally had a rule for one outcome and a natural default for the
+  other. `VALID` is a statement about provenance, not permission: it does not
+  establish that the call about to be made is permitted, that it is within the
+  consequence envelope an approver had in mind, or that the agent's current
+  inputs are trustworthy. `catalog_hash` pins which tools were approved, and
+  inside one authorized tool a read and an irreversible write are the same tool.
+  Per-call authorization joins the section 7.2 out-of-scope list, and the
+  overview sentence claiming the manifest proves "what it was allowed to do" is
+  narrowed to what it actually binds. No schema, field, or conformance change;
+  the conformance test from #280 already demonstrates the boundary.
+
 
 - **[SPEC][SDK]** Added the `com.agentrust-io.manifest` Agent Plugins 1.0.0
   extension profile. It resolves an HTTPS manifest by raw-byte digest, verifies

--- a/python/tests/test_valid_authorization_scope.py
+++ b/python/tests/test_valid_authorization_scope.py
@@ -1,7 +1,8 @@
 """AM-VERIFY-SCOPE: what VALID does and does not establish - issue #272.
 
 These tests assert what the implementation does today, not what it should do.
-They pass against main as written, and they are intended to.
+They pass against main as written, and they are intended to. Spec 5.3.2 now
+states the boundary they demonstrate; the tests came first, deliberately.
 
 A manifest can reach VALID with every artifact intact and its tool catalogue
 matching byte for byte, while the call made through an authorized tool is one

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -19,7 +19,7 @@ The Agent Manifest is a cryptographically signed, hardware-attestable document t
 
 ## Why This Matters Now
 
-MCP's emergence as the dominant agent-to-tool protocol has made the agent trust surface explicit and exploitable. In the period between January and February 2026, researchers filed over 30 CVEs targeting MCP servers, clients, and tooling. Palo Alto Unit 42 found that with five connected MCP servers, a single compromised server hit a 78.3% attack success rate. The problem is not MCP's protocol design - it is the absence of a standard identity primitive that makes every agent's approved deployment context verifiable to a third party. A signed JWT proves who called an API. An Agent Manifest proves who the agent was, what it was allowed to do, how it was built, which audit-chain baseline it started from, who approved it, and whether the deployment configuration changed before execution.
+MCP's emergence as the dominant agent-to-tool protocol has made the agent trust surface explicit and exploitable. In the period between January and February 2026, researchers filed over 30 CVEs targeting MCP servers, clients, and tooling. Palo Alto Unit 42 found that with five connected MCP servers, a single compromised server hit a 78.3% attack success rate. The problem is not MCP's protocol design - it is the absence of a standard identity primitive that makes every agent's approved deployment context verifiable to a third party. A signed JWT proves who called an API. An Agent Manifest proves who the agent was, which tools it was approved to hold, how it was built, which audit-chain baseline it started from, who approved it, and whether the deployment configuration changed before execution. It does not prove that a particular call through one of those tools may run; that is the authorization question section 5.3.2 keeps separate.
 
 ## 1. Problem Statement
 
@@ -1337,6 +1337,20 @@ A `VALID` result means all of the following are true:
 
 A `MISMATCH` result means at least one required field does not match its running artifact. The `mismatch_details` array MUST enumerate every mismatched field. A relying party receiving a `MISMATCH` MUST NOT proceed with the operation that triggered verification.
 
+##### 5.3.2 What `VALID` does not establish <!-- CHANGED: #272 - state the authorization boundary -->
+
+`VALID` establishes that the agent presenting this manifest is the agent that was approved, running the artifacts that were approved, unexpired and unrevoked. It is a statement about provenance, not about permission.
+
+A relying party MUST NOT treat `VALID` as authorization for the action that triggered verification. Specifically, `VALID` does not establish any of the following:
+
+- that the specific call about to be made is permitted. `tool_manifest.catalog_hash` pins which tools were approved and detects mutation of their definitions. Inside one authorized tool, a read and an irreversible write are the same tool, and nothing in this specification bounds the arguments a call may carry;
+- that the action is within the consequence envelope a human approver had in mind. `risk_tier` (section 3.5) describes the approval given at issuance, not the action being attempted now;
+- that the agent's current inputs are trustworthy. Section 7.2 keeps prompt injection out of scope, and a manifest that verifies is fully compatible with an agent being misled.
+
+Authorization is the policy layer's question, and the manifest is one of its inputs: a gateway evaluates its own policy over the call, with `VALID` as the precondition establishing which agent is asking rather than as the answer. A gateway that proceeds on `VALID` alone has an identity check where it needed an access decision.
+
+Stating this is not a narrowing of scope. It is what the specification already does: `delegation_chain` returns `UNVERIFIABLE` rather than `VALID` when a Cedar constraint cannot be evaluated, and `hitl_record` returns `APPROVAL_INSUFFICIENT` when an approval does not meet the bar for its `risk_tier`. Both refuse to let an unevaluated condition become a pass. The rule above says the same thing about the overall result, which had a defined behaviour on `MISMATCH` and none on `VALID`.
+
 #### 5.3.1 Runtime session binding for gateways
 
 A gateway that binds an Agent Manifest to a runtime session, such as cMCP, MUST
@@ -1670,6 +1684,7 @@ The following threats are explicitly out of scope for this specification:
 - Side-channel attacks on the TEE - hardware vulnerabilities in AMD SEV-SNP, Intel TDX, or NVIDIA Blackwell that allow measurement extraction are out of scope. These are platform-level threats addressed by hardware vendors.
 - Denial of service against the verification endpoint - availability of the verification service is an operational concern, not a correctness concern.
 - Human approver compromise - if an authorized approver's hardware key is compromised, the HITL record is valid despite the fraudulent approval. Key management and approver identity assurance are out of scope.
+- Per-call authorization - the manifest binds which tools were approved, not what a call through one of them may do. Argument-level policy, consequence bounds, and the read versus irreversible-write distinction inside a single tool belong to the policy layer that consumes a verification result. See section 5.3.2.
 
 ## 8. Conformance Requirements
 


### PR DESCRIPTION
Closes #272. Part of the CoSAI WS4 Phase 1 review (ws4 #149) close-out. Carried by a maintainer per `GOVERNANCE.md#who-may-author-normative-text` — @Mayur021 proposed it and is not the sponsor of the normative text.

## The gap

§5.3 tells a relying party what to do on `MISMATCH` and says nothing about `VALID`. A gateway reading it literally has defined behaviour for one outcome and a natural default for the other, and the natural default is to proceed. The overview paragraph made that reading easier by claiming the manifest proves "what it was allowed to do", which is not what the data model binds.

## What lands

New **§5.3.2, what `VALID` does not establish**. `VALID` is about provenance, not permission. It does not establish:

- that the call about to be made is permitted — `catalog_hash` pins which tools were approved and detects mutation of their definitions, and inside one authorized tool a read and an irreversible write are the same tool;
- that the action is within the consequence envelope an approver had in mind — `risk_tier` describes the approval given at issuance, not the action attempted now;
- that the agent's inputs are trustworthy — §7.2 already excludes prompt injection, and a manifest that verifies is fully compatible with an agent being misled.

Plus the §7.2 bullet the issue asked for, and the overview sentence narrowed to what the manifest actually binds.

## Why this is not a narrowing of scope

The spec already refuses to let an unevaluated condition become a pass: `delegation_chain` returns `UNVERIFIABLE` rather than `VALID` when a Cedar constraint cannot be evaluated, and `hitl_record` returns `APPROVAL_INSUFFICIENT` when an approval does not meet the bar for its `risk_tier`. §5.3.2 says the same thing about the overall result. What changes is that it is written down, in the section the layer that acts on the result actually reads.

The reporter's design note is worth keeping and is why this adds no field: consequence is a property of a call, so anything carried in a deploy-time signed payload is stale by construction.

## No code

No schema, field, or conformance-level change. The conformance test making the gap concrete landed in #280, written by the same reporter, and it passes for the uncomfortable reason — a manifest verifies `VALID` with its catalogue intact while the call through an authorized tool is one no reviewer would have approved. Its docstring now points at §5.3.2; the test came first, deliberately.

@imran-siddique for spec-editor review — this is normative text and I have not self-approved.
