### PR TITLE
docs: clarify ADR-0003 selects only two Merkle hash operations

### DIFF
--- a/docs/adr/0003-rfc9162-merkle-domain-separation.md
+++ b/docs/adr/0003-rfc9162-merkle-domain-separation.md
@@ -15,8 +15,14 @@ Use the RFC 9162 (Certificate Transparency v2) Merkle tree construction with exp
 - Leaf nodes: `SHA-256(0x00 || leaf_data)`
 - Internal nodes: `SHA-256(0x01 || left_hash || right_hash)`
 
-Leaf data for tool entries: RFC 8785 canonical JSON of the tool descriptor (schema + description, sorted by tool name).  
-Leaf data for corpus documents: RFC 8785 canonical JSON of the document descriptor (hash + identifier + ingested_at).
+These are the only two Merkle hash operations selected by this ADR. The entries in
+"Alternatives considered" are rejected constructions, not additional supported
+operations.
+
+Section 4.1.1 of the specification is the normative definition of the shared
+construction. Sections 3.2.3 and 3.2.5.1 normatively define each artifact's leaf
+data and ordering; they take precedence over this ADR for those details. RFC 8785
+applies only where those sections define JSON as an input to a hash.
 
 ## Rationale
 


### PR DESCRIPTION
## What

Clarifies ADR-0003 so it states plainly that only two Merkle hash operations are approved, instead of reading like there might be four.

## Why

Fixes #337. The "Alternatives considered" section listed rejected constructions (plain concatenation, BLAKE3, flat hash) right next to the two approved operations without saying they were rejected, so a reader could mistake them for additional supported options. The ADR also carried old leaf-content wording that no longer matches the current specification.

## Spec impact

No normative text changed. The ADR now explicitly defers to:
- Section 4.1.1 — the shared Merkle construction (the two approved hash operations)
- Section 3.2.3 — tool catalog leaf data and ordering
- Section 3.2.5.1 — RAG corpus leaf data and ordering

No conformance test IDs are affected.

## Test plan

- [x] Documentation-only change, no code affected
- [x] `git diff --check` passes (no whitespace errors)
- [x] Confirmed the outdated leaf-description wording is removed
- [x] No Markdown diagnostics on the file

## DCO

- [x] Sign-off not yet added to this commit — will add before merge if required.