### PR TITLE
test(verify): key-to-issuer authorization negative vectors (#325)

### DIFF
--- a/python/tests/vectors/AM-VEC-022.json
+++ b/python/tests/vectors/AM-VEC-022.json
@@ -1,0 +1,80 @@
+{
+  "id": "AM-VEC-022",
+  "description": "A trusted key not authorized for the manifest's issuer is rejected.",
+  "spec_refs": [
+    "5.3"
+  ],
+  "manifest": {
+    "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+    "agent_id": "spiffe://trust.example/agent/kyc/prod",
+    "version": "0.1",
+    "issued_at": "2025-01-01T00:00:00Z",
+    "expires_at": "2099-12-31T23:59:59Z",
+    "issuer": "spiffe://trust.example/signing-authority",
+    "crypto_profile": "standard",
+    "artifacts": {
+      "system_prompt": {
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "policy_bundle": {
+        "hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "model_identity": {
+        "model_hash": null,
+        "version": "claude-3",
+        "deployment_type": "api"
+      }
+    },
+    "delegation_chain": [],
+    "hitl_record": null,
+    "signature": {
+      "algorithm": "Ed25519",
+      "key_id": "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
+      "key_type": "software",
+      "signed_at": "2025-01-01T00:00:00Z",
+      "signature_value": "YUnGWwyv4mUTUrjmXi5FakUaEzPo_JkqEXxT4d6txlN_gFKpXPS2lG52SfuT7trQzwyvc4hwZ28uCg5Ve_0lBg",
+      "signed_fields": [
+        "@context",
+        "@type",
+        "manifest_id",
+        "previous_manifest_id",
+        "agent_id",
+        "agent_instance_id",
+        "version",
+        "min_verifier_version",
+        "issued_at",
+        "expires_at",
+        "issuer",
+        "crypto_profile",
+        "profile",
+        "unbound_artifacts",
+        "source_bundle",
+        "artifacts",
+        "delegation_chain",
+        "hitl_record",
+        "prior_transparency_log_entry",
+        "log_retention",
+        "data_scope",
+        "operational_lifecycle",
+        "intent"
+      ]
+    }
+  },
+  "context": {
+    "system_prompt_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "policy_bundle_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "model_version": "claude-3",
+    "trusted_keys": {
+      "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "trusted_key_issuers": {
+      "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": [
+        "spiffe://trust.example/other-authority"
+      ]
+    }
+  },
+  "expected": {
+    "result": "MISMATCH",
+    "signature_verified": false
+  }
+}

--- a/python/tests/vectors/AM-VEC-023.json
+++ b/python/tests/vectors/AM-VEC-023.json
@@ -1,0 +1,80 @@
+{
+  "id": "AM-VEC-023",
+  "description": "A key authorized for the subject (agent_id) but not the issuer is rejected.",
+  "spec_refs": [
+    "5.3"
+  ],
+  "manifest": {
+    "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+    "agent_id": "spiffe://trust.example/agent/kyc/prod",
+    "version": "0.1",
+    "issued_at": "2025-01-01T00:00:00Z",
+    "expires_at": "2099-12-31T23:59:59Z",
+    "issuer": "spiffe://trust.example/signing-authority",
+    "crypto_profile": "standard",
+    "artifacts": {
+      "system_prompt": {
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "policy_bundle": {
+        "hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "model_identity": {
+        "model_hash": null,
+        "version": "claude-3",
+        "deployment_type": "api"
+      }
+    },
+    "delegation_chain": [],
+    "hitl_record": null,
+    "signature": {
+      "algorithm": "Ed25519",
+      "key_id": "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
+      "key_type": "software",
+      "signed_at": "2025-01-01T00:00:00Z",
+      "signature_value": "YUnGWwyv4mUTUrjmXi5FakUaEzPo_JkqEXxT4d6txlN_gFKpXPS2lG52SfuT7trQzwyvc4hwZ28uCg5Ve_0lBg",
+      "signed_fields": [
+        "@context",
+        "@type",
+        "manifest_id",
+        "previous_manifest_id",
+        "agent_id",
+        "agent_instance_id",
+        "version",
+        "min_verifier_version",
+        "issued_at",
+        "expires_at",
+        "issuer",
+        "crypto_profile",
+        "profile",
+        "unbound_artifacts",
+        "source_bundle",
+        "artifacts",
+        "delegation_chain",
+        "hitl_record",
+        "prior_transparency_log_entry",
+        "log_retention",
+        "data_scope",
+        "operational_lifecycle",
+        "intent"
+      ]
+    }
+  },
+  "context": {
+    "system_prompt_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "policy_bundle_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "model_version": "claude-3",
+    "trusted_keys": {
+      "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "trusted_key_issuers": {
+      "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": [
+        "spiffe://trust.example/agent/kyc/prod"
+      ]
+    }
+  },
+  "expected": {
+    "result": "MISMATCH",
+    "signature_verified": false
+  }
+}

--- a/python/tests/vectors/generate.py
+++ b/python/tests/vectors/generate.py
@@ -884,6 +884,45 @@ def build() -> list[dict[str, Any]]:
         {"result": "MISMATCH", "signature_verified": False},
     ))
 
+    # 022 - a trusted key not authorized for the manifest's issuer (issue #325).
+    # The v0.1 counterpart of AM-VEC-COSE-009: the manifest, signature and
+    # signing key are byte-identical to AM-VEC-001, and only the context differs
+    # by naming a different authority in trusted_key_issuers. A verifier that
+    # stops at "the signature verifies under a trusted key" returns VALID here
+    # and has no key-to-issuer authorization boundary at all.
+    #
+    # signature_verified is false, not true as on AM-VEC-COSE-009: the v0.1
+    # path evaluates the issuer binding before it verifies the detached
+    # signature (spec 5.3), so on a mismatch it never reaches verification and
+    # the flag stays false. The COSE path appraises the envelope signature
+    # first, so its analog records true.
+    vectors.append(_vector(
+        "AM-VEC-022",
+        "A trusted key not authorized for the manifest's issuer is rejected.",
+        ["5.3"], base_manifest(),
+        base_context(
+            trusted_key_issuers={KEY_ID: ["spiffe://trust.example/other-authority"]}
+        ),
+        {"result": "MISMATCH", "signature_verified": False},
+    ))
+
+    # 023 - the subject presented as the authority. trusted_key_issuers names
+    # the manifest's own agent_id ("spiffe://trust.example/agent/kyc/prod")
+    # rather than its issuer, so the key is authorized for the subject it signs
+    # for and not for the issuer that signed. Companion to AM-VEC-022: a
+    # verifier that compared the key's authorization against agent_id instead of
+    # issuer would accept this one, so the two together pin that the binding is
+    # to the issuer specifically.
+    vectors.append(_vector(
+        "AM-VEC-023",
+        "A key authorized for the subject (agent_id) but not the issuer is rejected.",
+        ["5.3"], base_manifest(),
+        base_context(
+            trusted_key_issuers={KEY_ID: ["spiffe://trust.example/agent/kyc/prod"]}
+        ),
+        {"result": "MISMATCH", "signature_verified": False},
+    ))
+
     # --- version 0.2, COSE envelope (ADR-0011, issue #243) -----------------
     vectors.append(cose_encoding_vector())
     vectors.extend(cose_negative_vectors())

--- a/python/tests/vectors/index.json
+++ b/python/tests/vectors/index.json
@@ -114,6 +114,16 @@
       "description": "Post-quantum crypto_profile with an Ed25519 signature is a downgrade."
     },
     {
+      "id": "AM-VEC-022",
+      "file": "AM-VEC-022.json",
+      "description": "A trusted key not authorized for the manifest's issuer is rejected."
+    },
+    {
+      "id": "AM-VEC-023",
+      "file": "AM-VEC-023.json",
+      "description": "A key authorized for the subject (agent_id) but not the issuer is rejected."
+    },
+    {
       "id": "AM-VEC-COSE-001",
       "file": "AM-VEC-COSE-001.json",
       "description": "COSE_Sign1 encoding is pinned byte-for-byte: CBOR tag 18, a four-element array, and a zero-length unprotected header map before any receipt is attached."


### PR DESCRIPTION
Adds AM-VEC-022 and AM-VEC-023, the v0.1 counterparts of AM-VEC-COSE-009.

Both use the same manifest and signature as AM-VEC-001. Only the context differs: `trusted_key_issuers` binds the signing key to an authority other than the manifest's declared issuer.

AM-VEC-022: key authorized for a different authority. A verifier that stops at "the signature verifies under a trusted key" returns VALID and has no issuer authorization boundary.

AM-VEC-023: key authorized for the agent_id (the subject) instead of the issuer. A verifier that checked authorization against agent_id rather than issuer would accept this. The two vectors together pin that the binding is to the issuer specifically.

Both expect MISMATCH with signature_verified: false. The v0.1 path evaluates the issuer binding before verifying the detached signature, so on a mismatch it never reaches verification. This differs from AM-VEC-COSE-009 (true),
where the envelope signature is appraised first.

Generated via generate.py, not by hand. 1162 passed, 6 skipped.

Closes nothing — these are the conformance vectors for the spec change proposed in #325.