### PR TITLE
fix(cli): add --approver-key so HITL verification can succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   signatures, and approvals replayed from another manifest fail closed. See
   GHSA-ww2p-prj4-c6xf.
 
+- **[SECURITY][CLI]** `manifest verify` gained `--approver-key
+  APPROVER_ID=PATH` (repeatable) to supply trusted HITL approver keys. Without
+  it the CLI had no input that could populate `approver_public_keys`, so every
+  approval resolved to `UNVERIFIABLE` and `--enforce-hitl` could not succeed.
+  A failing result now names the missing option.
+
 - **[SECURITY][SDK]** Bound runtime artifacts now fail closed when their
   observed hashes are absent. Signature-only appraisal remains available only
   through an explicit API or CLI opt-out and must not be used as authorization

--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -112,8 +112,14 @@ Usage: manifest verify [OPTIONS] MANIFEST_FILE
 
   Use --crl-path to load a revocation list and check for revoked manifests.
 
+  HITL approvals attach outside the manifest signature, so supply the
+  approver keys you trust with --approver-key. Without them an approval is
+  UNVERIFIABLE and the manifest can never verify.
+
   Example:
     manifest verify attested.json --crl-path revocations.jsonl
+    manifest verify signed.json --public-key pub.hex --enforce-hitl
+      --approver-key mailto:alice@example.com=alice.hex
 
 Options:
   --enforce-hitl                  Fail unless a required HITL approval is present and
@@ -123,6 +129,9 @@ Options:
   --crl-path TEXT                 Path to a FileCRL JSON-Lines file for revocation
                                   checks
   --public-key TEXT               Path to a trusted raw Ed25519 public key hex file
+  --approver-key APPROVER_ID=PATH
+                                  Trusted HITL approver key as approver_id=path to a raw
+                                  Ed25519 public key hex file (repeatable)
   --require-transparency          Fail unless transparency evidence was independently
                                   verified
   --verified-transparency-entry-id TEXT

--- a/python/src/agent_manifest/cli.py
+++ b/python/src/agent_manifest/cli.py
@@ -34,6 +34,7 @@ from ._revocation import FileCRL
 from ._signing import Ed25519Signer, ed25519_from_private_bytes, generate_ed25519
 from ._types import ManifestId
 from ._verify import (
+    HitlResult,
     OverallResult,
     RevocationRecord,
     RevocationStore,
@@ -81,28 +82,59 @@ def _write(data: dict[str, Any], output: Optional[str]) -> None:
         click.echo(text)
 
 
-def _trusted_key_from_public_hex(path: str) -> dict[str, str]:
-    """Load a raw Ed25519 public key hex file as verifier trusted_keys."""
+def _public_bytes_from_hex_file(path: str, label: str = "Public key") -> bytes:
+    """Load and validate a raw Ed25519 public key from a hex file."""
     key_path = Path(path).resolve()
     if not key_path.is_file():
         raise click.ClickException(
-            f"Public key file not found or is not a regular file: {path}"
+            f"{label} file not found or is not a regular file: {path}"
         )
 
     key_hex = key_path.read_text().strip()
     try:
         public_bytes = bytes.fromhex(key_hex)
     except ValueError:
-        raise click.ClickException("Public key file does not contain valid hex data.")
+        raise click.ClickException(f"{label} file does not contain valid hex data.")
 
     if len(public_bytes) != 32:
         raise click.ClickException(
             f"Ed25519 public key must be 32 bytes, got {len(public_bytes)} bytes."
         )
 
+    return public_bytes
+
+
+def _trusted_key_from_public_hex(path: str) -> dict[str, str]:
+    """Load a raw Ed25519 public key hex file as verifier trusted_keys."""
+    public_bytes = _public_bytes_from_hex_file(path)
     key_id = hashlib.sha256(public_bytes).hexdigest()
     public_b64 = base64.urlsafe_b64encode(public_bytes).rstrip(b"=").decode()
     return {key_id: public_b64}
+
+
+def _approver_public_keys(specs: tuple[str, ...]) -> dict[str, str]:
+    """Parse ``APPROVER_ID=PATH`` pairs into verifier approver_public_keys.
+
+    HITL approvals attach outside the manifest signature, so the relying party
+    supplies the approver keys it trusts. Without them an approval is
+    UNVERIFIABLE and can never reach VALID.
+    """
+    keys: dict[str, str] = {}
+    for spec in specs:
+        approver_id, separator, path = spec.partition("=")
+        if not separator or not approver_id or not path:
+            raise click.ClickException(
+                "--approver-key expects APPROVER_ID=PATH, got: " + spec
+            )
+        if approver_id in keys:
+            raise click.ClickException(
+                f"--approver-key given more than once for approver_id {approver_id}"
+            )
+        public_bytes = _public_bytes_from_hex_file(path, "Approver key")
+        keys[approver_id] = (
+            base64.urlsafe_b64encode(public_bytes).rstrip(b"=").decode()
+        )
+    return keys
 
 
 @click.group()
@@ -321,6 +353,9 @@ def attest(manifest_file: str, provider: str, level: int, output: Optional[str])
               help="Fail unless the attestation report matches the manifest hash")
 @click.option("--crl-path", default=None, help="Path to a FileCRL JSON-Lines file for revocation checks")
 @click.option("--public-key", default=None, help="Path to a trusted raw Ed25519 public key hex file")
