### PR TITLE
spec: announce 2026-11-30 as the v0.1 manifest issuance end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Deprecated
+
+- **[SPEC] Issuing v0.1 manifests ends 2026-11-30** (issue #315, phase 5). From that
+  date the reference implementation produces v0.2 COSE envelopes only. The date follows
+  phase 4 completing: `cmcp` and `ca2a` both verify a v0.2 envelope through their real
+  loader paths and both reject a payload declaring v0.1 under a v0.2 envelope
+  (`AM-VEC-COSE-012`), so a consumer is exercising v0.2 rather than a test harness.
+
+  **Verifying v0.1 manifests is not deprecated and has no end date.** These are audit
+  records with regulated retention well beyond their 90-day validity, and a verifier that
+  stops reading them destroys evidence rather than tidying a codebase. Same reasoning as
+  keeping the `-8` Ed25519 code point acceptable indefinitely.
+
 ## [0.11.1] — 2026-08-23
 
 ### Fixed

--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -168,6 +168,11 @@ Verifier requirements:
 - MUST check `version` before verifying. If the version is unsupported, MUST return `INCOMPATIBLE_VERSION` rather than silently misinterpreting fields.
 - SHOULD support at least the current and one prior minor version.
 
+<!-- CHANGED: #315 phase 5 - announce the v0.1 issuance end date -->
+**Issuing v0.1 manifests ends 2026-11-30.** From that date the reference implementation produces v0.2 COSE envelopes only, and a producer SHOULD NOT set `version` to `"0.1"`.
+
+**Verifying v0.1 manifests is not deprecated and has no end date.** Manifests are audit records under retention obligations that outlast their validity by years, so a verifier that stopped reading them would destroy evidence rather than remove code. `INCOMPATIBLE_VERSION` stays reserved for versions a verifier genuinely cannot interpret, never for v0.1.
+
 Compatibility matrix:
 
 | Producer version | Verifier supports | Result |


### PR DESCRIPTION
Phase 5 of #315.

## Why now

Phase 5 was explicitly gated: "The date is a maintainer decision, not a technical one, and it should not be set before phase 4 shows a consumer verifying v0.2 in anger."

Phase 4 completed on 2026-08-19. [cmcp#530](https://github.com/agentrust-io/cmcp/pull/530) and [ca2a#122](https://github.com/agentrust-io/ca2a/pull/122) both merged, and each verifies a correctly signed v0.2 COSE envelope through its real loader path and rejects a payload declaring v0.1 under a v0.2 envelope (`AM-VEC-COSE-012`). Two consumers exercising the gate at their own boundary is the condition, and it is met.

## The date

**2026-11-30.** Roughly one v0.1 record lifetime of notice, which is the shortest period that cannot strand a manifest already in flight.

## What is not being deprecated

**Verifying v0.1 manifests, which gets no end date at all.** Manifests are audit records under retention obligations that outlast their 90-day validity by years. A verifier that stopped reading them would destroy evidence rather than remove code. This is the same reasoning already recorded for keeping the `-8` Ed25519 code point acceptable indefinitely after RFC 9864 deprecated it.

The distinction matters enough to state twice, because "v0.1 is deprecated" will otherwise be read as covering both.

## Changes

- `spec/agent-manifest-spec-v0.2.md` §2.4 Version Negotiation: the date, plus the explicit statement that `INCOMPATIBLE_VERSION` stays reserved for versions a verifier genuinely cannot interpret and never for v0.1.
- `CHANGELOG.md`: a `Deprecated` entry under Unreleased carrying the same two halves.

No code changes. The reference implementation still issues v0.1 on request until the date.