### PR TITLE
docs: document project sponsorship roles

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,12 +4,6 @@ Organizations using or evaluating Agent Manifest in production or pilot deployme
 
 To add your organization, open a PR editing this file. Include: organization name, use case (one sentence), and optionally a contact or case study link.
 
-## Founding contributors
-
-| Organization | Use case |
-|---|---|
-| OPAQUE Systems | Founding contributor — developed the initial specification and reference SDK |
-
 ## Community evaluations
 
 _Evaluations announced at Confidential Computing Summit, June 23 2026._
@@ -17,3 +11,5 @@ _Evaluations announced at Confidential Computing Summit, June 23 2026._
 ---
 
 If your organization is using Agent Manifest and would like to be listed, please open a pull request or email the Project Lead.
+
+Project sponsors and their contributions are listed separately in [SPONSORS.md](SPONSORS.md); sponsorship does not imply adoption.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -25,7 +25,7 @@ Out of scope: runtime policy enforcement (see Agent Governance Toolkit), MCP pro
 
 Upon CoSAI WS4 acceptance, governance transitions from the current single-maintainer model to a Technical Steering Committee (TSC), aligned with the OASIS Open Projects governance model.
 
-**Composition**: 3–7 members. No single organization may hold more than 40% of TSC seats. The founding Project Lead (Imran Siddique, OPAQUE Systems) holds one permanent founding seat for the v1.0 ratification cycle, after which all seats are elected.
+**Composition**: 3–7 members. No single organization may hold more than 40% of TSC seats. The founding Project Lead (Imran Siddique) holds one permanent founding seat for the v1.0 ratification cycle, after which all seats are elected.
 
 **Election**: TSC members are elected annually by active contributors (defined as: at least one merged PR or accepted spec change in the preceding 12 months). Each contributor has one vote.
 