+@click.option("--approver-key", multiple=True, metavar="APPROVER_ID=PATH",
+              help="Trusted HITL approver key as approver_id=path to a raw Ed25519 "
+                   "public key hex file (repeatable)")
 @click.option("--require-transparency", is_flag=True, default=False,
               help="Fail unless transparency evidence was independently verified")
 @click.option("--verified-transparency-entry-id", multiple=True,
@@ -342,6 +377,7 @@ def verify(
     enforce_attestation: bool,
     crl_path: Optional[str],
     public_key: Optional[str],
+    approver_key: tuple[str, ...],
     require_transparency: bool,
     verified_transparency_entry_id: tuple[str, ...],
     verified_transparency_receipt_hash: tuple[str, ...],
@@ -357,8 +393,15 @@ def verify(
     Use --crl-path to load a revocation list and check for revoked manifests.
 
     
+    HITL approvals attach outside the manifest signature, so supply the
+    approver keys you trust with --approver-key. Without them an approval is
+    UNVERIFIABLE and the manifest can never verify.
+
+    
     Example:
       manifest verify attested.json --crl-path revocations.jsonl
+      manifest verify signed.json --public-key pub.hex --enforce-hitl
+        --approver-key mailto:alice@example.com=alice.hex
     """
     subject = _load_manifest_or_envelope(manifest_file)
     trusted_keys = _trusted_key_from_public_hex(public_key) if public_key else {}
@@ -366,6 +409,7 @@ def verify(
         enforce_hitl=enforce_hitl,
         enforce_attestation=enforce_attestation,
         trusted_keys=trusted_keys,
+        approver_public_keys=_approver_public_keys(approver_key),
         require_transparency=require_transparency,
         verified_transparency_entry_ids=set(verified_transparency_entry_id),
         verified_transparency_receipt_hashes=set(verified_transparency_receipt_hash),
@@ -385,6 +429,13 @@ def verify(
 
     if result.result != OverallResult.VALID:
         click.echo(f"Result: {result.result.value}", err=True)
+        if result.fields_verified.hitl_record == HitlResult.UNVERIFIABLE:
+            click.echo(
+                "  HINT: this manifest carries a HITL approval and no trusted "
+                "approver key was supplied. Pass --approver-key "
+                "APPROVER_ID=PATH for each approver you trust.",
+                err=True,
+            )
         for d in result.mismatch_details:
             click.echo(f"  MISMATCH {d.field}: expected {d.expected_hash[:20]}...", err=True)
         sys.exit(1)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from agent_manifest.cli import cli
+from agent_manifest._delegation import HitlApprovalSigner
 from agent_manifest._signing import Ed25519Signer, generate_ed25519
+
+APPROVER_ID = "mailto:alice@example.com"
 
 
 def _signed_manifest(keypair):
@@ -266,3 +269,196 @@ def test_deprecated_group_is_hidden_from_help():
     assert "verify" in result.output
     # The alias exists for old scripts but must not be advertised.
     assert "\n  manifest " not in result.output
+
+
+# ---------------------------------------------------------------------------
+# HITL approver keys
+#
+# Approvals attach outside the manifest signature, so the relying party has to
+# supply the approver keys it trusts. Without --approver-key there is no CLI
+# input that can populate approver_public_keys, and every approval is
+# UNVERIFIABLE regardless of whether it is genuine.
+# ---------------------------------------------------------------------------
+
+
+def _hitl_approval(approver_keypair, *, manifest_id, signature=None):
+    approved_at = (
+        datetime.now(timezone.utc) - timedelta(minutes=30)
+    ).isoformat().replace("+00:00", "Z")
+    scope = {"approval_duration_seconds": 7200}
+    approval = {
+        "approver_id": APPROVER_ID,
+        "approved_at": approved_at,
+        "approved_scope": scope,
+        "approval_method": "hardware-key",
+    }
+    approval["approval_signature"] = signature or HitlApprovalSigner(
+        approver_keypair
+    ).sign_approval(
+        manifest_id=manifest_id,
+        approved_at=approved_at,
+        approved_scope=scope,
+        approver_id=APPROVER_ID,
+    )
+    return approval
+
+
+def _write_hitl_manifest(tmp_path: Path, keypair, approval) -> Path:
+    """Sign a manifest whose hitl_record already carries *approval*.
+
+    Approvals are normalized out of the signing pre-image (spec 3.6), so the
+    manifest signature stays valid with the approval attached.
+    """
+    manifest = _signed_manifest(keypair)
+    manifest["hitl_record"] = {"required": True, "approvals": [approval]}
+    manifest["signature"] = Ed25519Signer(keypair).sign(manifest)
+    signed_path = tmp_path / "hitl.json"
+    signed_path.write_text(json.dumps(manifest))
+    return signed_path
+
+
+def _write_approver_key(tmp_path: Path, keypair) -> Path:
+    approver_path = tmp_path / "approver.hex"
+    approver_path.write_text(keypair.public_bytes.hex())
+    return approver_path
+
+
+def test_cli_verify_hitl_with_trusted_approver_key_is_valid(tmp_path):
+    keypair = generate_ed25519()
+    approver = generate_ed25519()
+    manifest_path = _write_hitl_manifest(
+        tmp_path,
+        keypair,
+        _hitl_approval(approver, manifest_id=_signed_manifest(keypair)["manifest_id"]),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "verify", str(manifest_path),
+        "--public-key", str(_write_public_key(tmp_path, keypair)),
+        "--approver-key", f"{APPROVER_ID}={_write_approver_key(tmp_path, approver)}",
+        "--enforce-hitl", "--signature-only",
+    ])
+
+    payload = _json_stdout(result)
+    assert result.exit_code == 0
+    assert payload["result"] == "VALID"
+    assert payload["fields_verified"]["hitl_record"] == "APPROVED"
+
+
+def test_cli_verify_hitl_without_approver_key_is_unverifiable(tmp_path):
+    keypair = generate_ed25519()
+    approver = generate_ed25519()
+    manifest_path = _write_hitl_manifest(
+        tmp_path,
+        keypair,
+        _hitl_approval(approver, manifest_id=_signed_manifest(keypair)["manifest_id"]),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "verify", str(manifest_path),
+        "--public-key", str(_write_public_key(tmp_path, keypair)),
+        "--enforce-hitl", "--signature-only",
+    ])
+
+    payload = _json_stdout(result)
+    assert result.exit_code == 1
+    assert payload["result"] == "UNVERIFIABLE"
+    assert payload["fields_verified"]["hitl_record"] == "UNVERIFIABLE"
+    # The operator is told which input is missing, not just that it failed.
+    assert "--approver-key" in result.output
+
+
+def test_cli_verify_hitl_runs_without_enforce_hitl(tmp_path):
+    # hitl_record.required drives the check, so a manifest declaring HITL
+    # reaches the approver-key path even when the caller never asked for it.
+    keypair = generate_ed25519()
+    approver = generate_ed25519()
+    manifest_path = _write_hitl_manifest(
+        tmp_path,
+        keypair,
+        _hitl_approval(approver, manifest_id=_signed_manifest(keypair)["manifest_id"]),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "verify", str(manifest_path),
+        "--public-key", str(_write_public_key(tmp_path, keypair)),
+        "--signature-only",
+    ])
+
+    assert _json_stdout(result)["result"] == "UNVERIFIABLE"
+
+
+def test_cli_verify_rejects_forged_approval_signature(tmp_path):
+    keypair = generate_ed25519()
+    approver = generate_ed25519()
+    manifest_path = _write_hitl_manifest(
+        tmp_path,
+        keypair,
+        _hitl_approval(
+            approver,
+            manifest_id=_signed_manifest(keypair)["manifest_id"],
+            signature="c2ln",
+        ),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "verify", str(manifest_path),
+        "--public-key", str(_write_public_key(tmp_path, keypair)),
+        "--approver-key", f"{APPROVER_ID}={_write_approver_key(tmp_path, approver)}",
+        "--enforce-hitl", "--signature-only",
+    ])
+
+    payload = _json_stdout(result)
+    assert result.exit_code == 1
+    assert payload["fields_verified"]["hitl_record"] == "INVALID"
+
+
+def test_cli_verify_rejects_approval_replayed_from_another_manifest(tmp_path):
+    keypair = generate_ed25519()
+    approver = generate_ed25519()
+    manifest_path = _write_hitl_manifest(
+        tmp_path,
+        keypair,
+        _hitl_approval(
+            approver, manifest_id="018f4a3b-2c1d-7e5f-a8b9-ffffffffffff"
+        ),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "verify", str(manifest_path),
+        "--public-key", str(_write_public_key(tmp_path, keypair)),
+        "--approver-key", f"{APPROVER_ID}={_write_approver_key(tmp_path, approver)}",
+        "--enforce-hitl", "--signature-only",
+    ])
+
+    payload = _json_stdout(result)
+    assert result.exit_code == 1
+    assert payload["fields_verified"]["hitl_record"] == "INVALID"
+
+
+def test_cli_verify_rejects_malformed_approver_key_spec(tmp_path):
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+
+    result = CliRunner().invoke(cli, [
+        "verify", str(signed_path),
+        "--public-key", str(_write_public_key(tmp_path, keypair)),
+        "--approver-key", "no-separator-here",
+    ])
+
+    assert result.exit_code != 0
+    assert "APPROVER_ID=PATH" in result.output
+
+
+def test_cli_verify_rejects_missing_approver_key_file(tmp_path):
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+
+    result = CliRunner().invoke(cli, [
+        "verify", str(signed_path),
+        "--public-key", str(_write_public_key(tmp_path, keypair)),
+        "--approver-key", f"{APPROVER_ID}={tmp_path / 'absent.hex'}",
+    ])
+
+    assert result.exit_code != 0
+    assert "Approver key file not found" in result.output


### PR DESCRIPTION
Follow up to #331, which closed GHSA-ww2p-prj4-c6xf on the integrated path.

## Problem

The integrated verification path now requires a trusted approver key for every HITL approval, but `manifest verify` has no option that populates `approver_public_keys`. Whenever an approval is actually evaluated, meaning `hitl_record.required` is true or `--enforce-hitl` is passed, it resolves to UNVERIFIABLE, including approvals that are correctly signed and bound to the manifest being verified. So `--enforce-hitl` has no input that can produce VALID.

Because `hitl_record.required` triggers the check on its own, this also reaches callers that never passed `--enforce-hitl`. A third party manifest declaring `hitl_record.required` makes any CLI verification UNVERIFIABLE. The practical risk is that operators learn to ignore UNVERIFIABLE.

Reproduced against the real console script, same three manifests on main before and after #331, issuer key supplied with `--public-key`, `--signature-only` added where it exists so the artifact binding change is not the variable:

```
case                                          before #331      after #331
correctly signed approval, --enforce-hitl     VALID/APPROVED   UNVERIFIABLE
forged approval signature, --enforce-hitl     VALID/APPROVED   UNVERIFIABLE
correctly signed approval, no --enforce-hitl  VALID/APPROVED   UNVERIFIABLE
```

Row two is the advisory and #331 correctly closes it. Row one is the problem: that approval is signed by a real approver key over the correct pre image and bound to the right manifest_id, and it still cannot pass.

## Change

`--approver-key APPROVER_ID=PATH`, repeatable, maps one `approver_id` to a raw Ed25519 public key hex file. The hex loading and 32 byte validation already used by `--public-key` are factored into a shared helper so both options validate identically.

A failing result now names the missing input. When `fields_verified.hitl_record` is UNVERIFIABLE, stderr points at `--approver-key` instead of leaving a bare UNVERIFIABLE.

`docs/api-reference/cli.md` is regenerated with `scripts/gen_cli_reference.py`. The explanation lives in the command docstring, which the generator picks up.

Adding the option does not weaken anything. The three cases above are unchanged without it, and row one only reaches VALID once a trusted approver key is supplied:

```
correctly signed approval, --enforce-hitl                    UNVERIFIABLE
forged approval signature, --enforce-hitl                    UNVERIFIABLE
correctly signed approval, no --enforce-hitl                 UNVERIFIABLE
correctly signed approval, --enforce-hitl --approver-key     VALID/APPROVED
```

## Tests

Adds the CLI HITL coverage that was absent both before and after #331. No test in `python/tests/test_cli.py` matched `hitl` on either commit, which is why the suite stayed green while the flag was unusable.

- genuine approval with `--approver-key` verifies
- forged approval signature is INVALID
- approval replayed from another manifest is INVALID
- missing approver key is UNVERIFIABLE and the hint names the option
- `hitl_record.required` reaches the path without `--enforce-hitl`
- malformed `APPROVER_ID=PATH` and missing key file fail cleanly

Full suite: 1216 passed, 6 skipped.

## Note

Scope: this covers only the CLI gap. The other two items raised in review on #331 are still open on main and are deliberately not touched here. AM-VEC-009 signs its approval with the issuer key, which the advisory lists as an indicator, and it is a published conformance vector other implementations build against. And `pyproject.toml` reads 0.11.1 while the changelog has no `## [0.11.1]` section, so a release cut today would ship without release notes under its own version. Both are worth closing before 0.11.1 is published.