### PR TITLE
docs: update project contact email

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ description = "Agent Manifest SDK — cryptographically anchor all 10 artifacts 
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "Apache-2.0"}
-authors = [{name = "AgenTrust Authors", email = "maintainers@agentrust-io.com"}]
+authors = [{name = "AgenTrust Authors", email = "imransiddique@live.com"}]
 keywords = [
   "ai-agents", "attestation", "governance", "tee", "confidential-computing",
   "mcp", "agent-manifest", "trust", "hardware-attestation", "pydantic",


### PR DESCRIPTION
## Summary

- replace a non-operational project email with the current contact address
- leave example identities and protocol data unchanged

## Validation

- git diff --check
- verified the retired operational address is absent