### PR TITLE
security: close integrated verification trust gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
   signatures, and approvals replayed from another manifest fail closed. See
   GHSA-ww2p-prj4-c6xf.
 
+- **[SECURITY][SDK]** Bound runtime artifacts now fail closed when their
+  observed hashes are absent. Signature-only appraisal remains available only
+  through an explicit API or CLI opt-out and must not be used as authorization
+  evidence about a deployed agent.
+
+- **[SECURITY][SDK]** Transparency receipts are no longer treated as a warning-
+  only attachment at production conformance levels. Level 1+ (or explicit
+  `require_transparency`) requires an entry ID or receipt digest produced by an
+  independent appraisal against the relying party's trusted transparency-log
+  policy. An attacker-controlled receipt in a COSE unprotected header is
+  `UNVERIFIABLE`, not proof of inclusion.
+
 ### Added
 
 - **[SPEC][SDK]** Added configuration assurance for artifact #1 (spec 3.2.1.1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **[SECURITY][SDK]** The integrated verification path now authenticates every
+  enforced HITL approval against a trusted approver key and binds that approval
+  to the manifest being verified. Missing keys, malformed or invalid approval
+  signatures, and approvals replayed from another manifest fail closed. See
+  GHSA-ww2p-prj4-c6xf.
+
 ### Added
 
 - **[SPEC][SDK]** Added configuration assurance for artifact #1 (spec 3.2.1.1,

--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -120,6 +120,8 @@ Options:
   --enforce-attestation  Fail unless the attestation report matches the manifest hash
   --crl-path TEXT        Path to a FileCRL JSON-Lines file for revocation checks
   --public-key TEXT      Path to a trusted raw Ed25519 public key hex file
+  --signature-only       Authenticate only the manifest signature; explicitly allow
+                         bound runtime artifacts to remain unchecked
   -o, --output TEXT      Write output to file (default: stdout)
   --help                 Show this message and exit.
 ```

--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -116,14 +116,28 @@ Usage: manifest verify [OPTIONS] MANIFEST_FILE
     manifest verify attested.json --crl-path revocations.jsonl
 
 Options:
-  --enforce-hitl         Fail unless a required HITL approval is present and unexpired
-  --enforce-attestation  Fail unless the attestation report matches the manifest hash
-  --crl-path TEXT        Path to a FileCRL JSON-Lines file for revocation checks
-  --public-key TEXT      Path to a trusted raw Ed25519 public key hex file
-  --signature-only       Authenticate only the manifest signature; explicitly allow
-                         bound runtime artifacts to remain unchecked
-  -o, --output TEXT      Write output to file (default: stdout)
-  --help                 Show this message and exit.
+  --enforce-hitl                  Fail unless a required HITL approval is present and
+                                  unexpired
+  --enforce-attestation           Fail unless the attestation report matches the
+                                  manifest hash
+  --crl-path TEXT                 Path to a FileCRL JSON-Lines file for revocation
+                                  checks
+  --public-key TEXT               Path to a trusted raw Ed25519 public key hex file
+  --require-transparency          Fail unless transparency evidence was independently
+                                  verified
+  --verified-transparency-entry-id TEXT
+                                  Legacy entry UUID independently verified for this
+                                  manifest (repeatable)
+  --verified-transparency-receipt-hash TEXT
+                                  SHA-256 hex of a raw COSE receipt independently
+                                  verified for this manifest (repeatable)
+  --transparency-evidence-manifest-id TEXT
+                                  Manifest ID to which the independent transparency
+                                  appraisal was bound
+  --signature-only                Authenticate only the manifest signature; explicitly
+                                  allow bound runtime artifacts to remain unchecked
+  -o, --output TEXT               Write output to file (default: stdout)
+  --help                          Show this message and exit.
 ```
 
 ### manifest revoke

--- a/docs/tutorials/server-side-verification.md
+++ b/docs/tutorials/server-side-verification.md
@@ -186,6 +186,15 @@ if result.result == OverallResult.MISMATCH:
 
 An auditor that intentionally wants to authenticate only the manifest document, without making any claim about the running artifacts, can construct `VerificationContext(strict_artifact_verification=False)`. This is an explicit scope reduction: callers must label the result as signature-only and must not use it as an authorization decision about the deployed agent.
 
+For production/Level 1+ verification, transparency is also fail-closed. First
+appraise the Rekor entry or SCITT receipt against your trusted transparency
+service, then pass the verified legacy `entry_uuid` in
+`verified_transparency_entry_ids` or the SHA-256 hex digest of the raw COSE
+receipt in `verified_transparency_receipt_hashes`, together with the appraised
+manifest ID in `transparency_evidence_manifest_id`. Receipt presence alone never
+sets `transparency_verified`: COSE receipts live in an unprotected header and
+are attacker-malleable until independently verified.
+
 ---
 
 ## FastAPI middleware that gates requests on manifest ID

--- a/docs/tutorials/server-side-verification.md
+++ b/docs/tutorials/server-side-verification.md
@@ -173,7 +173,7 @@ if not result.attestation_verified:
 | `EXPIRED` | `expires_at` is in the past | Block; agent must re-issue the manifest |
 | `MISMATCH` | One or more artifact hashes differ | Block; agent may have drifted or been tampered with |
 | `ATTESTATION_UNAVAILABLE` | `enforce_attestation` set but no attestation present | Block in prod, warn in dev |
-| `INCOMPLETE` | `strict_artifact_verification` set and bound fields lack runtime hashes | Block |
+| `INCOMPLETE` | Bound fields lack runtime hashes; this is the safe default | Block |
 | `INCOMPATIBLE_VERSION` | Manifest spec version not supported | Upgrade the SDK |
 
 Inspect `mismatch_details` to identify which artifacts failed:
