### PR TITLE
spec: say what a governed memory checkpoint does not establish (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@
   defined value space and no verification behaviour, which is what it always
   was; the field name resembled an assurance signal and nothing said otherwise.
 
+- **[SPEC]** Stated the scope boundary of the memory checkpoint protocol
+  (section 3.2.6.2, issue #298). A governed advance establishes integrity,
+  ordering, freshness and budget, and establishes nothing about retrieval
+  behaviour over the new state. A checkpoint can satisfy every rule while an
+  appended correction stays less salient than the fact it corrects, while
+  authorized additions displace a safety or identity anchor, while another
+  tenant's memory becomes retrievable, or while states that should retrieve
+  differently collapse to the same context. None of that needs a forged
+  signature or a broken proof, so the protocol's own checks cannot see it.
+  Assessment is a separate evidence artifact over a pinned retriever and probe
+  suite, out of scope here and tracked in #298.
+
 - **[SPEC][SDK]** Withdrew the artifact-only refresh path at Level 1 and above,
   and made a stale attestation fatal (issue #265). Section 2.2 let
   `memory_baseline.snapshot_hash` be renewed and the manifest re-signed without

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -630,6 +630,8 @@ proof to the 2-operation log is the single node
 `42effb8d6d6bf9904585248b30b039a5ede7a447a5f8fd21cc0a8b0b850c566f`. Implementations MUST
 reproduce these values.
 
+Scope. A governed checkpoint advance establishes integrity, ordering, freshness and budget. It does not establish that retrieval behaviour over the new memory state remained acceptable, and nothing in this protocol assesses it. A checkpoint can satisfy every rule above while an appended correction stays less salient than the fact it corrects, while authorized additions displace a safety or identity anchor, while memory from another role or tenant becomes retrievable, or while states that should retrieve differently collapse to the same context. None of those requires a forged signature, a rewritten checkpoint, an expired TTL, or an invalid consistency proof. Assessing them is a separate evidence artifact over a pinned retriever and probe suite, out of scope for this specification and tracked in [agent-manifest#298](https://github.com/agentrust-io/agent-manifest/issues/298).
+
 Limitations (v0.2). Log compaction / checkpoint re-baseline is not yet defined: a
 deployment MUST re-baseline (full re-approval per Section 3.2.6.1) before the cumulative
 operation count approaches implementation limits. HITL co-signing of a checkpoint advance and


### PR DESCRIPTION
Refs #298 (stays open — see below). Normative-adjacent scope text carried by a maintainer; @nikshilov filed the report.

## The gap

§3.2.6.2 establishes that a candidate checkpoint is an append-only extension of an approved state, that its sequence advances, that it is fresh, and that it is within budget. It establishes nothing about retrieval behaviour over the new state, and nothing in the protocol looks at that.

Every failure mode in the report passes all four checks as written:

- an appended correction stays less salient than the fact it corrects;
- authorized additions displace a safety, identity, or continuity anchor;
- memory from another role, project, or tenant becomes retrievable;
- states that should retrieve differently collapse to the same context.

None needs a forged signature, a rewritten checkpoint, an expired TTL, or an invalid consistency proof. The protocol's own checks are structurally unable to see any of them.

`docs/memory-governance.md` already drew that line; the spec did not. A reader of §3.2.6.2 alone could reasonably take "governed advance" to mean the memory is still fit to retrieve from.

## What this does not do

It does not add the `MemoryCheckpointAssessment/0.1` artifact the report proposes. That is an external non-normative deliverable needing a reference harness, a pinned retriever adapter, and deterministic public fixtures, and the report is right that it starts outside the manifest rather than as a required field.

**#298 stays open** as the tracking issue for that work. Writing the boundary down first is what stops the spec claiming an assessment before the harness exists.
