### PR TITLE
spec(4.1.1): let "all Merkle tree constructions" mean all

### DIFF
--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -1224,9 +1224,9 @@ The standard cryptographic profile uses the following primitives:
 
 ##### 4.1.1 Merkle Tree Domain Separation <!-- CHANGED: CRYPTO-005 - explicit domain separation per RFC 9162 to prevent length-extension attacks -->
 
-All Merkle tree constructions in this specification (corpus `merkle_root`, tool `catalog_hash`) MUST use the RFC 9162 / RFC 6962 domain-separated hashing convention:
+All Merkle tree constructions in this specification MUST use the RFC 9162 / RFC 6962 domain-separated hashing convention: <!-- CHANGED: #337 - the parenthetical named two of five constructions and went stale twice; the per-section definitions are now the single source -->
 
-- Leaf hash: `SHA-256(0x00 || leaf_data)` where `leaf_data` is the per-item input bytes as defined in the relevant section (section 3.2.3 for catalog, section 3.2.5.1 for corpus).
+- Leaf hash: `SHA-256(0x00 || leaf_data)`, where `leaf_data` is defined by the section specifying that construction.
 - Interior node hash: `SHA-256(0x01 || left_child_hash || right_child_hash)`.
 
 The `0x00` and `0x01` domain separation prefixes prevent second-preimage attacks that are possible with plain Merkle-Damgard SHA-256 trees lacking domain separation (as demonstrated in the Certificate Transparency literature). This construction is referenced in RFC 9162 Section 2.1.


### PR DESCRIPTION
Closes #337, reported by @Mayur021.

## The problem

Section 4.1.1 says "All Merkle tree constructions in this specification" and then parenthetically names two of them. Its `leaf_data` pointer names two sections. The specification defines **five** leaf constructions using the `0x00` convention:

| Section | leaf |
|---|---|
| 3.2.2 | `SHA-256(0x00 \|\| raw sub-bundle digest bytes)`, composite policy bundle |
| 3.2.3 | `SHA-256(0x00 \|\| tool_id \|\| 0x00 \|\| schema_hash \|\| description_hash)`, tool catalog |
| 3.2.5.1 | corpus documents |
| 3.2.6 | `H(0x00 \|\| tag \|\| canonical_op)`, memory root |
| 3.2.7 | `H(0x00 \|\| "am-trace-entry\x00" \|\| canonical_entry)`, decision trace |

So a reader starting at 4.1.1 does not reach the composite rule #335 made normative, which is the concrete harm: #335 exists because all three readings of "a Merkle root over the hashes of each sub-bundle" satisfy the prose and produce different roots.

## Why drop the enumeration rather than extend it

The parenthetical has gone stale twice in a month. Once when 3.2.6 and 3.2.7 were added, again when #335 landed. Extending it now buys until the next construction and no further, and a summary that disagrees with the sections it summarises is worse than no summary, because "all" reads as authoritative.

The per-section definitions are already normative and already complete. Making them the single source is the option @Mayur021 proposed as less to maintain, and I agree.

Worth noting how careful the per-section text already is by comparison: 3.2.7 deliberately uses `0x02` rather than RFC 9162's `0x01` for its sequential chain "so that a sequential root can never be read as a merkle root over the same entries", and tags its leaves `am-trace-entry\x00` so a trace entry cannot collide with a memory operation that canonicalizes to the same bytes. The sections are doing the work; only the umbrella clause was behind.

## Impact

- **Backward compatible.** No construction changes, no leaf encoding changes, no root changes.
- **Conformance:** unaffected at all levels. Nothing in `python/` or `docs/` referenced the removed wording.
- **Affects:** editorial scope of one normative clause.

## Related

@Mayur021 counted four constructions and #338 currently says three. Both undercount; it is five. That is itself the argument for not enumerating.

The ADR-0003 wording is being handled separately in #338, and the two should agree once both land.