### PR TITLE
feat(tpm): verify marshalled signature envelopes (#255)

### DIFF
--- a/python/src/agent_manifest/_tpm_verify.py
+++ b/python/src/agent_manifest/_tpm_verify.py
@@ -12,8 +12,9 @@ Verification is fail-closed, in four steps:
 2. The attestation-key (AK) certificate chain is verified up to a
    caller-supplied trusted root (leaf issued-by next, root pinned by
    SHA-256 fingerprint). A self-signed AK is never trusted on its own.
-3. The AK signature over the ``TPMS_ATTEST`` blob is verified (ECDSA-P256 or
-   RSA PKCS#1 v1.5, both over SHA-256).
+3. The AK signature over the ``TPMS_ATTEST`` blob is verified. Bare signatures
+   retain the legacy SHA-256 behavior; a ``TPMT_SIGNATURE`` selects RSASSA,
+   RSAPSS, or ECDSA and SHA-256, SHA-384, or SHA-512 from its signed envelope.
 4. The qualifying data (the verifier's nonce, carried in ``extraData``) and the
    PCR digest (the platform measurement) are checked against expected values
    with constant-time compares.
@@ -285,7 +286,10 @@ def parse_tpmt_signature(blob: bytes) -> ParsedSignature:
             offset += 2
             if len(blob) < offset + size:
                 raise TpmVerificationError("TPMT_SIGNATURE truncated inside the RSA signature")
-            return ParsedSignature(sig_alg, hash_alg, blob[offset:offset + size])
+            offset += size
+            if offset != len(blob):
+                raise TpmVerificationError("TPMT_SIGNATURE has trailing bytes")
+            return ParsedSignature(sig_alg, hash_alg, blob[offset - size:offset])
 
         if sig_alg == _ALG_ECDSA:
             from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
@@ -300,6 +304,8 @@ def parse_tpmt_signature(blob: bytes) -> ParsedSignature:
                     )
                 parts.append(blob[offset:offset + size])
                 offset += size
+            if offset != len(blob):
+                raise TpmVerificationError("TPMT_SIGNATURE has trailing bytes")
             return ParsedSignature(
                 sig_alg,
                 hash_alg,
@@ -347,7 +353,7 @@ def _verify_ak_chain(ak_chain_pem: bytes, trusted_roots_pem: bytes) -> "object":
 
 def verify_tpm_quote(
     attest: bytes,
-    signature: bytes,
+    signature: bytes | ParsedSignature,
     ak_chain_pem: bytes,
     *,
     trusted_roots_pem: bytes,
@@ -358,8 +364,10 @@ def verify_tpm_quote(
 
     Args:
         attest: the raw ``TPMS_ATTEST`` blob the TPM signed.
-        signature: the AK signature over ``attest`` (DER ECDSA-P256 or RSA
-            PKCS#1 v1.5, SHA-256).
+        signature: either the legacy bare AK signature (DER ECDSA or RSA
+            PKCS#1 v1.5 over SHA-256), a parsed :class:`ParsedSignature`, or a
+            marshalled ``TPMT_SIGNATURE``. Envelopes select RSASSA, RSAPSS, or
+            ECDSA and SHA-256, SHA-384, or SHA-512 from their algorithm ids.
         ak_chain_pem: the AK certificate chain (PEM, leaf first).
         trusted_roots_pem: the caller's trusted vendor EK/AK roots (PEM).
         expected_qualifying_data: if given, the quote's ``extraData`` (nonce)
@@ -375,8 +383,8 @@ def verify_tpm_quote(
     """
     try:
         from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
-        from cryptography.hazmat.primitives.hashes import SHA256
     except ImportError as e:  # pragma: no cover
         raise TpmVerificationError(
             "TPM quote verification requires the 'cryptography' package"
@@ -403,11 +411,55 @@ def verify_tpm_quote(
     # signed the inner structure, so verifying over the outer bytes would fail a
     # genuine quote.
     signed = quote.raw
+    parsed_signature: ParsedSignature | None = None
+    if isinstance(signature, ParsedSignature):
+        parsed_signature = signature
+    elif len(signature) >= 2 and int.from_bytes(signature[:2], "big") in (
+        _ALG_RSASSA,
+        _ALG_RSAPSS,
+        _ALG_ECDSA,
+    ):
+        parsed_signature = parse_tpmt_signature(signature)
+
+    if parsed_signature is None:
+        assert isinstance(signature, bytes)
+        bare_signature = signature
+        signature_algorithm = None
+        digest: hashes.HashAlgorithm = hashes.SHA256()
+    else:
+        bare_signature = parsed_signature.signature
+        signature_algorithm = parsed_signature.sig_alg
+        if parsed_signature.hash_alg == 0x000B:
+            digest = hashes.SHA256()
+        elif parsed_signature.hash_alg == 0x000C:
+            digest = hashes.SHA384()
+        elif parsed_signature.hash_alg == 0x000D:
+            digest = hashes.SHA512()
+        else:
+            raise TpmVerificationError(
+                f"unsupported hash algorithm 0x{parsed_signature.hash_alg:04x}"
+            )
+
     try:
         if isinstance(ak_key, ec.EllipticCurvePublicKey):
-            ak_key.verify(signature, signed, ec.ECDSA(SHA256()))
+            if signature_algorithm not in (None, _ALG_ECDSA):
+                raise TpmVerificationError(
+                    "TPMT_SIGNATURE algorithm does not match the EC attestation key"
+                )
+            ak_key.verify(bare_signature, signed, ec.ECDSA(digest))
         elif isinstance(ak_key, rsa.RSAPublicKey):
-            ak_key.verify(signature, signed, padding.PKCS1v15(), SHA256())
+            signature_padding: padding.AsymmetricPadding
+            if signature_algorithm in (None, _ALG_RSASSA):
+                signature_padding = padding.PKCS1v15()
+            elif signature_algorithm == _ALG_RSAPSS:
+                signature_padding = padding.PSS(
+                    mgf=padding.MGF1(digest), salt_length=digest.digest_size
+                )
+            else:
+                raise TpmVerificationError(
+                    "TPMT_SIGNATURE algorithm does not match the RSA attestation key"
+                )
+            ak_key.verify(bare_signature, signed, signature_padding, digest)
         else:
             raise TpmVerificationError("unsupported AK public-key type for TPM quote")
     except InvalidSignature:

--- a/python/tests/test_tpm_verify.py
+++ b/python/tests/test_tpm_verify.py
@@ -21,6 +21,7 @@ from agent_manifest._tpm_verify import (  # noqa: E402
     parse_tpm_attest,
     parse_tpm_nv_certify,
     parse_tpm_quote,
+    parse_tpmt_signature,
     verify_tpm_quote,
 )
 
@@ -109,6 +110,27 @@ def _sign(ak_key, attest):
     if isinstance(ak_key, ec.EllipticCurvePrivateKey):
         return ak_key.sign(attest, ec.ECDSA(hashes.SHA256()))
     return ak_key.sign(attest, padding.PKCS1v15(), hashes.SHA256())
+
+
+def _tpmt_signature(ak_key, attest, *, sig_alg, hash_alg, digest):
+    if isinstance(ak_key, ec.EllipticCurvePrivateKey):
+        from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+        signature = ak_key.sign(attest, ec.ECDSA(digest))
+        r, s = decode_dss_signature(signature)
+        r_bytes = r.to_bytes((r.bit_length() + 7) // 8, "big")
+        s_bytes = s.to_bytes((s.bit_length() + 7) // 8, "big")
+        body = len(r_bytes).to_bytes(2, "big") + r_bytes
+        body += len(s_bytes).to_bytes(2, "big") + s_bytes
+    else:
+        scheme = (
+            padding.PKCS1v15()
+            if sig_alg == 0x0014
+            else padding.PSS(mgf=padding.MGF1(digest), salt_length=digest.digest_size)
+        )
+        signature = ak_key.sign(attest, scheme, digest)
+        body = len(signature).to_bytes(2, "big") + signature
+    return sig_alg.to_bytes(2, "big") + hash_alg.to_bytes(2, "big") + body
 
 
 NONCE = bytes(range(32))
@@ -262,6 +284,54 @@ def test_verify_rejects_wrong_ak_key():
     other = ec.generate_private_key(ec.SECP256R1())
     sig = _sign(other, attest)  # signed by a key that is not the AK
     assert verify_tpm_quote(attest, sig, chain, trusted_roots_pem=roots) is False
+
+
+@pytest.mark.parametrize(
+    ("kind", "sig_alg"),
+    [("rsa", 0x0014), ("rsa", 0x0016), ("ec", 0x0018)],
+)
+def test_verify_accepts_sha384_tpmt_signature(kind, sig_alg):
+    ak_key, chain, roots = _ak_chain(kind)
+    attest = _build_attest(NONCE, PCR)
+    signature = _tpmt_signature(
+        ak_key,
+        attest,
+        sig_alg=sig_alg,
+        hash_alg=0x000C,
+        digest=hashes.SHA384(),
+    )
+
+    assert verify_tpm_quote(attest, signature, chain, trusted_roots_pem=roots) is True
+
+
+def test_verify_rejects_tpmt_signature_with_unsupported_hash():
+    ak_key, chain, roots = _ak_chain("rsa")
+    attest = _build_attest(NONCE, PCR)
+    signature = _tpmt_signature(
+        ak_key,
+        attest,
+        sig_alg=0x0014,
+        hash_alg=0x0004,
+        digest=hashes.SHA1(),
+    )
+
+    with pytest.raises(TpmVerificationError, match="unsupported hash algorithm"):
+        verify_tpm_quote(attest, signature, chain, trusted_roots_pem=roots)
+
+
+def test_tpmt_signature_rejects_trailing_bytes():
+    ak_key, _chain, _roots = _ak_chain("rsa")
+    attest = _build_attest(NONCE, PCR)
+    signature = _tpmt_signature(
+        ak_key,
+        attest,
+        sig_alg=0x0014,
+        hash_alg=0x000B,
+        digest=hashes.SHA256(),
+    )
+
+    with pytest.raises(TpmVerificationError, match="trailing bytes"):
+        parse_tpmt_signature(signature + b"extra")
 
 
 def test_verify_rejects_untrusted_root():


### PR DESCRIPTION
Closes #255.

## What changed

- `verify_tpm_quote()` now accepts marshalled `TPMT_SIGNATURE` envelopes and `ParsedSignature` values directly.
- Verification selects RSASSA, RSAPSS, or ECDSA from `sig_alg`.
- Verification selects SHA-256, SHA-384, or SHA-512 from `hash_alg`.
- Existing bare-signature callers retain SHA-256 compatibility.
- Signature envelopes with trailing bytes, unsupported hashes, or an algorithm that does not match the AK key type fail closed.

## Why

The parsers and NV-certify dispatch had already landed through #258 and #304, but the canonical verifier still ignored the envelope algorithm identifiers. Consumers therefore could not pass real TPM output through untouched and RSAPSS or SHA-384 quotes could not verify.

## Evidence

- Pre-change focused run: 5 new cases failed.
- Post-change focused run: 6 passed.
- TPM suite: 44 passed.
- Full suite: 1123 passed, 6 skipped.
- `mypy src/agent_manifest`: passed.
- CI Ruff command: passed.
- `git diff --check`: passed.