@@ -88,3 +88,7 @@ This project is targeting contribution to CoSAI Working Stream 4 (Secure Design 
 Phase 1 is a review pass, not a request to accept. Until WS4 accepts a contribution, this charter describes the intended governance and the GOVERNANCE.md file describes the current operating governance.
 
 The Agent Governance Toolkit is governed separately and its own standards destination is not set by this charter.
+
+## 10. Sponsors
+
+Organizations providing financial, engineering, infrastructure, or other material support are recognized in [SPONSORS.md](SPONSORS.md). Sponsorship is separate from project governance and does not confer specification authority, additional voting rights, preferential conformance treatment, or endorsement of a sponsor's implementation.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,7 +20,7 @@ Full commit and merge rights on designated package areas. PyPI publish rights on
 
 ### Project Lead
 
-Final decision authority on specification changes, standards contribution scope, conformance test disputes, and Maintainer appointments. Currently: Imran Siddique (OPAQUE Systems).
+Final decision authority on specification changes, standards contribution scope, conformance test disputes, and Maintainer appointments. Currently: Imran Siddique.
 
 **Succession**: If the Project Lead is unavailable for 30+ days without notice, the active Maintainers vote to appoint an interim lead. Succession plan will be formalized before v1.0 contribution to CoSAI with a Technical Steering Committee structure.
 
@@ -51,6 +51,10 @@ A normative PR opened without a sponsor is not rejected on that basis. Reviewers
 ## Conflict of interest
 
 Maintainers must disclose any commercial interest in a proposal before participating in its review. Disclosed conflicts do not disqualify a Maintainer from voting but must be on the record.
+
+## Sponsorship
+
+Project sponsors are recognized in [`SPONSORS.md`](https://github.com/agentrust-io/agent-manifest/blob/main/SPONSORS.md). Project sponsorship is distinct from the organizational sponsorship required for a normative proposal above: supporting the project does not automatically sponsor a normative change. Project sponsorship and participant affiliations are informational and do not confer specification authority, additional decision rights, preferential conformance treatment, or endorsement of a sponsor's implementation.
 
 ## Foundation transition
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,9 +2,9 @@
 
 ## Project Lead
 
-| Name | Affiliation | GitHub | Role |
+| Name | Project affiliation | GitHub | Role |
 |------|-------------|--------|------|
-| Imran Siddique | OPAQUE Systems | @agentrust-io | Project Lead, Spec Author |
+| Imran Siddique | AgenTrust-io | @agentrust-io | Project Lead, Spec Author |
 
 The Project Lead has final decision authority on specification changes, standards contribution scope, and maintainer appointments.
 
@@ -14,7 +14,9 @@ The Project Lead has final decision authority on specification changes, standard
 
 **Maintainer**: Active Reviewer for 60+ days, 5+ merged PRs, demonstrated judgment on spec or SDK design questions. Nominated by any Maintainer, approved by Project Lead. Maintainers have PyPI publish rights on the `agent-manifest` package.
 
-We are actively recruiting maintainers from organizations outside OPAQUE Systems. If you are using agent-manifest in a product and want to participate in governance, open an issue tagged `maintainer-interest`.
+We are actively recruiting maintainers across independent organizations. If you are using agent-manifest in a product and want to participate in governance, open an issue tagged `maintainer-interest`.
+
+Affiliations identify a maintainer's project context; they do not give an affiliated organization ownership or additional governance rights. See [GOVERNANCE.md](GOVERNANCE.md) and [SPONSORS.md](SPONSORS.md).
 
 ## Emeritus
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 agent-manifest collects and transmits no personal data.
 
-It runs locally as a Python library and CLI. It processes only the inputs you give it, entirely on your machine, and sends no telemetry, analytics, or usage data to agentrust-io, OPAQUE, or any third party. There is no account, login, or tracking, and no cookies or background network calls.
+It runs locally as a Python library and CLI. It processes only the inputs you give it, entirely on your machine, and sends no telemetry, analytics, or usage data to agentrust-io or any third party. There is no account, login, or tracking, and no cookies or background network calls.
 
 Signing and verification run locally against the keys and files you provide; no outbound calls are made.
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,15 @@
+# Sponsors
+
+The Agent Manifest project recognizes organizations that provide financial, engineering, infrastructure, or other material support.
+
+Sponsorship does not confer specification authority, additional governance or voting rights, preferential conformance treatment, endorsement of a sponsor's implementation, or rights to project names and marks. Project decisions follow [GOVERNANCE.md](GOVERNANCE.md), regardless of sponsorship.
+
+## Current sponsors
+
+| Organization | Support |
+|---|---|
+| OPAQUE Systems | Founding engineering and infrastructure support, including contributions to the initial specification and reference SDK |
+
+## Adding or updating a sponsor
+
+Sponsor recognition must describe the support factually and must not imply certification or endorsement. Open a pull request updating this file with the organization name and a concise description of its support.

--- a/docs/sponsors.md
+++ b/docs/sponsors.md
@@ -1,0 +1,5 @@
+# Sponsors
+
+The canonical sponsor list and sponsorship policy are in [`SPONSORS.md`](https://github.com/agentrust-io/agent-manifest/blob/main/SPONSORS.md).
+
+Sponsors provide financial, engineering, infrastructure, or other material support. Sponsorship is recognized separately from project governance and does not confer specification authority, additional decision rights, preferential conformance treatment, or endorsement of a sponsor's implementation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,6 +221,7 @@ nav:
       - Changelog: changelog.md
       - Contributing: contributing.md
       - Governance: governance.md
+      - Sponsors: sponsors.md
 
 extra_javascript:
   - https://agentrust-io.com/supernav.js

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts 
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "Apache-2.0"}
-authors = [{name = "Imran Siddique", email = "oss@opaque.co"}]
+authors = [{name = "AgenTrust Authors", email = "maintainers@agentrust-io.com"}]
 keywords = [
   "ai-agents", "attestation", "governance", "tee", "confidential-computing",
   "mcp", "agent-manifest", "trust", "hardware-attestation", "pydantic",


### PR DESCRIPTION
## Summary

- add a dedicated sponsor policy and recognition page
- separate sponsor recognition from adoption and project governance
- use project-level maintainer and package metadata
- add sponsor information to the documentation site

## Validation

- `git diff --check`
- `python -m mkdocs build`