### PR TITLE
fix: replace the dead Discord invite in the README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/agent-manifest?label=PyPI)](https://pypi.org/project/agent-manifest/)
 [![Spec](https://img.shields.io/badge/Spec-v0.2_·_197_tests-0ea5e9)](spec/agent-manifest-spec-v0.2.md)
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white&style=flat)](https://discord.gg/9JWNpH7E)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white&style=flat)](https://discord.gg/grgzFEHgkj)
 
 > **Developer Preview.** Launched at Confidential Computing Summit, June 23 2026.
 


### PR DESCRIPTION
`discord.gg/9JWNpH7E` returns `{"message": "Unknown Invite", "code": 10006}`. The working invite across the rest of the estate is `discord.gg/grgzFEHgkj`.

The same dead invite was also in the trace-tests README and site footer, fixed in [trace-tests#71](https://github.com/agentrust-io/trace-tests/pull/71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EQx4N5BzTQbY8kvXUsdkY