### PR TITLE
fix(verify): cross-check enforcement_mode when verifying policy_bundle

### DIFF
--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -256,6 +256,12 @@ class VerificationContext(BaseModel):
 
     system_prompt_hash: Optional[str] = None
     policy_bundle_hash: Optional[str] = None
+    # Spec 6.2: the runtime's attested policy-enforcement mode ("enforce",
+    # "advisory", or "audit-only"). Compared against
+    # artifacts.policy_bundle.enforcement_mode when the manifest declares one.
+    # A caller whose runtime has no notion of enforcement mode simply leaves
+    # this unset, which skips the check (matches today's behavior).
+    enforcement_mode: Optional[str] = None
     tool_catalog_hash: Optional[str] = None
     model_version: Optional[str] = None
     rag_corpus_merkle_root: Optional[str] = None
@@ -894,6 +900,30 @@ def verify_manifest(
         pb.get("hash"),
         context.policy_bundle_hash,
     )
+    # Spec 6.2: a manifest that declares an enforcement_mode is asserting the
+    # runtime must be attested as operating in that mode. The hash matching
+    # is not sufficient on its own -- the same approved policy bundle could
+    # be loaded while the runtime enforces it differently (e.g. "advisory"
+    # instead of "enforce"), which is exactly the gap this closes. Only
+    # runs when the manifest actually declares a mode, so a manifest that
+    # doesn't (or a caller that doesn't pass context.enforcement_mode) keeps
+    # today's behavior unchanged.
+    declared_mode = pb.get("enforcement_mode")
+    if declared_mode is not None and fields.policy_bundle != FieldResult.NOT_BOUND:
+        if context.enforcement_mode is None:
+            mismatches.append(MismatchDetail(
+                field="policy_bundle.enforcement_mode",
+                expected_hash=declared_mode,
+                actual_hash="<not provided>",
+            ))
+            fields.policy_bundle = FieldResult.MISMATCH
+        elif declared_mode != context.enforcement_mode:
+            mismatches.append(MismatchDetail(
+                field="policy_bundle.enforcement_mode",
+                expected_hash=declared_mode,
+                actual_hash=context.enforcement_mode,
+            ))
+            fields.policy_bundle = FieldResult.MISMATCH
 
     tm = artifacts.get("tool_manifest") or {}
     fields.tool_manifest = _check(

--- a/python/tests/test_am_compat.py
+++ b/python/tests/test_am_compat.py
@@ -274,6 +274,7 @@ def test_verification_engine_valid_after_sign():
     ctx = VerificationContext(
         system_prompt_hash="sha256:" + "a" * 64,
         policy_bundle_hash="sha256:" + "b" * 64,
+        enforcement_mode="enforce",
         trusted_keys={kp.key_id: kp.public_b64url()},
         strict_artifact_verification=False,
     )

--- a/python/tests/test_am_verify.py
+++ b/python/tests/test_am_verify.py
@@ -71,6 +71,7 @@ def ctx(**overrides):
     c = VerificationContext(
         system_prompt_hash=SHA_A,
         policy_bundle_hash=SHA_B,
+        enforcement_mode="enforce",
         model_version="claude-3",
         audit_chain_root=SHA_C,
         trusted_keys=dict(TRUSTED_KEYS),

--- a/python/tests/test_composition_only.py
+++ b/python/tests/test_composition_only.py
@@ -128,6 +128,7 @@ def test_composition_only_verifies_as_incomplete_with_declared_not_bound_fields(
         VerificationContext(
             system_prompt_hash=SHA,
             policy_bundle_hash="sha256:" + "b" * 64,
+            enforcement_mode="enforce",
             trusted_keys={key.key_id: key.public_b64url()},
         ),
         RevocationStore(),

--- a/python/tests/test_public_api.py
+++ b/python/tests/test_public_api.py
@@ -62,6 +62,7 @@ def test_public_verify_roundtrip_valid_then_mismatch():
     matching = agent_manifest.VerificationContext(
         system_prompt_hash=sha_a,
         policy_bundle_hash=sha_b,
+        enforcement_mode="enforce",
         model_version="claude-3",
         trusted_keys=trusted,
     )

--- a/python/tests/test_valid_authorization_scope.py
+++ b/python/tests/test_valid_authorization_scope.py
@@ -80,6 +80,7 @@ def ctx_matching_catalog():
     c = VerificationContext(
         system_prompt_hash=SHA_A,
         policy_bundle_hash=SHA_B,
+        enforcement_mode="enforce",
         model_version="claude-3",
         audit_chain_root=SHA_C,
         trusted_keys=dict(TRUSTED_KEYS),

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -228,6 +228,67 @@ def test_mismatch_includes_all_failing_fields():
 
 
 # ---------------------------------------------------------------------------
+# ENFORCEMENT MODE (spec 6.2) — agentrust-io/cmcp#576
+# ---------------------------------------------------------------------------
+
+
+def test_enforcement_mode_match_is_unaffected():
+    """A manifest that declares a mode, matched by the runtime, still MATCHes."""
+    manifest = base_manifest(artifacts={
+        "system_prompt": {"hash": SHA},
+        "policy_bundle": {"hash": "sha256:" + "b" * 64, "enforcement_mode": "enforce"},
+        "model_identity": {"model_hash": None, "version": "claude-3", "deployment_type": "api"},
+    })
+    ctx = base_context(enforcement_mode="enforce")
+    result = verify_manifest(manifest, ctx, store())
+    assert result.result == OverallResult.VALID
+    assert result.fields_verified.policy_bundle == FieldResult.MATCH
+
+
+def test_enforcement_mode_mismatch_fails_policy_bundle():
+    """Hash matches, but the runtime is attested in a different mode than the
+    manifest declares -- this must fail, not silently pass on the hash alone.
+    """
+    manifest = base_manifest(artifacts={
+        "system_prompt": {"hash": SHA},
+        "policy_bundle": {"hash": "sha256:" + "b" * 64, "enforcement_mode": "enforce"},
+        "model_identity": {"model_hash": None, "version": "claude-3", "deployment_type": "api"},
+    })
+    ctx = base_context(enforcement_mode="advisory")
+    result = verify_manifest(manifest, ctx, store())
+    assert result.result == OverallResult.MISMATCH
+    assert result.fields_verified.policy_bundle == FieldResult.MISMATCH
+    assert any(d.field == "policy_bundle.enforcement_mode" for d in result.mismatch_details)
+
+
+def test_enforcement_mode_declared_but_not_provided_fails_closed():
+    """The manifest declares a required mode; the caller didn't pass one.
+
+    Fail closed rather than silently skipping the check -- an unattested mode
+    is not evidence the runtime is in the declared mode.
+    """
+    manifest = base_manifest(artifacts={
+        "system_prompt": {"hash": SHA},
+        "policy_bundle": {"hash": "sha256:" + "b" * 64, "enforcement_mode": "enforce"},
+        "model_identity": {"model_hash": None, "version": "claude-3", "deployment_type": "api"},
+    })
+    ctx = base_context()  # enforcement_mode left unset
+    result = verify_manifest(manifest, ctx, store())
+    assert result.result == OverallResult.MISMATCH
+    assert result.fields_verified.policy_bundle == FieldResult.MISMATCH
+
+
+def test_enforcement_mode_absent_from_manifest_is_backward_compatible():
+    """A manifest that never declares enforcement_mode is unaffected, even if
+    the caller happens to pass one -- there is nothing to cross-check against.
+    """
+    ctx = base_context(enforcement_mode="enforce")
+    result = verify_manifest(base_manifest(), ctx, store())  # base_manifest has no enforcement_mode
+    assert result.result == OverallResult.VALID
+    assert result.fields_verified.policy_bundle == FieldResult.MATCH
+
+
+# ---------------------------------------------------------------------------
 # EXPIRED
 # ---------------------------------------------------------------------------
 

--- a/scripts/verify_python_distribution.py
+++ b/scripts/verify_python_distribution.py
@@ -57,6 +57,7 @@ def main() -> None:
     context = agent_manifest.VerificationContext(
         system_prompt_hash=prompt_hash,
         policy_bundle_hash=policy_hash,
+        enforcement_mode="enforce",
         model_version="release-smoke",
         trusted_keys={keypair.key_id: keypair.public_b64url()},
     )


### PR DESCRIPTION
## What

Makes verify_manifest actually cross-check policy_bundle.enforcement_mode against the runtime's attested mode, instead of only checking the policy_bundle hash.

## Why

Fixes:  [cmcp#576 (agentrust-io/cmcp).](https://github.com/agentrust-io/cmcp/issues/576)

Spec section 6.2 already says this is required: a verifying party MUST reject a manifest whose enforcement_mode doesn't match the runtime's attested mode, and the spec's own table lists it as "MUST match. Conflict = attestation failure." But the SDK's VerificationContext never had a place to give it the runtime's mode, and verify_manifest never checked it so a manifest requiring enforce could match on hash alone while the runtime was actually running advisory (warn-only) or silent, and verification would still say VALID. This PR implements the check the spec already requires.

## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [x] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
