### PR TITLE
fix(hitl): define and enforce risk tiers (#313)

### DIFF
--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -911,6 +911,7 @@ def verify_manifest(
             # Check if any approval has expired (HITL-001: parse failure must set all_ok=False)
             now = datetime.now(timezone.utc)
             all_ok = True
+            approval_insufficient = False
             for approval in approvals:
                 approved_at = approval.get("approved_at", "")
                 duration = approval.get("approved_scope", {}).get("approval_duration_seconds", 0)
@@ -924,14 +925,32 @@ def verify_manifest(
                     # Unparseable timestamp - treat as expired to fail safe (HITL-001)
                     all_ok = False
                     break
-            if not all_ok:
+                if context.conformance_level >= 2:
+                    scope = approval.get("approved_scope") or {}
+                    risk_tier = scope.get("risk_tier")
+                    method = approval.get("approval_method")
+                    if method == "software-key" or (
+                        risk_tier in {"high", "critical"} and method != "hardware-key"
+                    ):
+                        approval_insufficient = True
+                        break
+            if approval_insufficient:
+                mismatches.append(MismatchDetail(
+                    field="hitl_record",
+                    expected_hash="<approval method sufficient for declared risk tier>",
+                    actual_hash="<approval method insufficient>",
+                ))
+                fields.hitl_record = HitlResult.APPROVAL_INSUFFICIENT
+            elif not all_ok:
                 # Expired approvals always add to mismatches regardless of enforce_hitl (HITL-002)
                 mismatches.append(MismatchDetail(
                     field="hitl_record",
                     expected_hash="<valid unexpired approval>",
                     actual_hash="<approval expired or unparseable>",
                 ))
-            fields.hitl_record = HitlResult.APPROVED if all_ok else HitlResult.EXPIRED
+                fields.hitl_record = HitlResult.EXPIRED
+            else:
+                fields.hitl_record = HitlResult.APPROVED
     elif context.enforce_hitl:
         # enforce_hitl with no hitl_record at all - fail closed. Omitting the
         # record entirely MUST NOT be weaker than declaring it with no approvals.

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -641,6 +641,50 @@ def test_enforce_hitl_with_valid_approval_passes():
     assert result.result == OverallResult.VALID
 
 
+def test_level_2_rejects_software_key_for_high_risk_approval():
+    approval_time = (NOW - timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
+    m = base_manifest(hitl_record={
+        "required": True,
+        "approvals": [{
+            "approved_at": approval_time,
+            "approved_scope": {
+                "approval_duration_seconds": 7200,
+                "risk_tier": "high",
+            },
+            "approval_method": "software-key",
+        }],
+    })
+    result = verify_manifest(
+        m,
+        base_context(enforce_hitl=True, conformance_level=2),
+        store(),
+    )
+    assert result.fields_verified.hitl_record == HitlResult.APPROVAL_INSUFFICIENT
+    assert result.result == OverallResult.MISMATCH
+
+
+def test_level_2_accepts_hardware_key_for_high_risk_approval():
+    approval_time = (NOW - timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
+    m = base_manifest(hitl_record={
+        "required": True,
+        "approvals": [{
+            "approved_at": approval_time,
+            "approved_scope": {
+                "approval_duration_seconds": 7200,
+                "risk_tier": "high",
+            },
+            "approval_method": "hardware-key",
+        }],
+    })
+    result = verify_manifest(
+        m,
+        base_context(enforce_hitl=True, conformance_level=2),
+        store(),
+    )
+    assert result.fields_verified.hitl_record == HitlResult.APPROVED
+    assert result.result == OverallResult.VALID
+
+
 # ---------------------------------------------------------------------------
 # Fail-closed delegation chain verification (spec 3.4.1 / 5.2)
 # ---------------------------------------------------------------------------

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -992,10 +992,23 @@ For agents operating under EU AI Act Article 14 requirements or any policy that 
 
 `approver_id` MUST be a human-attributable identity. SPIFFE SVIDs MUST NOT be used as `approver_id` values - SPIFFE SVIDs identify machine workloads, not natural persons. The preferred form is an OIDC `sub` claim paired with an `approver_oidc_issuer` URI (e.g., `sub: "1234567890"` + `iss: "https://accounts.google.com"`), an email address as a URI (`mailto:approver@example.com`), or a W3C DID bound to a hardware authenticator. For EU AI Act Art. 14 compliance, the approver identity MUST be traceable to a natural person in the deployer's HR or IAM system.
 
+`risk_tier` is assigned on the reversibility and operational-boundary axis below. It is not an operator's estimate of likelihood or severity and MUST NOT be lowered because an action is routine. The approver MUST assign the highest tier of any action permitted by the approved scope or its bound policy:
+
+| Tier | Falsifiable assignment rule |
+|---|---|
+| `low` | The scope permits no durable external effect. Its effects are confined to the evaluated system and disappear when the operation ends or can be withdrawn completely without a compensating action. |
+| `medium` | The scope permits a durable effect, but the effect remains wholly within the deployer's control and can be withdrawn completely by that deployer. |
+| `high` | The scope permits an effect outside the deployer's control, but a documented external or compensating action can reverse the effect. |
+| `critical` | The scope permits an effect that cannot be fully recalled or reversed after execution, including an external party acting on released information or an irreversible safety, legal, or financial action. |
+
+If the permitted actions span tiers, the highest tier applies. If reversibility or the operational boundary cannot be established from the bound policy, tool catalog, and approval evidence, the approver MUST use `critical`. A verifier proves only that the declared tier and approval method were signed and satisfy the mechanical ordering below; it does not infer that the tier is truthful. A reviewer or deployment policy compares the declaration with the bound capabilities. A `VALID` result therefore MUST NOT be represented as proof that the tier assignment was correct.
+
 `approval_method` trust ordering for regulatory compliance: <!-- CHANGED: SCHEMA F-11 -->
 - `hardware-key` (FIDO2 passkey, HSM, or smartcard): satisfies EU AI Act Art. 14 non-repudiation requirements. REQUIRED for `risk_tier: high` or `critical` at Level 2 conformance.
-- `mfa-backed` (software key protected by MFA): acceptable for medium-risk approvals only.
+- `mfa-backed` (software key protected by MFA): acceptable for `low` or `medium` at Level 2 conformance.
 - `software-key`: acceptable only for Level 0 non-regulated deployments.
+
+At Level 2, a verifier MUST return `APPROVAL_INSUFFICIENT` when any otherwise-current approval uses `software-key`, or when a `high` or `critical` approval uses anything other than `hardware-key`. The overall result MUST be `MISMATCH`. Level 0 records the declared method without making a regulatory-strength claim; Level 1 deployments define their minimum method in relying-party policy.
 
 `hitl_runtime` block declares the runtime human oversight capabilities required by EU AI Act Art. 14(4) operational oversight obligations. The `hitl_record.approvals` structure satisfies Art. 14 pre-deployment documentation obligations (Art. 14(4)(b)-(e)). The `hitl_runtime` block separately addresses the runtime stop/override capability requirement (Art. 14(4)(a)). Both are required for full Art. 14 compliance. See section 9.1 for the regulatory mapping. <!-- CHANGED: REG-001 -->
 


### PR DESCRIPTION
## Summary

- define risk tiers on a falsifiable reversibility and operational-boundary axis
- require the highest applicable tier and fail closed to critical when reversibility cannot be established
- state explicitly that VALID proves the signed declaration and method ordering, not that the tier is truthful
- make Level 2 verification return APPROVAL_INSUFFICIENT for software keys and for non-hardware high/critical approvals

Closes #313.

## Evidence

- focused HITL tests: 7 passed
- full Python suite: 1120 passed, 6 skipped
- regression cases separate the concrete failure (software-key/high) from the valid boundary (hardware-key/high)
- git diff --check: clean

## Environment note

Local mypy reaches the unchanged optional oqs import without a stub; repository CI is the authoritative configured type gate.