### PR TITLE
spec: pin the composite policy-bundle Merkle leaf encoding (3.2.2)

### DIFF
--- a/docs/adr/0003-rfc9162-merkle-domain-separation.md
+++ b/docs/adr/0003-rfc9162-merkle-domain-separation.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted  
 **Date**: 2026-05-10  
-**Spec section**: Section 4.1.1, Section 3.2.3 (tool catalog hash), Section 3.2.5 (RAG corpus)
+**Spec section**: Section 4.1.1, Section 3.2.2 (composite policy bundle), Section 3.2.3 (tool catalog hash), Section 3.2.5 (RAG corpus)
 
 ## Context
 
@@ -16,7 +16,8 @@ Use the RFC 9162 (Certificate Transparency v2) Merkle tree construction with exp
 - Internal nodes: `SHA-256(0x01 || left_hash || right_hash)`
 
 Leaf data for tool entries: RFC 8785 canonical JSON of the tool descriptor (schema + description, sorted by tool name).  
-Leaf data for corpus documents: RFC 8785 canonical JSON of the document descriptor (hash + identifier + ingested_at).
+Leaf data for corpus documents: RFC 8785 canonical JSON of the document descriptor (hash + identifier + ingested_at).  
+Leaf data for composite policy sub-bundles (Section 3.2.2): the **raw digest bytes** of each sub-bundle hash, not the `sha256:`-prefixed hex string and not a JSON descriptor. Unlike the two above, this leaf carries no structured descriptor, because the ordering rule already fixes which sub-bundle each leaf is.
 
 ## Rationale
 
@@ -36,7 +37,7 @@ Leaf data for corpus documents: RFC 8785 canonical JSON of the document descript
 ## Consequences
 
 - The `0x00` prefix on leaf nodes and `0x01` prefix on internal nodes are mandatory. Implementations that omit them will fail conformance test AM-BIND-015.
-- Leaf ordering must be deterministic: tool entries sorted by `tool_id` (lexicographic, Unicode code point order, same as RFC 8785 key ordering). Corpus documents sorted by `document_id`.
+- Leaf ordering must be deterministic: tool entries sorted by `tool_id` (lexicographic, Unicode code point order, same as RFC 8785 key ordering). Corpus documents sorted by `document_id`. Composite policy sub-bundles sorted by policy language identifier (`cedar`, `rego`, `yaml-agt`), per Section 3.2.2.
 - Empty trees (no tools, no corpus documents) are represented by the SHA-256 of the empty string: `sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
 
 ## References

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -397,6 +397,9 @@ The policy bundle hash covers the complete Cedar policy set, including all polic
 
 For `policy_language: composite`, the `hash` field MUST be a Merkle root over the hashes of each sub-bundle, sorted by policy language identifier in lexicographic order (`cedar`, `rego`, `yaml-agt`). Each sub-bundle MUST be hashed independently using the same hash algorithm as the manifest. The `agt_version` field MUST reference the AGT version used to assemble the composite bundle, even if individual sub-bundles were produced by other tools.
 
+<!-- CHANGED: #149 - pin the composite Merkle leaf encoding, which ADR-0003 defined for 3.2.3 and 3.2.5 but not here -->
+The composite tree is constructed per ADR-0003, and **`leaf_data` for it is the raw digest bytes of each sub-bundle hash**: the bytes the hash algorithm produces, not the `sha256:`-prefixed hex string and not a JSON descriptor. Each leaf is therefore `SHA-256(0x00 || <raw digest bytes>)`. This is normative rather than editorial: all three readings satisfy "a Merkle root over the hashes of each sub-bundle", they produce different roots from identical inputs, and a verifier holding a manifest cannot tell which one it is checking.
+
 AGT policy scope identifiers use the form `<namespace>:<resource-type>:<action>`, e.g., `finance:ledger:write`. For the full scope identifier registry, refer to the AGT specification.
 
 #### 3.2.3 Tool Manifest Binding


### PR DESCRIPTION
## The gap

ADR-0003 pins the Merkle construction rigorously: RFC 9162, `SHA-256(0x00 || leaf_data)` for leaves, `SHA-256(0x01 || left || right)` for internal nodes, and it explicitly rejects the flat concatenated-hash form. It then defines `leaf_data` for **§3.2.3** tool entries and **§3.2.5** corpus documents.

It says nothing about **§3.2.2**, the composite policy bundle. Its own header does not even list that section.

§3.2.2 said only:

> the `hash` field MUST be a Merkle root over the hashes of each sub-bundle, sorted by policy language identifier in lexicographic order

Ordering pinned, encoding not. Raw digest bytes, the `sha256:`-prefixed hex string, and a small descriptor JSON all satisfy that sentence, and they produce **three different roots from identical sub-bundles**. A verifier holding a manifest cannot tell which one it is checking.

That is exactly the cross-implementation reproducibility gap ADR-0003 exists to close, in the one section it missed.

## The decision

`leaf_data` for the composite tree is the **raw digest bytes** of each sub-bundle hash. Not the `sha256:`-prefixed string, not a JSON descriptor.

Chosen over a descriptor JSON, which would have been more consistent with the two sibling definitions, for two reasons:

1. The sibling leaves carry structured descriptors because they need to: a tool leaf binds schema to description, a corpus leaf binds hash to identifier and ingest time. A composite sub-bundle leaf carries one hash, and the ordering rule already fixes which sub-bundle it is.
2. Worked records already exist on the digest-bytes reading and are published.

The trade being accepted, stated so it is on the record: the leaf does not itself commit to the policy language. Two manifests declaring different language sets produce the same root if the differing sub-bundles are byte-identical. That requires an attacker to control both bundles and make them identical, at which point the substitution buys nothing, but if that ever stops being true this is the line to revisit.

## Changes

- **`spec/agent-manifest-spec-v0.2.md` §3.2.2**: new normative paragraph pinning the encoding, with the reason it is normative rather than editorial.
- **`docs/adr/0003-rfc9162-merkle-domain-separation.md`**: §3.2.2 added to the Spec section header, a third `Leaf data for` line, and the ordering rule extended in Consequences.

## Credit

Found by @rabbidave while implementing the composite root for the ocsf-schema 1724 class, reported on cosai-oasis/ws4-secure-design-agentic-systems#149. Their first pass used the flat concatenated form and ADR-0003 caught it, which is the ADR doing its job; this is the neighbouring case it could not catch. They also offered a conformance test alongside AM-BIND-015, which is worth taking as a follow-up.