### PR TITLE
spec+sdk: a carried-forward attestation binds the old manifest (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Added
 
+- **[SPEC][SDK]** Withdrew the artifact-only refresh path at Level 1 and above,
+  and made a stale attestation fatal (issue #265). Section 2.2 let
+  `memory_baseline.snapshot_hash` be renewed and the manifest re-signed without
+  re-running the TEE attestation. That cannot hold: `manifest_hash_in_report` is
+  computed over the full manifest including the `signature` block, so the
+  refresh changes the attested pre-image twice and the retained report binds the
+  previous document. A verifier had to either reject the refreshed manifest or
+  stop enforcing the binding, and both cannot be conformant at once. Governed
+  memory evolution belongs to the section 3.2.6.2 checkpoint protocol, which
+  exists so a growing store does not mutate the attested document.
+
+  The verifier previously reported a mismatched `manifest_hash_in_report` only
+  when `enforce_attestation` was set, so the default path returned `VALID` for
+  exactly the case above. A present attestation binding a different manifest is
+  now `MISMATCH` regardless: `enforce_attestation` governs whether an
+  attestation is required, not whether a wrong one counts. `AM-VEC-021` pins it,
+  and `examples/level1-tpm-attested.json` carried a placeholder hash that bound
+  no document, which the new rule surfaced.
+
 
 - **[SPEC][SDK]** Added the `com.agentrust-io.manifest` Agent Plugins 1.0.0
   extension profile. It resolves an HTTPS manifest by raw-byte digest, verifies

--- a/examples/level1-tpm-attested.json
+++ b/examples/level1-tpm-attested.json
@@ -111,7 +111,7 @@
     "platform": "tpm",
     "tee_version": "2.0",
     "measurement": "32b2c3d4e5f67890a2b2c3d4e5f67890a2b2c3d4e5f67890a2b2c3d4e5f67890",
-    "manifest_hash_in_report": "sha256:22b2c3d4e5f67890a2b2c3d4e5f67890a2b2c3d4e5f67890a2b2c3d4e5f67890",
+    "manifest_hash_in_report": "sha256:8bba1e58d40803b9ddbca309fd9d780b98f653c094203310c161e2a5d0cbc67c",
     "audit_chain_root": "sha256:e2b2c3d4e5f67890e2b2c3d4e5f67890e2b2c3d4e5f67890e2b2c3d4e5f67890",
     "report_timestamp": "2026-06-04T00:00:30Z",
     "report_uri": "https://attestation.internal.acme.co/reports/payment-authorizer-20260604"

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -808,7 +808,15 @@ def verify_manifest(
                 expected_attest_hash = "sha256:" + _hashlib.sha256(_canonicalize(subset)).hexdigest()
             if hmac.compare_digest(reported_hash, expected_attest_hash):
                 result.attestation_verified = True
-            elif context.enforce_attestation:
+            else:
+                # A present attestation that binds a different manifest is a
+                # mismatch whether or not the caller asked for enforcement
+                # (spec 3.3, issue #265). Absent is a policy question and
+                # enforce_attestation still governs it; present-and-wrong is
+                # not: it is a report about some other document, and the case
+                # that produces it is the stale attestation left on a re-signed
+                # manifest. Gating it on enforce_attestation meant the default
+                # verifier returned VALID for exactly that.
                 mismatches.append(MismatchDetail(
                     field="attestation",
                     expected_hash=expected_attest_hash,

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -317,12 +317,16 @@ def test_attestation_hash_mismatch_with_enforce_raises_mismatch():
     assert any(d.field == "attestation" for d in result.mismatch_details)
 
 
-def test_attestation_hash_mismatch_without_enforce_is_valid():
+def test_attestation_hash_mismatch_is_fatal_without_enforce():
+    """Issue #265: a present attestation that binds a different manifest is
+    a report about some other document. enforce_attestation governs whether
+    an attestation is required, not whether a wrong one counts."""
     m = base_manifest()
     m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": "sha256:" + "00" * 32}
     result = verify_manifest(m, base_context(), store())
     assert result.attestation_verified is False
-    assert result.result == OverallResult.VALID
+    assert result.result == OverallResult.MISMATCH
+    assert [d for d in result.mismatch_details if d.field == "attestation"]
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/vectors/AM-VEC-021.json
+++ b/python/tests/vectors/AM-VEC-021.json
@@ -1,0 +1,82 @@
+{
+  "id": "AM-VEC-021",
+  "description": "Attestation carried forward onto a re-signed manifest binds the previous document.",
+  "spec_refs": [
+    "2.2",
+    "3.3"
+  ],
+  "manifest": {
+    "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+    "agent_id": "spiffe://trust.example/agent/kyc/prod",
+    "version": "0.1",
+    "issued_at": "2025-01-01T00:00:00Z",
+    "expires_at": "2099-12-31T23:59:59Z",
+    "issuer": "spiffe://trust.example/signing-authority",
+    "crypto_profile": "standard",
+    "artifacts": {
+      "system_prompt": {
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "policy_bundle": {
+        "hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "model_identity": {
+        "model_hash": null,
+        "version": "claude-3",
+        "deployment_type": "api"
+      },
+      "memory_baseline": {
+        "snapshot_hash": "sha256:b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      }
+    },
+    "delegation_chain": [],
+    "hitl_record": null,
+    "signature": {
+      "algorithm": "Ed25519",
+      "key_id": "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
+      "key_type": "software",
+      "signed_at": "2025-01-01T00:00:00Z",
+      "signature_value": "RlKGJN6JbV6lLGoNs59IShQBGZW6vEjsmbQec2eKzFBFmDM0mKFioCiBERBF7bT1GC7s1WwMGwc1BJtT2e9iCw",
+      "signed_fields": [
+        "@context",
+        "@type",
+        "manifest_id",
+        "previous_manifest_id",
+        "agent_id",
+        "version",
+        "min_verifier_version",
+        "issued_at",
+        "expires_at",
+        "issuer",
+        "crypto_profile",
+        "profile",
+        "unbound_artifacts",
+        "source_bundle",
+        "artifacts",
+        "delegation_chain",
+        "hitl_record",
+        "prior_transparency_log_entry",
+        "log_retention",
+        "data_scope",
+        "operational_lifecycle",
+        "intent"
+      ]
+    },
+    "attestation": {
+      "platform": "tpm",
+      "manifest_hash_in_report": "sha256:b68318cc801604dbca75370489da37ee4e0c3fd44c9de41037ed4a1731f8cc4b"
+    }
+  },
+  "context": {
+    "system_prompt_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "policy_bundle_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "model_version": "claude-3",
+    "trusted_keys": {
+      "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    }
+  },
+  "expected": {
+    "result": "MISMATCH",
+    "attestation_verified": false
+  }
+}

--- a/python/tests/vectors/generate.py
+++ b/python/tests/vectors/generate.py
@@ -810,6 +810,44 @@ def build() -> list[dict[str, Any]]:
         {"result": "VALID", "attestation_verified": True},
     ))
 
+    # 018b - the stale-attestation case from issue #265. The manifest is
+    # attested, then memory_baseline.snapshot_hash is renewed and the document
+    # re-signed, and the original attestation block is carried forward. This is
+    # exactly what the withdrawn artifact-only refresh path described. The
+    # pre-image covers the signature block, so re-signing alone would have been
+    # enough to break the binding; the retained report binds the previous
+    # document either way, and spec 3.3 requires MISMATCH regardless of
+    # enforce_attestation.
+    m = base_manifest(artifacts={
+        "system_prompt": {"hash": SP_HASH},
+        "policy_bundle": {"hash": PB_HASH},
+        "model_identity": {
+            "model_hash": None,
+            "version": "claude-3",
+            "deployment_type": "api",
+        },
+        "memory_baseline": {"snapshot_hash": "sha256:" + "a1" * 32},
+    })
+    subset = {k: v for k, v in m.items() if k not in ("attestation", "transparency_log_entry")}
+    stale_hash = "sha256:" + hashlib.sha256(canonicalize(subset)).hexdigest()
+    refreshed = base_manifest(artifacts={
+        "system_prompt": {"hash": SP_HASH},
+        "policy_bundle": {"hash": PB_HASH},
+        "model_identity": {
+            "model_hash": None,
+            "version": "claude-3",
+            "deployment_type": "api",
+        },
+        "memory_baseline": {"snapshot_hash": "sha256:" + "b2" * 32},
+    })
+    refreshed["attestation"] = {"platform": "tpm", "manifest_hash_in_report": stale_hash}
+    vectors.append(_vector(
+        "AM-VEC-021",
+        "Attestation carried forward onto a re-signed manifest binds the previous document.",
+        ["2.2", "3.3"], refreshed, base_context(),
+        {"result": "MISMATCH", "attestation_verified": False},
+    ))
+
     # 019 - a fully signed, verifiable single-hop delegation chain.
     # The chain root principal must equal the manifest signing identity (issuer),
     # so a valid chain cannot be grafted onto an unrelated manifest.

--- a/python/tests/vectors/index.json
+++ b/python/tests/vectors/index.json
@@ -99,6 +99,11 @@
       "description": "Attestation report hash matching the canonical manifest hash verifies."
     },
     {
+      "id": "AM-VEC-021",
+      "file": "AM-VEC-021.json",
+      "description": "Attestation carried forward onto a re-signed manifest binds the previous document."
+    },
+    {
       "id": "AM-VEC-019",
       "file": "AM-VEC-019.json",
       "description": "Signed single-hop delegation chain bound to the manifest issuer verifies."

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -125,7 +125,8 @@ The `manifest_id` field is immutable per issuance. Any change to any signed fiel
 Two update paths are defined:
 
 - Full re-issuance: A new UUID v7, a new TEE attestation run, and a new transparency log entry. Required when any artifact binding changes, the signing key rotates, or the manifest expires.
-- Artifact-only refresh: Used only for `memory_baseline.snapshot_hash` renewal within the same `ttl_seconds` window. The manifest is re-signed but the TEE attestation need not be re-run if no other artifact has changed. This path is NOT available for any other artifact.
+- Artifact-only refresh: **Withdrawn at Level 1 and above** <!-- CHANGED: #265 --> in favour of the memory checkpoint protocol. It permitted `memory_baseline.snapshot_hash` to be renewed and the manifest re-signed without re-running the TEE attestation, which cannot hold: `manifest_hash_in_report` (section 3.3) is computed over the full manifest including the `signature` block, so changing the snapshot hash and re-signing changes the attested pre-image twice over. The retained attestation binds the previous document. A verifier had to either reject the refreshed manifest or stop enforcing the binding, and both cannot be conformant at once. At Level 1 and above, any change to a signed field MUST produce a new manifest and a fresh attestation binding its new `manifest_hash_in_report`. At Level 0 there is no attestation to invalidate, so a re-signed manifest with a new `manifest_id` is the only requirement and the refresh path adds nothing.
+- Governed memory evolution: Memory may advance without re-attesting the root manifest through the checkpoint and delta protocol in section 3.2.6.2, which binds the advance in a separate object with its own consistency proof and freshness rule. That protocol exists so a growing memory store does not have to mutate the document whose exact hash was attested. A checkpoint advance is not a refreshed manifest and MUST NOT be presented as one.
 
 Version Negotiation
 
@@ -708,6 +709,10 @@ The attestation block binds the manifest to a specific TEE hardware measurement.
 `manifest_hash_in_report` pre-image <!-- CHANGED: SPEC-09 - normative pre-image definition -->
 
 The `manifest_hash_in_report` pre-image is the RFC 8785 canonical JSON serialization of the full manifest document including the `signature` block and excluding only the `attestation` block. The `attestation` key MUST NOT be present in the pre-image document. The `transparency_log_entry` key MUST also be absent from the pre-image (it is populated after log submission). The hash MUST be computed over the UTF-8 encoding of this canonical form with no BOM.
+
+Because the pre-image covers the `signature` block, re-signing a manifest changes its `manifest_hash_in_report` even when no artifact value changed. An attestation carried forward onto a re-signed document therefore binds the previous document, not the one being verified.
+
+A verifier that finds an `attestation` block whose `manifest_hash_in_report` does not equal the hash computed above MUST return `MISMATCH`, whether or not `enforce_attestation` is set. <!-- CHANGED: #265 --> `enforce_attestation` governs whether an attestation is *required*; it does not govern whether a wrong one counts. An absent attestation and a present attestation that binds a different manifest are different conditions: the first is a policy question and the second is a report about some other document.
 
 The `audit_key_sealed` field (JSON boolean) MUST be `true` for production deployments. It indicates that the audit log signing key was generated inside the TEE and has never been exported to operator-readable memory. A manifest with `audit_key_sealed: false` MUST be treated as software-attested and MUST NOT satisfy regulatory requirements that call for hardware-rooted evidence.
 


### PR DESCRIPTION
Closes #265. Part of the CoSAI WS4 Phase 1 review (ws4 #149) close-out. Normative text carried by a maintainer per `GOVERNANCE.md#who-may-author-normative-text`; @sapsan14 reported it.

## The contradiction

§2.2's artifact-only refresh let `memory_baseline.snapshot_hash` be renewed and the manifest re-signed without re-running the TEE attestation. §3.3 computes `manifest_hash_in_report` over the full manifest **including the `signature` block**, so the refresh changes the attested pre-image twice — once for the artifact, once for the signature over it. The retained report binds the previous document. A verifier had to either reject the refreshed manifest or stop enforcing the binding; both cannot be conformant at once.

## Withdrawn, not patched

There is no version of that path that works — re-signing alone breaks the binding even when no artifact value changed. At Level 1+, any change to a signed field now requires a new manifest and a fresh attestation. At Level 0 there is no attestation to invalidate, so the path was only ever describing ordinary re-issuance there (which also answers item 4 of the issue: there is no legacy shorthand worth keeping).

Governed memory evolution already has a home: the §3.2.6.2 checkpoint/delta protocol, which binds an advance in a separate object with its own consistency proof and freshness rule — built so a growing store does not mutate the attested document. §2.2 now points at it instead of offering a second mechanism that undermines it.

## The verifier was the larger half

Reporting a mismatched `manifest_hash_in_report` was gated on `enforce_attestation`, so **the default verifier returned `VALID` for exactly the case in this issue.** That gate conflated two conditions:

- *absent* attestation — a policy question, and `enforce_attestation` is the right control;
- *present and wrong* — a report about a different document, which nothing makes acceptable.

Present-and-wrong is now `MISMATCH` either way.

Two things fell out:

- `test_attestation_hash_mismatch_without_enforce_is_valid` asserted the old behaviour by name; rewritten to assert the rule.
- `examples/level1-tpm-attested.json` carried a placeholder `manifest_hash_in_report` binding no document at all, so it stopped returning `UNVERIFIABLE`. Its hash is now computed over its own canonical form, which a published example should have been doing regardless.

## AM-VEC-021

Item 3 of the issue, as a portable vector: attest a manifest, renew the snapshot hash, re-sign, keep the original attestation block, expect `MISMATCH`. The withdrawn path expressed as a test, so other implementations inherit the rule rather than the prose.

## Verification

Full suite 1072 passed, 6 skipped. `mypy` strict and `ruff` under the CI rule set clean. Vectors regenerate byte-identically.

@imran-siddique for spec-editor and maintainer review — normative text plus a verifier behaviour change, and I have not self-approved.
