### PR TITLE
ci: stop SBOM workflow pushing to protected main

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   generate:
@@ -42,14 +42,3 @@ jobs:
           name: sbom-cdx
           path: sbom.cdx.json
           retention-days: 90
-
-      - name: Commit SBOM to repo
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          mv sbom.cdx.json sbom/sbom.cdx.json 2>/dev/null || \
-            (mkdir -p sbom && mv sbom.cdx.json sbom/sbom.cdx.json)
-          git add sbom/sbom.cdx.json
-          git diff --cached --quiet || \
-            git commit -m "chore(sbom): update CycloneDX SBOM [skip ci]"
-          git push


### PR DESCRIPTION
The SBOM job already uploads the generated CycloneDX document as a retained artifact. Its final bot push always violates the repository's PR-only main rule, turning a successful generation into a failed workflow. Remove that push step and reduce permissions from contents: write to contents: read.\n\nEvidence: run 33125832539 generated and committed the SBOM locally, then failed only at git push with GH013. YAML parses successfully.\n\nSigned-off-by: Imran Siddique <oss@opaque.co>