### PR TITLE
fix(delegation): bound child scope_grant ttl_seconds by absolute expiry

### DIFF
--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -13,7 +13,7 @@ form of approved_scope + manifest_id + approved_at.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from ._canonicalize import canonicalize
@@ -254,8 +254,15 @@ def verify_delegation_chain(
 
 
 def _parse_delegated_at(value: str) -> datetime:
-    """Parse a hop's ``delegated_at`` ISO 8601 timestamp (accepts a 'Z' suffix)."""
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    """Parse a hop's ``delegated_at`` ISO 8601 timestamp (accepts a 'Z' suffix).
+
+    A timestamp with no offset is treated as UTC rather than left naive: hops in
+    one chain are written by different parties and need not agree on whether to
+    include one, and comparing a naive against an aware datetime raises
+    TypeError, which is not a refusal.
+    """
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
 
 def _check_scope_narrowing(

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -13,11 +13,11 @@ form of approved_scope + manifest_id + approved_at.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from datetime import datetime, timedelta
+from typing import Any
 
 from ._canonicalize import canonicalize
-from ._signing import Ed25519Verifier, Ed25519KeyPair
-
+from ._signing import Ed25519KeyPair, Ed25519Verifier
 
 # ---------------------------------------------------------------------------
 # A2A Delegation chain
@@ -146,7 +146,7 @@ def verify_delegation_chain(
     delegation_chain: list[dict[str, Any]],
     public_keys: dict[str, bytes],  # principal_id -> public key bytes
     manifest_id: str,
-    manifest_issuer: Optional[str] = None,
+    manifest_issuer: str | None = None,
 ) -> None:
     """Verify all hops in a delegation chain.
 
@@ -205,7 +205,8 @@ def verify_delegation_chain(
             f"root max_delegation_depth {root_max_depth}"
         )
 
-    prev_scope: Optional[dict[str, Any]] = None
+    prev_scope: dict[str, Any] | None = None
+    prev_delegated_at: str | None = None
 
     for i, hop in enumerate(delegation_chain):
         # Structural validation before any field access (raises ValueError on violation)
@@ -238,13 +239,35 @@ def verify_delegation_chain(
 
         # Scope narrowing check
         scope = hop["scope_grant"]
+                # Scope narrowing check
+        scope = hop["scope_grant"]
+        delegated_at = hop["delegated_at"]
         if prev_scope is not None:
-            _check_scope_narrowing(prev_scope, scope, hop_index=i)
+            _check_scope_narrowing(
+                prev_scope,
+                scope,
+                hop_index=i,
+                parent_delegated_at=prev_delegated_at,
+                child_delegated_at=delegated_at,
+            )
 
         prev_scope = scope
+        prev_delegated_at = delegated_at
 
 
-def _check_scope_narrowing(parent: dict[str, Any], child: dict[str, Any], hop_index: int) -> None:
+def _parse_delegated_at(value: str) -> datetime:
+    """Parse a hop's ``delegated_at`` ISO 8601 timestamp (accepts a 'Z' suffix)."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _check_scope_narrowing(
+    parent: dict[str, Any],
+    child: dict[str, Any],
+    hop_index: int,
+    *,
+    parent_delegated_at: str | None = None,
+    child_delegated_at: str | None = None,
+) -> None:
     """Raise ValueError if child scope is broader than parent scope."""
     parent_tools = set(parent.get("tools") or [])
     child_tools = set(child.get("tools") or [])
@@ -306,6 +329,33 @@ def _check_scope_narrowing(parent: dict[str, Any], child: dict[str, Any], hop_in
             f"child ttl_seconds {child_ttl!r} exceeds parent ttl_seconds "
             f"{parent_ttl!r}"
         )
+    # DELEG-005: ttl_seconds is a *duration measured from that hop's own*
+    # delegated_at, not from a shared origin. Comparing the two durations in
+    # isolation (above) is not sufficient: a child hop delegated partway
+    # through its parent's window can carry a duration that does not exceed
+    # the parent's, yet its absolute expiry (its own delegated_at + its own
+    # ttl_seconds) can still fall *after* the parent's absolute expiry
+    # (parent's delegated_at + parent's ttl_seconds) - the grant would then
+    # outlive the authority it was narrowed from. Comparing the two absolute
+    # expiries directly closes this regardless of how far apart the hops'
+    # delegated_at timestamps are.
+    if (
+        parent_ttl is not None
+        and child_ttl is not None
+        and parent_delegated_at is not None
+        and child_delegated_at is not None
+    ):
+        parent_expiry = _parse_delegated_at(parent_delegated_at) + timedelta(seconds=parent_ttl)
+        child_expiry = _parse_delegated_at(child_delegated_at) + timedelta(seconds=child_ttl)
+        if child_expiry > parent_expiry:
+            raise ValueError(
+                f"Scope laundering at hop {hop_index}: child scope_grant "
+                f"expires at {child_expiry.isoformat()}, after the parent's "
+                f"absolute expiry {parent_expiry.isoformat()}, even though "
+                "its ttl_seconds duration does not exceed the parent's "
+                "(the child was delegated later, so the same duration "
+                "outlives the parent's grant)"
+            )
 
     # max_delegation_depth: a child may not authorize a deeper sub-chain than
     # its parent permitted. Omission defaults to the spec value (3).
@@ -383,7 +433,7 @@ def verify_hitl_approval(
         ValueError: If required fields are missing or the approval has expired.
     """
     import base64
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timezone
 
     # HITL-003: enforce approval expiry before verifying signature
     duration = approval.get("approved_scope", {}).get("approval_duration_seconds", 0)

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -239,8 +239,6 @@ def verify_delegation_chain(
 
         # Scope narrowing check
         scope = hop["scope_grant"]
-                # Scope narrowing check
-        scope = hop["scope_grant"]
         delegated_at = hop["delegated_at"]
         if prev_scope is not None:
             _check_scope_narrowing(

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -2,8 +2,6 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from cryptography.exceptions import InvalidSignature
-
 from agent_manifest._delegation import (
     DelegationHopSigner,
     HitlApprovalSigner,
@@ -13,6 +11,7 @@ from agent_manifest._delegation import (
     verify_hitl_approval,
 )
 from agent_manifest._signing import generate_ed25519
+from cryptography.exceptions import InvalidSignature
 
 NOW = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 MID = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
@@ -252,6 +251,68 @@ def test_child_raising_max_delegation_depth_is_rejected():
 
 
 # ---------------------------------------------------------------------------
+# DELEG-005: ttl_seconds narrowing must hold in absolute (wall-clock) time,
+# not just as a raw duration comparison - ttl_seconds is measured from each
+# hop's own delegated_at, so two hops delegated at different times can carry
+# equal (or even shrinking) durations while the later hop's grant still
+# outlives the earlier one's in absolute terms.
+# ---------------------------------------------------------------------------
+
+def _two_hop_chain_at(root_scope, child_scope, root_at, child_at):
+    kp_root, kp_child = generate_ed25519(), generate_ed25519()
+    sig0 = DelegationHopSigner(kp_root).sign_hop(
+        hop=0, principal_id="spiffe://x/root", principal_type="human",
+        delegated_at=root_at, scope_grant=root_scope, manifest_id=MID,
+    )
+    sig1 = DelegationHopSigner(kp_child).sign_hop(
+        hop=1, principal_id="spiffe://x/child", principal_type="agent",
+        delegated_at=child_at, scope_grant=child_scope, manifest_id=MID,
+    )
+    chain = [
+        {"hop": 0, "principal_id": "spiffe://x/root", "principal_type": "human",
+         "delegated_at": root_at, "scope_grant": root_scope, "delegation_signature": sig0},
+        {"hop": 1, "principal_id": "spiffe://x/child", "principal_type": "agent",
+         "delegated_at": child_at, "scope_grant": child_scope, "delegation_signature": sig1},
+    ]
+    keys = {"spiffe://x/root": kp_root.public_bytes,
+            "spiffe://x/child": kp_child.public_bytes}
+    return chain, keys
+
+
+def test_child_delegated_late_with_equal_ttl_outlives_parent_is_rejected():
+    # Root is delegated at T0 with a 1-hour window (expires at T0+1h).
+    # Child is delegated 50 minutes into that window with the SAME duration
+    # (3600s), which passes the plain "child_ttl > parent_ttl" comparison,
+    # but the child's absolute expiry (T0+50m+1h) falls 50 minutes after the
+    # root's absolute expiry (T0+1h) — the grant outlives its parent.
+    root_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    child_at = root_at + timedelta(minutes=50)
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600}
+    child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600}
+    chain, keys = _two_hop_chain_at(
+        root, child, root_at.isoformat().replace("+00:00", "Z"),
+        child_at.isoformat().replace("+00:00", "Z"),
+    )
+    with pytest.raises(ValueError, match="Scope laundering.*absolute expiry"):
+        verify_delegation_chain(chain, keys, MID)
+
+
+def test_child_delegated_late_with_shorter_ttl_still_within_parent_window_passes():
+    # Child is delegated 5 minutes into the root's 1-hour window with a
+    # 30-minute duration; its absolute expiry (T0+5m+30m = T0+35m) is well
+    # inside the root's absolute expiry (T0+1h), so this must pass.
+    root_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    child_at = root_at + timedelta(minutes=5)
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600}
+    child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 1800}
+    chain, keys = _two_hop_chain_at(
+        root, child, root_at.isoformat().replace("+00:00", "Z"),
+        child_at.isoformat().replace("+00:00", "Z"),
+    )
+    verify_delegation_chain(chain, keys, MID)  # must not raise
+
+
+# ---------------------------------------------------------------------------
 # HITL approval signing
 # ---------------------------------------------------------------------------
 
@@ -358,8 +419,12 @@ def test_approval_no_duration_does_not_expire():
 # ---------------------------------------------------------------------------
 
 def _approval_kwargs(approver_id):
-    from agent_manifest.models import ApprovalMethod, ApprovedScope, RiskTier
-    from agent_manifest.models import ApproverIdentityType
+    from agent_manifest.models import (
+        ApprovalMethod,
+        ApprovedScope,
+        ApproverIdentityType,
+        RiskTier,
+    )
     identity_type = (
         ApproverIdentityType.email
         if approver_id.startswith("mailto:")
@@ -383,8 +448,8 @@ def _approval_kwargs(approver_id):
 
 
 def test_hitl_approval_rejects_spiffe_approver_id():
-    from pydantic import ValidationError
     from agent_manifest.models import HitlApproval
+    from pydantic import ValidationError
     with pytest.raises(ValidationError, match="MUST NOT be a SPIFFE URI"):
         HitlApproval(**_approval_kwargs("spiffe://trust.acme.co/user/alice"))
 

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -312,6 +312,23 @@ def test_child_delegated_late_with_shorter_ttl_still_within_parent_window_passes
     verify_delegation_chain(chain, keys, MID)  # must not raise
 
 
+def test_mixed_z_and_naive_delegated_at_still_refuses_on_absolute_expiry():
+    # delegated_at is a required field with no format validation, so one hop
+    # in a chain can legitimately be written with a 'Z' offset and another
+    # without one. A naive datetime cannot be compared against an aware one
+    # (TypeError), which is not a refusal verify_delegation_chain documents
+    # raising (its docstring promises InvalidSignature or ValueError). The
+    # parser must treat an offset-less timestamp as UTC so the absolute-expiry
+    # comparison still runs -- and still refuses -- instead of crashing.
+    root_at = "2026-01-01T00:00:00Z"          # aware
+    child_at = "2026-01-01T00:50:00"          # naive, same chain, outlives root
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600}
+    child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600}
+    chain, keys = _two_hop_chain_at(root, child, root_at, child_at)
+    with pytest.raises(ValueError, match="Scope laundering.*absolute expiry"):
+        verify_delegation_chain(chain, keys, MID)
+
+
 # ---------------------------------------------------------------------------
 # HITL approval signing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The ttl_seconds check only compared the parent and child durations, without considering when each delegation was issued. Since ttl_seconds is measured from each hop’s own delegated_at, a child delegated later could actually expire after its parent, even with a smaller TTL. The check should compare their absolute expiry times instead.

## Why

Concrete failure: A root grant valid for 1 hour can delegate again 50 minutes later with another 1-hour TTL. The old check only compared 3600 to 3600, it passed but the child would actually remain valid 50 minutes longer than the root.

## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [x] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
