### PR TITLE
fix(seo): social cards used the site name, not the page title

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - "overrides/**"
       - "mkdocs.yml"
       - "requirements-docs.txt"
       - "python/src/**"

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -11,7 +11,10 @@
 #}
 {% block extrahead %}
   {{ super() }}
-  {%- set page_title = (config.site_name if (page and page.is_homepage) else (page.title if page else config.site_name)) | default(config.site_name, true) -%}
+  {#- page.title is the nav label; page.meta.title is the front matter, which is
+      the only one of the two that describes the page. -#}
+  {%- set page_name = (page.meta.title if (page and page.meta and page.meta.title) else (page.title if page else None)) -%}
+  {%- set page_title = (page_name ~ " - " ~ config.site_name if page_name and page_name != config.site_name else config.site_name) | default(config.site_name, true) -%}
   {%- set page_desc = (page.meta.description if page and page.meta else config.site_description) | default(config.site_description, true) -%}
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="{{ config.site_name }}">


### PR DESCRIPTION
`og:title` and `twitter:title` on the homepage were hardcoded to fall back to `config.site_name`, so every link preview of [manifest.agentrust-io.com](https://manifest.agentrust-io.com/) said just **"Agent Manifest"** while the `<title>` said "Verifiable identity and permissions for AI agents - Agent Manifest".

Uses `page.meta.title` (the front matter) with a fallback to `page.title` and then the site name, matching the fix applied to trace-spec, cmcp, ca2a and trace-tests.

Also adds `overrides/**` to the docs deploy filter. Without it, a change to this very file merges, goes green, and never deploys. That is how the same fix on three sibling repos ended up merged but not live.

| | Before | After |
|---|---|---|
| homepage | `Agent Manifest` | `Verifiable identity and permissions for AI agents - Agent Manifest` |
| inner page | `Limitations - Agent Manifest` | unchanged |

The homepage `og:title` now matches its `<title>`.

Not touched: the build emits 10 pre-existing `mkdocs_autorefs` warnings from `[SDK]` tags in `CHANGELOG.md`, which autorefs reads as cross-reference targets. CI does not run `--strict` and the text renders correctly, so silencing them would mean escaping 63 lines of shipped release history for no reader-visible gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EQx4N5BzTQbY8kvXUsdkY