### PR TITLE
spec: replace raw NUL with escaped byte notation (#318)

### DIFF
--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -687,7 +687,7 @@ A checkpoint binds `{audit_chain_root, tree_size, seq, observed_at, ttl_seconds}
 }
 ```
 
-Entry leaves. An entry leaf is `H(0x00 || "am-trace-entry " || canonical_entry)`, where `canonical_entry` is the RFC 8785 canonical JSON (Section 4.3) of the audit entry. The tag domain-separates a trace entry from a memory operation or a corpus document that canonicalizes to the same bytes.
+Entry leaves. An entry leaf is `H(0x00 || "am-trace-entry\x00" || canonical_entry)`, where `canonical_entry` is the RFC 8785 canonical JSON (Section 4.3) of the audit entry. The tag domain-separates a trace entry from a memory operation or a corpus document that canonicalizes to the same bytes.
 
 Continuity evidence. The shape depends on the signed `trace_type`, and the verifier MUST use the `trace_type` bound in the manifest rather than one asserted at fetch time.
 


### PR DESCRIPTION
Closes #318.

## What changed

- Replaced the literal NUL byte in the trace-entry domain-separation tag with the textual `\x00` notation.
- Kept the specified bytes unchanged while making the Markdown file safe for ordinary text search.

## Root cause

The intended trailing NUL was embedded directly in the Markdown source instead of being represented as an escape, causing grep-compatible tools to classify the specification as binary.

## Validation

- Byte-level check: NUL count changed from 1 to 0.
- `rg risk_tier spec/agent-manifest-spec-v0.2.md` now returns normal text matches.
- `PYTHONPATH=python/src python -m pytest -q --basetemp C:\Users\imran\source\.pytest-tmp-am318`: 1118 passed, 6 skipped.
- `git diff --check`: clean.