@@ -183,6 +183,8 @@ if result.result == OverallResult.MISMATCH:
     for detail in result.mismatch_details:
         print(f"  [{detail.field}] expected={detail.expected_hash} got={detail.actual_hash}")
 ```
+
+An auditor that intentionally wants to authenticate only the manifest document, without making any claim about the running artifacts, can construct `VerificationContext(strict_artifact_verification=False)`. This is an explicit scope reduction: callers must label the result as signature-only and must not use it as an authorization decision about the deployed agent.
 
 ---
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-manifest"
-version = "0.11.0"
+version = "0.11.1"
 description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts defining an AI agent at deployment"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -277,7 +277,10 @@ class VerificationContext(BaseModel):
     # approver_id -> base64url-encoded Ed25519 public key bytes (for HITL)
     approver_public_keys: dict[str, str] = Field(default_factory=dict)
     # When True, bound artifacts without runtime hashes cause INCOMPLETE result
-    strict_artifact_verification: bool = False
+    # Safe by default: an authentic manifest is not proof that the running
+    # artifacts match it. Callers performing an intentional signature-only
+    # appraisal must opt out explicitly.
+    strict_artifact_verification: bool = True
     # When True, manifest must have a delegation chain
     require_delegation: bool = False
     # Conformance level for enforcing spec §3.2.5.1 poisoning_scan rules.

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -147,6 +147,10 @@ class VerificationResult(BaseModel):
     verification_context_hash: Optional[str] = None
     result: OverallResult
     signature_verified: bool = False
+    # True only when a receipt/entry was independently appraised against the
+    # relying party's transparency-service trust policy. Presence alone is not
+    # verification because COSE unprotected headers are attacker-malleable.
+    transparency_verified: bool = False
     attestation_verified: bool = False
     fields_verified: FieldsVerified = Field(default_factory=FieldsVerified)
     # Spec 5.2. NOT_ASSESSED is the default because absence of an assessment is
@@ -208,6 +212,11 @@ class VerifyRequest(BaseModel):
     delegation_public_keys: dict[str, str] = Field(default_factory=dict)
     # approver_id -> base64url-encoded Ed25519 public key bytes (for HITL)
     approver_public_keys: dict[str, str] = Field(default_factory=dict)
+    # Digests/IDs produced by an independently trusted transparency verifier.
+    verified_transparency_entry_ids: set[str] = Field(default_factory=set)
+    verified_transparency_receipt_hashes: set[str] = Field(default_factory=set)
+    transparency_evidence_manifest_id: Optional[str] = None
+    require_transparency: bool = False
     # When True, a manifest without a delegation_chain is a verification failure
     require_delegation: bool = False
 
@@ -276,6 +285,16 @@ class VerificationContext(BaseModel):
     delegation_public_keys: dict[str, str] = Field(default_factory=dict)
     # approver_id -> base64url-encoded Ed25519 public key bytes (for HITL)
     approver_public_keys: dict[str, str] = Field(default_factory=dict)
+    # Legacy Rekor entry UUIDs and sha256 hex digests of raw COSE receipt bytes
+    # that the relying party has independently verified against a trusted log.
+    # These are evidence inputs, not presence assertions made by the envelope.
+    verified_transparency_entry_ids: set[str] = Field(default_factory=set)
+    verified_transparency_receipt_hashes: set[str] = Field(default_factory=set)
+    # The manifest to which the independent appraisal bound those IDs/digests.
+    # This prevents a verified receipt allow-list from becoming replayable.
+    transparency_evidence_manifest_id: Optional[str] = None
+    # Level 1+ implies this requirement even when the flag is false.
+    require_transparency: bool = False
     # When True, bound artifacts without runtime hashes cause INCOMPLETE result
     # Safe by default: an authentic manifest is not proof that the running
     # artifacts match it. Callers performing an intentional signature-only
@@ -516,6 +535,7 @@ _CONTEXT_HASH_FIELDS: tuple[str, ...] = (
     "min_slsa_level",
     "purpose",
     "require_delegation",
+    "require_transparency",
     "strict_artifact_verification",
     "verifier_id",
 )
@@ -619,6 +639,8 @@ def verify_manifest(
     result.challenge_nonce = context.challenge_nonce
     mismatches: list[MismatchDetail] = []
     fields = result.fields_verified
+    transparency_present = False
+    transparency_unverifiable = False
 
     # --- Schema validation (fail-closed). verify_manifest accepts a raw dict,
     # so it must run the manifest through the Pydantic guards before trusting
@@ -1163,6 +1185,43 @@ def verify_manifest(
                     actual_hash=reported_hash,
                 ))
 
+    # --- Transparency receipt. The envelope field/header is untrusted input;
+    # only an entry ID or receipt digest supplied by an independent log
+    # appraisal can make this true. Level 1+ is production conformance and
+    # therefore requires transparency under spec sections 3.6 and 5.3.
+    require_transparency = context.require_transparency or context.conformance_level >= 1
+    transparency_evidence_bound = context.transparency_evidence_manifest_id == manifest_id
+    if _envelope is not None:
+        for receipt in _envelope.receipts:
+            if not isinstance(receipt, bytes):
+                continue
+            transparency_present = True
+            digest = hashlib.sha256(receipt).hexdigest()
+            if (
+                transparency_evidence_bound
+                and digest in context.verified_transparency_receipt_hashes
+            ):
+                result.transparency_verified = True
+    else:
+        entry = manifest.get("transparency_log_entry")
+        if isinstance(entry, dict):
+            entry_id = entry.get("entry_uuid")
+            transparency_present = isinstance(entry_id, str) and bool(entry_id)
+            if (
+                transparency_evidence_bound
+                and entry_id in context.verified_transparency_entry_ids
+            ):
+                result.transparency_verified = True
+
+    if require_transparency and transparency_present and not result.transparency_verified:
+        result.warnings.append(
+            "transparency receipt is present but was not independently verified "
+            "against a trusted transparency-service policy"
+        )
+        transparency_unverifiable = require_transparency
+    elif require_transparency and not transparency_present:
+        result.warnings.append("no transparency receipt was supplied")
+
     # --- Final result (fail-closed: VALID requires a verified signature and
     # a verifiable delegation chain - spec 5.3)
     result.mismatch_details = mismatches
@@ -1174,6 +1233,8 @@ def verify_manifest(
         # Signature present but no trusted keys (or verification never ran) -
         # the manifest cannot be authenticated. Never VALID.
         result.result = OverallResult.UNVERIFIABLE
+    elif transparency_unverifiable and OverallResult.VALID == result.result:
+        result.result = OverallResult.UNVERIFIABLE
     elif fields.delegation_chain == DelegationResult.UNVERIFIABLE:
         result.result = OverallResult.UNVERIFIABLE
     elif fields.hitl_record == HitlResult.UNVERIFIABLE:
@@ -1183,6 +1244,8 @@ def verify_manifest(
         # agent, not a complete agent instance. INCOMPLETE is deliberate: it
         # can be verified and inspected but cannot be mistaken for Level 0.
         if manifest.get("profile") == "composition-only":
+            result.result = OverallResult.INCOMPLETE
+        elif require_transparency and not transparency_present:
             result.result = OverallResult.INCOMPLETE
         # VERIFY-001: bound artifacts with no runtime hashes in strict mode
         elif context.strict_artifact_verification and unverified_bound:
@@ -1296,11 +1359,6 @@ def _verify_cose_envelope(
         payload_manifest, context, revocation_store, _envelope=envelope
     )
 
-    if not envelope.receipts:
-        result.warnings.append(
-            "no transparency receipt in the unprotected header (label 394); "
-            "a production manifest is expected to carry one"
-        )
     return result
 
 
@@ -1470,6 +1528,10 @@ def create_router(
             trusted_key_issuers=request.trusted_key_issuers,
             delegation_public_keys=request.delegation_public_keys,
             approver_public_keys=request.approver_public_keys,
+            verified_transparency_entry_ids=request.verified_transparency_entry_ids,
+            verified_transparency_receipt_hashes=request.verified_transparency_receipt_hashes,
+            transparency_evidence_manifest_id=request.transparency_evidence_manifest_id,
+            require_transparency=request.require_transparency,
             require_delegation=request.require_delegation,
         )
         return verify_manifest(manifest, ctx, revocation_store)

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -88,6 +88,8 @@ class HitlResult(str, Enum):
     NOT_REQUIRED = "NOT_REQUIRED"
     MISSING = "MISSING"
     APPROVAL_INSUFFICIENT = "APPROVAL_INSUFFICIENT"
+    INVALID = "INVALID"
+    UNVERIFIABLE = "UNVERIFIABLE"
 
 
 class MismatchDetail(BaseModel):
@@ -188,6 +190,11 @@ class VerifyRequest(BaseModel):
     ``trusted_key_issuers`` maps each trusted key_id to the issuer SPIFFE URIs
     authorized to sign manifests with that key. When supplied, key-to-issuer
     authorization is fail-closed.
+
+    ``approver_public_keys`` maps the human-attributable ``approver_id`` on a
+    HITL approval to its trusted Ed25519 public key. HITL verification is
+    fail-closed: an approval without a trusted key is ``UNVERIFIABLE`` and an
+    invalid signature is ``INVALID``; neither can produce ``VALID``.
     """
 
     manifest_id: str
@@ -199,6 +206,8 @@ class VerifyRequest(BaseModel):
     trusted_key_issuers: dict[str, list[str]] = Field(default_factory=dict)
     # principal_id -> base64url-encoded public key bytes (for delegation chain)
     delegation_public_keys: dict[str, str] = Field(default_factory=dict)
+    # approver_id -> base64url-encoded Ed25519 public key bytes (for HITL)
+    approver_public_keys: dict[str, str] = Field(default_factory=dict)
     # When True, a manifest without a delegation_chain is a verification failure
     require_delegation: bool = False
 
@@ -265,6 +274,8 @@ class VerificationContext(BaseModel):
     trusted_key_issuers: dict[str, list[str]] = Field(default_factory=dict)
     # principal_id -> base64url-encoded public key bytes (for delegation chain)
     delegation_public_keys: dict[str, str] = Field(default_factory=dict)
+    # approver_id -> base64url-encoded Ed25519 public key bytes (for HITL)
+    approver_public_keys: dict[str, str] = Field(default_factory=dict)
     # When True, bound artifacts without runtime hashes cause INCOMPLETE result
     strict_artifact_verification: bool = False
     # When True, manifest must have a delegation chain
@@ -580,6 +591,8 @@ def verify_manifest(
       result is ``UNVERIFIABLE`` (spec 3.4.1 / 5.2).
     - ``enforce_hitl=True`` with no ``hitl_record`` in the manifest is a
       failure (``HitlResult.MISSING`` and a non-VALID overall result).
+    - An approval is never ``APPROVED`` unless its own signature verifies with
+      a trusted approver key and binds the current manifest ID and scope.
 
     The ``_envelope`` parameter is internal: it carries an already-appraised
     COSE envelope into the shared pipeline and is not part of the public API.
@@ -1014,10 +1027,19 @@ def verify_manifest(
                 ))
             fields.hitl_record = HitlResult.MISSING
         else:
-            # Check if any approval has expired (HITL-001: parse failure must set all_ok=False)
+            # Approval entries attach outside the manifest/COSE signature and
+            # MUST be authenticated independently (spec 3.5, 3.6, and 5.3).
+            # Presence, lifetime, and method checks alone do not prove that a
+            # human approved this manifest: the signature pre-image binds the
+            # manifest ID, approver, timestamp, and exact scope.
+            from ._delegation import verify_hitl_approval
+            from ._signing import _b64url_decode
+
             now = datetime.now(timezone.utc)
             all_ok = True
             approval_insufficient = False
+            approval_invalid = False
+            approval_unverifiable = False
             for approval in approvals:
                 approved_at = approval.get("approved_at", "")
                 duration = approval.get("approved_scope", {}).get("approval_duration_seconds", 0)
@@ -1040,7 +1062,36 @@ def verify_manifest(
                     ):
                         approval_insufficient = True
                         break
-            if approval_insufficient:
+
+                approver_id = approval.get("approver_id")
+                public_key_b64 = context.approver_public_keys.get(approver_id)
+                if public_key_b64 is None:
+                    approval_unverifiable = True
+                    break
+                try:
+                    verify_hitl_approval(
+                        approval,
+                        manifest_id,
+                        _b64url_decode(public_key_b64),
+                    )
+                except (InvalidSignature, KeyError, TypeError, ValueError):
+                    approval_invalid = True
+                    break
+
+            if approval_unverifiable:
+                fields.hitl_record = HitlResult.UNVERIFIABLE
+                result.warnings.append(
+                    "HITL approval could not be authenticated: no trusted "
+                    "approver key is available for its approver_id"
+                )
+            elif approval_invalid:
+                mismatches.append(MismatchDetail(
+                    field="hitl_record.approval_signature",
+                    expected_hash="<valid approval signature bound to this manifest>",
+                    actual_hash="<invalid or malformed approval signature>",
+                ))
+                fields.hitl_record = HitlResult.INVALID
+            elif approval_insufficient:
                 mismatches.append(MismatchDetail(
                     field="hitl_record",
                     expected_hash="<approval method sufficient for declared risk tier>",
@@ -1121,6 +1172,8 @@ def verify_manifest(
         # the manifest cannot be authenticated. Never VALID.
         result.result = OverallResult.UNVERIFIABLE
     elif fields.delegation_chain == DelegationResult.UNVERIFIABLE:
+        result.result = OverallResult.UNVERIFIABLE
+    elif fields.hitl_record == HitlResult.UNVERIFIABLE:
         result.result = OverallResult.UNVERIFIABLE
     elif OverallResult.VALID == result.result:
         # A composition-only document authenticates a contribution to a future
@@ -1400,8 +1453,10 @@ def create_router(
         The request body carries ``trusted_keys`` (key_id -> base64url public
         key) used for manifest signature verification, optionally
         ``trusted_key_issuers`` (key_id -> issuer SPIFFE URIs) for key issuer
-        authorization, and optionally ``delegation_public_keys`` (principal_id
-        -> base64url public key) for delegation chain verification.
+        authorization, optionally ``delegation_public_keys`` (principal_id ->
+        base64url public key) for delegation chain verification, and optionally
+        ``approver_public_keys`` (approver_id -> base64url Ed25519 public key)
+        for HITL approval verification.
         Verification is fail-closed - see :func:`verify_manifest`.
         """
         manifest = _lookup_manifest(request.manifest_id)
@@ -1411,6 +1466,7 @@ def create_router(
             trusted_keys=request.trusted_keys,
             trusted_key_issuers=request.trusted_key_issuers,
             delegation_public_keys=request.delegation_public_keys,
+            approver_public_keys=request.approver_public_keys,
             require_delegation=request.require_delegation,
         )
         return verify_manifest(manifest, ctx, revocation_store)

--- a/python/src/agent_manifest/cli.py
+++ b/python/src/agent_manifest/cli.py
@@ -321,6 +321,14 @@ def attest(manifest_file: str, provider: str, level: int, output: Optional[str])
               help="Fail unless the attestation report matches the manifest hash")
 @click.option("--crl-path", default=None, help="Path to a FileCRL JSON-Lines file for revocation checks")
 @click.option("--public-key", default=None, help="Path to a trusted raw Ed25519 public key hex file")
+@click.option("--require-transparency", is_flag=True, default=False,
+              help="Fail unless transparency evidence was independently verified")
+@click.option("--verified-transparency-entry-id", multiple=True,
+              help="Legacy entry UUID independently verified for this manifest (repeatable)")
+@click.option("--verified-transparency-receipt-hash", multiple=True,
+              help="SHA-256 hex of a raw COSE receipt independently verified for this manifest (repeatable)")
+@click.option("--transparency-evidence-manifest-id",
+              help="Manifest ID to which the independent transparency appraisal was bound")
 @click.option(
     "--signature-only",
     is_flag=True,
@@ -334,6 +342,10 @@ def verify(
     enforce_attestation: bool,
     crl_path: Optional[str],
     public_key: Optional[str],
+    require_transparency: bool,
+    verified_transparency_entry_id: tuple[str, ...],
+    verified_transparency_receipt_hash: tuple[str, ...],
+    transparency_evidence_manifest_id: Optional[str],
     signature_only: bool,
     output: Optional[str],
 ) -> None:
@@ -354,6 +366,10 @@ def verify(
         enforce_hitl=enforce_hitl,
         enforce_attestation=enforce_attestation,
         trusted_keys=trusted_keys,
+        require_transparency=require_transparency,
+        verified_transparency_entry_ids=set(verified_transparency_entry_id),
+        verified_transparency_receipt_hashes=set(verified_transparency_receipt_hash),
+        transparency_evidence_manifest_id=transparency_evidence_manifest_id,
         strict_artifact_verification=not signature_only,
     )
 

--- a/python/src/agent_manifest/cli.py
+++ b/python/src/agent_manifest/cli.py
@@ -321,6 +321,12 @@ def attest(manifest_file: str, provider: str, level: int, output: Optional[str])
               help="Fail unless the attestation report matches the manifest hash")
 @click.option("--crl-path", default=None, help="Path to a FileCRL JSON-Lines file for revocation checks")
 @click.option("--public-key", default=None, help="Path to a trusted raw Ed25519 public key hex file")
+@click.option(
+    "--signature-only",
+    is_flag=True,
+    default=False,
+    help="Authenticate only the manifest signature; explicitly allow bound runtime artifacts to remain unchecked",
+)
 @click.option("--output", "-o", default=None, help="Write output to file (default: stdout)")
 def verify(
     manifest_file: str,
@@ -328,6 +334,7 @@ def verify(
     enforce_attestation: bool,
     crl_path: Optional[str],
     public_key: Optional[str],
+    signature_only: bool,
     output: Optional[str],
 ) -> None:
     """Verify a manifest against the local verification engine.
@@ -347,6 +354,7 @@ def verify(
         enforce_hitl=enforce_hitl,
         enforce_attestation=enforce_attestation,
         trusted_keys=trusted_keys,
+        strict_artifact_verification=not signature_only,
     )
 
     # REVOC-001: load CRL if provided, otherwise use empty in-memory store
@@ -382,7 +390,7 @@ def verify(
                 "  WARNING: this manifest binds artifacts, but no runtime "
                 "hashes were checked. The signature is authentic; the running "
                 "artifacts were NOT compared against the manifest. Provide "
-                "runtime hashes (or use strict verification) to verify bindings.",
+                "runtime hashes to verify bindings.",
                 err=True,
             )
         else:

--- a/python/tests/test_am_compat.py
+++ b/python/tests/test_am_compat.py
@@ -275,6 +275,7 @@ def test_verification_engine_valid_after_sign():
         system_prompt_hash="sha256:" + "a" * 64,
         policy_bundle_hash="sha256:" + "b" * 64,
         trusted_keys={kp.key_id: kp.public_b64url()},
+        strict_artifact_verification=False,
     )
     result = verify_manifest(raw, ctx, RevocationStore())
     assert result.result == OverallResult.VALID

--- a/python/tests/test_am_verify.py
+++ b/python/tests/test_am_verify.py
@@ -394,14 +394,14 @@ def test_http_get_verify_without_keys_is_unverifiable():
 
 
 @require_fastapi
-def test_http_post_verify_with_trusted_keys_is_valid():
+def test_http_post_verify_with_trusted_keys_is_incomplete_without_runtime_evidence():
     client, _ = _client()
     r = client.post("/verify", json={
         "manifest_id": MID,
         "trusted_keys": TRUSTED_KEYS,
     })
     assert r.status_code == 200
-    assert r.json()["result"] == "VALID"
+    assert r.json()["result"] == "INCOMPLETE"
     assert r.json()["signature_verified"] is True
 
 

--- a/python/tests/test_am_verify.py
+++ b/python/tests/test_am_verify.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from agent_manifest._delegation import HitlApprovalSigner
 from agent_manifest._signing import Ed25519Signer, generate_ed25519
 from agent_manifest._verify import (
     DelegationResult,
@@ -33,6 +34,8 @@ MID   = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
 # trusted key in the verification context.
 KP = generate_ed25519()
 TRUSTED_KEYS = {KP.key_id: KP.public_b64url()}
+APPROVER_KP = generate_ed25519()
+APPROVER_ID = "mailto:alice@example.com"
 ISSUER_A = "spiffe://trust.example/issuer/a"
 ISSUER_B = "spiffe://trust.example/issuer/b"
 
@@ -71,6 +74,7 @@ def ctx(**overrides):
         model_version="claude-3",
         audit_chain_root=SHA_C,
         trusted_keys=dict(TRUSTED_KEYS),
+        approver_public_keys={APPROVER_ID: APPROVER_KP.public_b64url()},
     )
     for k, v in overrides.items():
         setattr(c, k, v)
@@ -79,6 +83,20 @@ def ctx(**overrides):
 
 def store():
     return RevocationStore()
+
+
+def hitl_approval(approved_at, approved_scope):
+    return {
+        "approver_id": APPROVER_ID,
+        "approved_at": approved_at,
+        "approved_scope": approved_scope,
+        "approval_signature": HitlApprovalSigner(APPROVER_KP).sign_approval(
+            manifest_id=MID,
+            approved_at=approved_at,
+            approved_scope=approved_scope,
+            approver_id=APPROVER_ID,
+        ),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +319,7 @@ def test_hitl_not_required():
 def test_hitl_approved():
     ago = (NOW - timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
     m = manifest(hitl_record={"required": True, "approvals": [
-        {"approved_at": ago, "approved_scope": {"approval_duration_seconds": 3600}}
+        hitl_approval(ago, {"approval_duration_seconds": 3600})
     ]})
     r = verify_manifest(m, ctx(), store())
     assert r.fields_verified.hitl_record == HitlResult.APPROVED

--- a/python/tests/test_challenge_binding.py
+++ b/python/tests/test_challenge_binding.py
@@ -93,7 +93,7 @@ def test_the_nonce_is_not_an_input_to_the_context_hash():
         ("enforce_hitl", True),
         ("enforce_attestation", True),
         ("min_slsa_level", 3),
-        ("strict_artifact_verification", True),
+        ("strict_artifact_verification", False),
         ("require_delegation", True),
         ("conformance_level", 2),
     ],

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -170,6 +170,60 @@ def test_cli_verify_bound_artifacts_without_runtime_hashes_is_incomplete(tmp_pat
     assert any("artifact bindings NOT verified" in w for w in payload["warnings"])
 
 
+def test_cli_required_transparency_missing_is_incomplete(tmp_path):
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path), "--public-key", str(public_path),
+            "--signature-only", "--require-transparency",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = _json_stdout(result)
+    assert payload["result"] == "INCOMPLETE"
+    assert payload["transparency_verified"] is False
+
+
+def test_cli_verified_legacy_transparency_entry_is_valid(tmp_path):
+    keypair = generate_ed25519()
+    manifest = _signed_manifest(keypair)
+    entry_id = "rekor-cli-entry"
+    manifest["transparency_log_entry"] = {
+        "log_id": "0" * 64,
+        "log_index": 1,
+        "entry_uuid": entry_id,
+        "integrated_time": 1,
+        "inclusion_proof": {
+            "checkpoint": "signed-checkpoint",
+            "hashes": [],
+            "tree_size": 1,
+        },
+    }
+    signed_path = tmp_path / "signed-with-receipt.json"
+    signed_path.write_text(json.dumps(manifest))
+    public_path = _write_public_key(tmp_path, keypair)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path), "--public-key", str(public_path),
+            "--signature-only", "--require-transparency",
+            "--verified-transparency-entry-id", entry_id,
+            "--transparency-evidence-manifest-id", manifest["manifest_id"],
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = _json_stdout(result)
+    assert payload["result"] == "VALID"
+    assert payload["transparency_verified"] is True
+
+
 # ---------------------------------------------------------------------------
 # Command surface: the documented invocation must be the real one
 # ---------------------------------------------------------------------------

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -85,7 +85,10 @@ def test_cli_verify_with_matching_public_key_is_valid(tmp_path):
 
     result = CliRunner().invoke(
         cli,
-        ["verify", str(signed_path), "--public-key", str(public_path)],
+        [
+            "verify", str(signed_path), "--public-key", str(public_path),
+            "--signature-only",
+        ],
     )
 
     payload = _json_stdout(result)
@@ -147,10 +150,10 @@ def test_cli_verify_with_missing_public_key_file_fails_cleanly(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_cli_verify_bound_artifacts_without_runtime_hashes_qualifies_valid(tmp_path):
+def test_cli_verify_bound_artifacts_without_runtime_hashes_is_incomplete(tmp_path):
     # The manifest binds system_prompt and policy_bundle hashes, but the CLI
     # supplies no runtime hashes, so those bindings are never compared. The
-    # output must qualify the VALID status and warn - never a bare "VALID".
+    # safe default must not turn signature validity into artifact validity.
     keypair = generate_ed25519()
     signed_path = _write_signed_manifest(tmp_path, keypair)
     public_path = _write_public_key(tmp_path, keypair)
@@ -160,15 +163,10 @@ def test_cli_verify_bound_artifacts_without_runtime_hashes_qualifies_valid(tmp_p
         ["verify", str(signed_path), "--public-key", str(public_path)],
     )
 
-    # Signature is genuinely valid (exit 0), but the status must be qualified.
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     payload = _json_stdout(result)
-    assert payload["result"] == "VALID"
-    assert "VALID (signature only - artifact bindings NOT verified)" in result.output
-    assert "WARNING" in result.output
-    # The bare "Result: VALID" line must NOT be emitted in this case.
-    assert "Result: VALID\n" not in result.output
-    # And the result payload carries the machine-readable warning too.
+    assert payload["result"] == "INCOMPLETE"
+    assert "Result: INCOMPLETE" in result.output
     assert any("artifact bindings NOT verified" in w for w in payload["warnings"])
 
 
@@ -196,7 +194,10 @@ def test_deprecated_nested_invocation_still_works(tmp_path):
 
     result = CliRunner().invoke(
         cli,
-        ["manifest", "verify", str(signed_path), "--public-key", str(public_path)],
+        [
+            "manifest", "verify", str(signed_path), "--public-key", str(public_path),
+            "--signature-only",
+        ],
     )
 
     assert result.exit_code == 0

--- a/python/tests/test_cli_cose.py
+++ b/python/tests/test_cli_cose.py
@@ -91,7 +91,7 @@ def test_verify_detects_the_envelope_from_the_cbor_tag(workspace):
 
     out = workspace / "result.json"
     result = run(
-        "verify", signed, "--public-key", workspace / "pub.hex", "-o", out
+        "verify", signed, "--public-key", workspace / "pub.hex", "--signature-only", "-o", out
     )
     assert result.exit_code == 0, result.output
     assert json.loads(out.read_text())["result"] == "VALID"

--- a/python/tests/test_cose.py
+++ b/python/tests/test_cose.py
@@ -777,9 +777,48 @@ def test_engine_verifies_a_cose_manifest():
 
 def test_engine_warns_when_no_receipt_is_attached():
     result = verify_manifest(
-        sign_cose_sign1(base_manifest(), KP), base_context(), store()
+        sign_cose_sign1(base_manifest(), KP),
+        base_context(require_transparency=True),
+        store(),
     )
     assert any("transparency receipt" in w for w in result.warnings)
+
+
+def test_required_cose_receipt_missing_is_incomplete():
+    result = verify_manifest(
+        sign_cose_sign1(base_manifest(), KP),
+        base_context(require_transparency=True),
+        store(),
+    )
+    assert result.result == OverallResult.INCOMPLETE
+    assert result.transparency_verified is False
+
+
+def test_attacker_supplied_cose_receipt_is_not_treated_as_verified():
+    envelope = attach_receipt(
+        sign_cose_sign1(base_manifest(), KP), b"attacker-controlled-receipt"
+    )
+    result = verify_manifest(
+        envelope, base_context(require_transparency=True), store()
+    )
+    assert result.result == OverallResult.UNVERIFIABLE
+    assert result.transparency_verified is False
+
+
+def test_independently_verified_cose_receipt_satisfies_requirement():
+    receipt = b"trusted-transparency-service-receipt"
+    envelope = attach_receipt(sign_cose_sign1(base_manifest(), KP), receipt)
+    result = verify_manifest(
+        envelope,
+        base_context(
+            require_transparency=True,
+            verified_transparency_receipt_hashes={hashlib.sha256(receipt).hexdigest()},
+            transparency_evidence_manifest_id=base_manifest()["manifest_id"],
+        ),
+        store(),
+    )
+    assert result.result == OverallResult.VALID
+    assert result.transparency_verified is True
 
 
 def test_engine_reports_unverifiable_without_trusted_keys():

--- a/python/tests/test_cose.py
+++ b/python/tests/test_cose.py
@@ -15,6 +15,8 @@ import cbor2
 import pytest
 from cryptography.exceptions import InvalidSignature
 
+from agent_manifest._delegation import HitlApprovalSigner
+
 from agent_manifest._cose import (
     ALG_ED25519,
     ALG_EDDSA,
@@ -91,6 +93,8 @@ SHA_B = "sha256:" + "b" * 64
 
 KP = generate_ed25519()
 TRUSTED_KEYS = {KP.key_id: KP.public_b64url()}
+APPROVER_KP = generate_ed25519()
+APPROVER_ID = "mailto:alice@example.com"
 
 
 def base_manifest(**overrides):
@@ -121,6 +125,7 @@ def base_context(**overrides):
         policy_bundle_hash=SHA_B,
         model_version="claude-3",
         trusted_keys=dict(TRUSTED_KEYS),
+        approver_public_keys={APPROVER_ID: APPROVER_KP.public_b64url()},
     )
     for k, v in overrides.items():
         setattr(ctx, k, v)
@@ -135,7 +140,7 @@ def approval(**overrides):
     """A schema-valid HITL approval, authenticated by its own signature."""
     a = {
         "approval_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b60",
-        "approver_id": "mailto:alice@example.com",
+        "approver_id": APPROVER_ID,
         "approver_identity_type": "email",
         "approver_role": "ciso",
         "approved_at": NOW.isoformat().replace("+00:00", "Z"),
@@ -144,11 +149,18 @@ def approval(**overrides):
             "risk_tier": "high",
             "approval_duration_seconds": 3600,
         },
-        "approval_signature": "c2ln",
         "approval_method": "hardware-key",
         "evidence_uri": "https://evidence.example/approvals/1",
     }
     a.update(overrides)
+    if "approval_signature" not in overrides:
+        a["approval_signature"] = HitlApprovalSigner(APPROVER_KP).sign_approval(
+            manifest_id=overrides.get("manifest_id", base_manifest()["manifest_id"]),
+            approved_at=a["approved_at"],
+            approved_scope=a["approved_scope"],
+            approver_id=a["approver_id"],
+        )
+    a.pop("manifest_id", None)
     return a
 
 
@@ -850,6 +862,33 @@ def test_engine_evaluates_approvals_from_the_unprotected_header():
     signed = attach_approvals(signed, [approval()])
     result = verify_manifest(signed, base_context(enforce_hitl=True), store())
     assert result.fields_verified.hitl_record == HitlResult.APPROVED
+
+
+def test_engine_rejects_approval_bound_to_another_manifest():
+    manifest = base_manifest(hitl_record={"required": True})
+    other_manifest_id = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b61"
+    signed = attach_approvals(
+        sign_cose_sign1(manifest, KP),
+        [approval(manifest_id=other_manifest_id)],
+    )
+
+    result = verify_manifest(signed, base_context(enforce_hitl=True), store())
+
+    assert result.fields_verified.hitl_record == HitlResult.INVALID
+    assert result.result == OverallResult.MISMATCH
+
+
+def test_engine_rejects_dummy_approval_signature():
+    manifest = base_manifest(hitl_record={"required": True})
+    signed = attach_approvals(
+        sign_cose_sign1(manifest, KP),
+        [approval(approval_signature="c2ln")],
+    )
+
+    result = verify_manifest(signed, base_context(enforce_hitl=True), store())
+
+    assert result.fields_verified.hitl_record == HitlResult.INVALID
+    assert result.result == OverallResult.MISMATCH
 
 
 def test_signed_hitl_requirement_cannot_be_satisfied_by_editing_the_header():

--- a/python/tests/test_poisoning_scan.py
+++ b/python/tests/test_poisoning_scan.py
@@ -22,6 +22,7 @@ FUTURE = (NOW + timedelta(days=90)).isoformat().replace("+00:00", "Z")
 SHA_A = "sha256:" + "a" * 64
 SHA_B = "sha256:" + "b" * 64
 MID = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+TRANSPARENCY_ENTRY_ID = "rekor-poisoning-suite-entry"
 
 KP = generate_ed25519()
 TRUSTED_KEYS = {KP.key_id: KP.public_b64url()}
@@ -29,6 +30,21 @@ TRUSTED_KEYS = {KP.key_id: KP.public_b64url()}
 
 def sign(m):
     m["signature"] = Ed25519Signer(KP).sign(m)
+    return m
+
+
+def attach_transparency_entry(m):
+    m["transparency_log_entry"] = {
+        "log_id": "0" * 64,
+        "log_index": 1,
+        "entry_uuid": TRANSPARENCY_ENTRY_ID,
+        "integrated_time": int(NOW.timestamp()),
+        "inclusion_proof": {
+            "checkpoint": "signed-checkpoint",
+            "hashes": [],
+            "tree_size": 1,
+        },
+    }
     return m
 
 
@@ -52,7 +68,7 @@ def base_manifest(poisoning_result: str):
         "delegation_chain": [],
         "hitl_record": None,
     }
-    return sign(m)
+    return attach_transparency_entry(sign(m))
 
 
 def base_context(conformance_level: int = 0):
@@ -63,6 +79,8 @@ def base_context(conformance_level: int = 0):
         rag_corpus_merkle_root=SHA_A,
         trusted_keys=dict(TRUSTED_KEYS),
         conformance_level=conformance_level,
+        verified_transparency_entry_ids={TRANSPARENCY_ENTRY_ID},
+        transparency_evidence_manifest_id=MID,
     )
 
 
@@ -159,12 +177,15 @@ def test_no_rag_corpus_no_warnings():
         "hitl_record": None,
     }
     sign(m)
+    attach_transparency_entry(m)
     ctx = VerificationContext(
         system_prompt_hash=SHA_A,
         policy_bundle_hash=SHA_B,
         model_version="claude-3",
         trusted_keys=dict(TRUSTED_KEYS),
         conformance_level=1,
+        verified_transparency_entry_ids={TRANSPARENCY_ENTRY_ID},
+        transparency_evidence_manifest_id=MID,
     )
     result = verify_manifest(m, ctx, store())
     assert result.result == OverallResult.VALID

--- a/python/tests/test_public_api.py
+++ b/python/tests/test_public_api.py
@@ -85,8 +85,8 @@ def test_public_verify_roundtrip_valid_then_mismatch():
 def test_partial_context_leaves_unprovided_fields_not_bound():
     # A verifier only checks what it can observe at runtime. With a partial
     # context (system prompt provided, policy bundle omitted), the unprovided
-    # field is reported NOT_BOUND rather than a mismatch, and the overall result
-    # stays VALID.
+    # field is reported NOT_BOUND rather than a mismatch, and the safe default
+    # makes the overall result INCOMPLETE.
     keypair = agent_manifest.generate_ed25519()
     manifest, sha_a, _sha_b = _signed_manifest(keypair)
     trusted = {keypair.key_id: keypair.public_b64url()}
@@ -98,5 +98,5 @@ def test_partial_context_leaves_unprovided_fields_not_bound():
     result = agent_manifest.verify_manifest(
         manifest, partial, agent_manifest.RevocationStore()
     )
-    assert result.result == agent_manifest.OverallResult.VALID
+    assert result.result == agent_manifest.OverallResult.INCOMPLETE
     assert result.fields_verified.policy_bundle == agent_manifest.FieldResult.NOT_BOUND

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from agent_manifest import _signing
+from agent_manifest._delegation import HitlApprovalSigner
 from agent_manifest._signing import Ed25519Signer, _b64url_encode, generate_ed25519
 from agent_manifest._verify import (
     DelegationResult,
@@ -26,6 +27,8 @@ SHA = "sha256:" + "a" * 64
 # require a signed manifest and the matching trusted key in the context.
 KP = generate_ed25519()
 TRUSTED_KEYS = {KP.key_id: KP.public_b64url()}
+APPROVER_KP = generate_ed25519()
+APPROVER_ID = "mailto:alice@example.com"
 ISSUER_A = "spiffe://trust.example/issuer/a"
 ISSUER_B = "spiffe://trust.example/issuer/b"
 
@@ -67,6 +70,7 @@ def base_context(**overrides):
         policy_bundle_hash="sha256:" + "b" * 64,
         model_version="claude-3",
         trusted_keys=dict(TRUSTED_KEYS),
+        approver_public_keys={APPROVER_ID: APPROVER_KP.public_b64url()},
     )
     for k, v in overrides.items():
         setattr(ctx, k, v)
@@ -75,6 +79,22 @@ def base_context(**overrides):
 
 def store():
     return RevocationStore()
+
+
+def hitl_approval(approved_at, approved_scope, **overrides):
+    approval = {
+        "approver_id": APPROVER_ID,
+        "approved_at": approved_at,
+        "approved_scope": approved_scope,
+    }
+    approval.update(overrides)
+    approval["approval_signature"] = HitlApprovalSigner(APPROVER_KP).sign_approval(
+        manifest_id=base_manifest()["manifest_id"],
+        approved_at=approval["approved_at"],
+        approved_scope=approval["approved_scope"],
+        approver_id=approval["approver_id"],
+    )
+    return approval
 
 
 # ---------------------------------------------------------------------------
@@ -213,10 +233,9 @@ def test_hitl_approved():
     approval_time = (NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
     m = base_manifest(hitl_record={
         "required": True,
-        "approvals": [{
-            "approved_at": approval_time,
-            "approved_scope": {"approval_duration_seconds": 7200},
-        }],
+        "approvals": [hitl_approval(
+            approval_time, {"approval_duration_seconds": 7200}
+        )],
     })
     result = verify_manifest(m, base_context(), store())
     assert result.fields_verified.hitl_record == HitlResult.APPROVED
@@ -631,10 +650,9 @@ def test_enforce_hitl_with_valid_approval_passes():
     approval_time = (NOW - timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
     m = base_manifest(hitl_record={
         "required": True,
-        "approvals": [{
-            "approved_at": approval_time,
-            "approved_scope": {"approval_duration_seconds": 7200},
-        }],
+        "approvals": [hitl_approval(
+            approval_time, {"approval_duration_seconds": 7200}
+        )],
     })
     result = verify_manifest(m, base_context(enforce_hitl=True), store())
     assert result.fields_verified.hitl_record == HitlResult.APPROVED
@@ -667,14 +685,13 @@ def test_level_2_accepts_hardware_key_for_high_risk_approval():
     approval_time = (NOW - timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
     m = base_manifest(hitl_record={
         "required": True,
-        "approvals": [{
-            "approved_at": approval_time,
-            "approved_scope": {
+        "approvals": [hitl_approval(
+            approval_time, {
                 "approval_duration_seconds": 7200,
                 "risk_tier": "high",
             },
-            "approval_method": "hardware-key",
-        }],
+            approval_method="hardware-key",
+        )],
     })
     result = verify_manifest(
         m,

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -22,6 +22,7 @@ NOW = datetime.now(timezone.utc)
 FUTURE = (NOW + timedelta(days=90)).isoformat().replace("+00:00", "Z")
 PAST = (NOW - timedelta(days=1)).isoformat().replace("+00:00", "Z")
 SHA = "sha256:" + "a" * 64
+TRANSPARENCY_ENTRY_ID = "rekor-entry-123"
 
 # Module-level signing key - the verifier is fail-closed, so VALID results
 # require a signed manifest and the matching trusted key in the context.
@@ -81,6 +82,22 @@ def store():
     return RevocationStore()
 
 
+def attach_transparency_entry(manifest):
+    """Attach a structurally valid post-signing Rekor entry."""
+    manifest["transparency_log_entry"] = {
+        "log_id": "0" * 64,
+        "log_index": 1,
+        "entry_uuid": TRANSPARENCY_ENTRY_ID,
+        "integrated_time": int(NOW.timestamp()),
+        "inclusion_proof": {
+            "checkpoint": "signed-checkpoint",
+            "hashes": [],
+            "tree_size": 1,
+        },
+    }
+    return manifest
+
+
 def hitl_approval(approved_at, approved_scope, **overrides):
     approval = {
         "approver_id": APPROVER_ID,
@@ -108,6 +125,52 @@ def test_valid_all_match():
     assert result.fields_verified.system_prompt == FieldResult.MATCH
     assert result.fields_verified.policy_bundle == FieldResult.MATCH
     assert result.mismatch_details == []
+
+
+def test_required_transparency_missing_is_incomplete():
+    result = verify_manifest(
+        base_manifest(), base_context(require_transparency=True), store()
+    )
+    assert result.result == OverallResult.INCOMPLETE
+    assert result.transparency_verified is False
+
+
+def test_present_but_untrusted_transparency_entry_is_unverifiable():
+    result = verify_manifest(
+        attach_transparency_entry(base_manifest()),
+        base_context(require_transparency=True),
+        store(),
+    )
+    assert result.result == OverallResult.UNVERIFIABLE
+    assert result.transparency_verified is False
+
+
+def test_independently_verified_transparency_entry_satisfies_requirement():
+    result = verify_manifest(
+        attach_transparency_entry(base_manifest()),
+        base_context(
+            require_transparency=True,
+            verified_transparency_entry_ids={TRANSPARENCY_ENTRY_ID},
+            transparency_evidence_manifest_id=base_manifest()["manifest_id"],
+        ),
+        store(),
+    )
+    assert result.result == OverallResult.VALID
+    assert result.transparency_verified is True
+
+
+def test_verified_transparency_entry_cannot_be_replayed_to_another_manifest():
+    result = verify_manifest(
+        attach_transparency_entry(base_manifest()),
+        base_context(
+            require_transparency=True,
+            verified_transparency_entry_ids={TRANSPARENCY_ENTRY_ID},
+            transparency_evidence_manifest_id="018f4a3b-2c1d-7e5f-a8b9-ffffffffffff",
+        ),
+        store(),
+    )
+    assert result.result == OverallResult.UNVERIFIABLE
+    assert result.transparency_verified is False
 
 
 @pytest.mark.parametrize(
@@ -693,9 +756,15 @@ def test_level_2_accepts_hardware_key_for_high_risk_approval():
             approval_method="hardware-key",
         )],
     })
+    attach_transparency_entry(m)
     result = verify_manifest(
         m,
-        base_context(enforce_hitl=True, conformance_level=2),
+        base_context(
+            enforce_hitl=True,
+            conformance_level=2,
+            verified_transparency_entry_ids={TRANSPARENCY_ENTRY_ID},
+            transparency_evidence_manifest_id=m["manifest_id"],
+        ),
         store(),
     )
     assert result.fields_verified.hitl_record == HitlResult.APPROVED

--- a/python/tests/vectors/AM-VEC-009.json
+++ b/python/tests/vectors/AM-VEC-009.json
@@ -31,10 +31,12 @@
       "required": true,
       "approvals": [
         {
+          "approver_id": "mailto:alice@example.com",
           "approved_at": "2025-01-01T00:00:00Z",
           "approved_scope": {
             "approval_duration_seconds": 3153600000
-          }
+          },
+          "approval_signature": "BBIMVEKTd1e6wXdxc_kc_WLuUg_fw47ONXEXTdGoVobzz8x8u9I2HGaQBNFinhGuBWdGURfngJ_UaMhYybp-Dg"
         }
       ]
     },
@@ -78,7 +80,10 @@
     "trusted_keys": {
       "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
     },
-    "enforce_hitl": true
+    "enforce_hitl": true,
+    "approver_public_keys": {
+      "mailto:alice@example.com": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    }
   },
   "expected": {
     "result": "VALID",

--- a/python/tests/vectors/generate.py
+++ b/python/tests/vectors/generate.py
@@ -52,7 +52,7 @@ from agent_manifest._cose import (
     payload_hash,
     sign_cose_sign1,
 )
-from agent_manifest._delegation import DelegationHopSigner
+from agent_manifest._delegation import DelegationHopSigner, HitlApprovalSigner
 from agent_manifest._signing import (
     Ed25519Signer,
     ed25519_from_private_bytes,
@@ -76,6 +76,7 @@ assert (KP.key_id, KP.public_b64url()) == (KEY_ID, PUBLIC_KEY_B64URL), (
     "fixed signing key drifted from the published public key/key_id constants"
 )
 TRUSTED_KEYS = {KEY_ID: PUBLIC_KEY_B64URL}
+APPROVER_ID = "mailto:alice@example.com"
 
 # Stable absolute timestamps (never "now").
 ISSUED_AT = "2025-01-01T00:00:00Z"
@@ -698,13 +699,23 @@ def build() -> list[dict[str, Any]]:
     m = base_manifest(hitl_record={
         "required": True,
         "approvals": [{
+            "approver_id": APPROVER_ID,
             "approved_at": ISSUED_AT,
             "approved_scope": {"approval_duration_seconds": CENTURY_SECONDS},
+            "approval_signature": HitlApprovalSigner(KP).sign_approval(
+                manifest_id=MANIFEST_ID,
+                approved_at=ISSUED_AT,
+                approved_scope={"approval_duration_seconds": CENTURY_SECONDS},
+                approver_id=APPROVER_ID,
+            ),
         }],
     })
     vectors.append(_vector(
         "AM-VEC-009", "Required HITL with an unexpired approval passes under enforce_hitl.",
-        ["3.2.10", "5.3"], m, base_context(enforce_hitl=True),
+        ["3.2.10", "5.3"], m, base_context(
+            enforce_hitl=True,
+            approver_public_keys={APPROVER_ID: PUBLIC_KEY_B64URL},
+        ),
         {"result": "VALID", "fields_verified": {"hitl_record": "APPROVED"}},
     ))
 

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -1296,6 +1296,7 @@ Content-Type: application/json
     "verifier_id": "<SPIFFE URI of verifying party>  -- OPTIONAL",
     "required_fields": ["system_prompt", "policy_bundle", "tool_manifest"],
     "enforce_hitl": "<boolean>  -- OPTIONAL, default false",
+    "approver_public_keys": "<object mapping approver_id to trusted base64url Ed25519 public key>  -- REQUIRED when a HITL approval is evaluated",
     "enforce_attestation": "<boolean>  -- OPTIONAL, default false",
     "min_slsa_level": "1 | 2 | 3 | 4  -- OPTIONAL"
   }
@@ -1356,7 +1357,7 @@ A service that receives no `challenge_nonce` returns a result without one, and a
     "decision_trace": "MATCH | EXTENDED | MISMATCH | NOT_BOUND  -- REQUIRED",
     "supply_chain": "MATCH | MISMATCH | NOT_BOUND  -- REQUIRED",
     "delegation_chain": "VALID | INVALID | NOT_PRESENT | UNVERIFIABLE  -- REQUIRED",
-    "hitl_record": "APPROVED | EXPIRED | NOT_REQUIRED | MISSING | APPROVAL_INSUFFICIENT  -- REQUIRED"
+    "hitl_record": "APPROVED | EXPIRED | NOT_REQUIRED | MISSING | APPROVAL_INSUFFICIENT | INVALID | UNVERIFIABLE  -- REQUIRED"
   },
   "configuration_assurance": "PASSED | FLAGGED | NOT_ASSESSED  -- REQUIRED",
   "mismatch_details": [
@@ -1391,6 +1392,8 @@ A service that receives no `challenge_nonce` returns a result without one, and a
 `configuration_assurance` reports the state of `system_prompt.assurance_test` (section 3.2.1.1): `PASSED` when an assessment ran and found no violation, `FLAGGED` when one ran and did, and `NOT_ASSESSED` when the block is absent or carries `not-assessed`. `FLAGGED` MUST cause the overall result to be `MISMATCH`. `NOT_ASSESSED` does not affect the overall result in v0.2 and is reported so that a relying party can tell an assessed configuration from an unassessed one rather than inferring a pass from silence.
 
 `hitl_record` returns `APPROVAL_INSUFFICIENT` when an approval exists but does not meet the `approval_method` requirement for the declared `risk_tier` (e.g., `software-key` approval on a `high` risk tier operation at Level 2).
+
+`hitl_record` returns `INVALID` when an approval's own signature is malformed or does not verify over the current `manifest_id`, `approver_id`, `approved_at`, and exact `approved_scope`. It returns `UNVERIFIABLE` when the verifier has no trusted public key for the approval's `approver_id`. Neither state permits an overall `VALID` result. A manifest or COSE signature does not authenticate approval entries, which attach after issuance and MUST be verified independently.
 
 `challenge_nonce` and `verification_context_hash` bind a result to the request that produced it; see section 5.1.2 for how a relying party checks them and why a `verified_at` timestamp is not a substitute.
 

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -1425,6 +1425,7 @@ Access control for confidential payloads: Tool call payload fields in TRACE enve
 A `VALID` result means all of the following are true:
 
 - The manifest signature is valid under RFC 8785 canonicalization and the manifest is present in the transparency log. Before checking the issuer signature, the verifier MUST apply the `hitl_record.approvals` normalization rule from section 3.6 (replace `hitl_record.approvals` with `[]` in the signing pre-image); approvals are verified separately against their own `approval_signature`s
+- Receipt presence alone MUST NOT satisfy the transparency-log condition. A verifier MUST authenticate the receipt or inclusion evidence against its configured Transparency Service trust policy. In particular, a receipt carried in a COSE unprotected header is untrusted input until that independent appraisal succeeds.
 - The TEE attestation report confirms the manifest hash is bound to the hardware measurement
 - All fields specified in `required_fields` match their running artifacts. For `decision_trace`, `EXTENDED` satisfies this condition and `MISMATCH` does not; see Section 3.2.7.1
 - The manifest has not expired


### PR DESCRIPTION
Fixes the published GHSA-ww2p-prj4-c6xf and prepares agent-manifest 0.11.1.\n\nSecurity changes:\n- authenticate enforced HITL approvals and bind them to the current manifest\n- fail closed when bound runtime artifacts were not observed\n- require independently appraised, manifest-bound transparency evidence at Level 1+\n- reject forged or cross-manifest-replayed transparency receipts\n\nEvidence on the rebased candidate:\n- 1209 passed, 6 skipped\n- wheel and sdist built successfully\n- twine check passed\n- git diff --check passed