### PR TITLE
fix(attestation): reject expired certificates in hardware attestation chains

### DIFF
--- a/python/src/agent_manifest/_cert_chain.py
+++ b/python/src/agent_manifest/_cert_chain.py
@@ -19,8 +19,9 @@ each carrying their own chain verifier; the AMD-specific
 """
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cryptography import x509
@@ -31,12 +32,44 @@ class CertChainError(Exception):
     """Raised when a certificate chain fails to verify or pin to a trusted root."""
 
 
-def verify_cert_chain(
-    chain: "Sequence[x509.Certificate]",
-    trusted_roots: "Sequence[x509.Certificate]",
+def check_validity_period(
+    cert: x509.Certificate,
     *,
-    root_fingerprint_hash: "Optional[HashAlgorithm]" = None,
-    verification_time: Optional[datetime] = None,
+    label: str,
+    verification_time: datetime | None = None,
+) -> None:
+    """Raise :class:`CertChainError` if *cert* is expired or not yet valid.
+
+    Every certificate-chain verifier in this package (SEV-SNP, TDX, TPM, and
+    this module's own :func:`verify_cert_chain`) needs the same check, so it
+    lives here once rather than as three copies that can silently drift out
+    of sync with each other.
+
+    Args:
+        cert: the certificate to check.
+        label: identifies which certificate this is in the caller's chain
+            (e.g. ``"VCEK"``, ``"PCK chain link 0"``), for the error message.
+        verification_time: UTC-aware time to check against (default: current
+            UTC time). Primarily useful for deterministic tests.
+    """
+    now = verification_time or datetime.now(timezone.utc)
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise CertChainError("verification_time must be timezone-aware")
+    now = now.astimezone(timezone.utc)
+    if not (cert.not_valid_before_utc <= now < cert.not_valid_after_utc):
+        raise CertChainError(
+            f"{label} is outside its validity period "
+            f"({cert.not_valid_before_utc.isoformat()} - "
+            f"{cert.not_valid_after_utc.isoformat()}, checked at {now.isoformat()})"
+        )
+
+
+def verify_cert_chain(
+    chain: Sequence[x509.Certificate],
+    trusted_roots: Sequence[x509.Certificate],
+    *,
+    root_fingerprint_hash: HashAlgorithm | None = None,
+    verification_time: datetime | None = None,
 ) -> bool:
     """Verify a leaf-first certificate chain up to a fingerprint-pinned root.
 
@@ -64,8 +97,8 @@ def verify_cert_chain(
             certificate signing, an unpinned root, or missing ``cryptography``.
     """
     try:
-        from cryptography.exceptions import InvalidSignature
         from cryptography import x509
+        from cryptography.exceptions import InvalidSignature
         from cryptography.hazmat.primitives.hashes import SHA256
     except ImportError as e:  # pragma: no cover - exercised via install extra
         raise CertChainError(
@@ -83,8 +116,7 @@ def verify_cert_chain(
     now = now.astimezone(timezone.utc)
 
     for i, cert in enumerate(chain):
-        if not (cert.not_valid_before_utc <= now < cert.not_valid_after_utc):
-            raise CertChainError(f"certificate at position {i} is outside its validity period")
+        check_validity_period(cert, label=f"certificate at position {i}", verification_time=now)
 
     for i, issuer in enumerate(chain[1:], start=1):
         try:

--- a/python/src/agent_manifest/_snp_verify.py
+++ b/python/src/agent_manifest/_snp_verify.py
@@ -38,7 +38,7 @@ import hashlib
 import hmac
 import struct
 from dataclasses import dataclass
-from typing import Optional
+from datetime import datetime
 
 # Raw SNP attestation report field offsets (AMD SEV-SNP ABI, Table 22).
 _OFF_VERSION = 0x00
@@ -209,8 +209,8 @@ def parse_platform_info(platform_info: int) -> SnpPlatformInfo:
 def appraise_platform_info(
     info: SnpPlatformInfo,
     *,
-    require: "Optional[set[str]]" = None,
-    forbid: "Optional[set[str]]" = None,
+    require: set[str] | None = None,
+    forbid: set[str] | None = None,
     reject_unrecognized_bits: bool = False,
 ) -> None:
     """Appraise a decoded PLATFORM_INFO against an explicit policy.
@@ -333,7 +333,7 @@ def load_snp_cert_chain(pem_bundle: bytes) -> tuple[object, object, object]:
 
     try:
         certs = x509.load_pem_x509_certificates(pem_bundle)
-    except Exception as exc:  # noqa: BLE001 - any parse failure is a bad bundle
+    except Exception as exc:
         raise SnpVerificationError(f"could not parse the PEM bundle: {exc}") from exc
 
     vcek = next((c for c in certs if isinstance(c.public_key(), ec.EllipticCurvePublicKey)), None)
@@ -399,7 +399,8 @@ def verify_vcek_chain(
     vcek_cert_der: bytes,
     cert_chain_pem: bytes,
     *,
-    trusted_ark_der: Optional[bytes] = None,
+    trusted_ark_der: bytes | None = None,
+    verification_time: datetime | None = None,
 ) -> bool:
     """Verify VCEK <- ASK <- ARK, and that ARK is self-signed (the AMD root).
 
@@ -407,6 +408,10 @@ def verify_vcek_chain(
     ``cert_chain_pem`` is the KDS ``cert_chain`` blob (ASK then ARK). If
     ``trusted_ark_der`` is supplied, the chain's ARK public key must match it,
     pinning the root instead of trusting whatever the chain carries.
+
+    Every certificate in the chain must be within its validity period (see
+    :func:`._cert_chain.check_validity_period`); an expired VCEK, ASK, or ARK
+    is rejected even if every signature in the chain is otherwise valid.
 
     Returns True on success; raises :class:`SnpVerificationError` on a broken
     chain or missing ``cryptography``.
@@ -420,6 +425,8 @@ def verify_vcek_chain(
         from cryptography.hazmat.primitives import hashes, serialization
         from cryptography.hazmat.primitives.asymmetric import padding
         from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
+        from ._cert_chain import CertChainError, check_validity_period
     except ImportError as e:  # pragma: no cover
         raise SnpVerificationError(
             "VCEK chain verification requires the 'cryptography' package"
@@ -428,7 +435,7 @@ def verify_vcek_chain(
     pems = re.findall(
         rb"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
         cert_chain_pem,
-        re.S,
+        re.DOTALL,
     )
     if len(pems) < 2:
         raise SnpVerificationError("cert_chain must contain ASK and ARK certificates")
@@ -436,6 +443,13 @@ def verify_vcek_chain(
     vcek = x509.load_der_x509_certificate(vcek_cert_der)
     ask = x509.load_pem_x509_certificate(pems[0])
     ark = x509.load_pem_x509_certificate(pems[1])
+
+    try:
+        check_validity_period(vcek, label="VCEK", verification_time=verification_time)
+        check_validity_period(ask, label="ASK", verification_time=verification_time)
+        check_validity_period(ark, label="ARK", verification_time=verification_time)
+    except CertChainError as e:
+        raise SnpVerificationError(str(e)) from e
 
     pss = padding.PSS(mgf=padding.MGF1(hashes.SHA384()), salt_length=48)
 

--- a/python/src/agent_manifest/_tdx_verify.py
+++ b/python/src/agent_manifest/_tdx_verify.py
@@ -29,7 +29,8 @@ import hashlib
 import hmac
 import struct
 from dataclasses import dataclass
-from typing import Any, Optional
+from datetime import datetime
+from typing import Any
 
 # Intel SGX Provisioning Certification Root CA (public, long-lived). The PCK
 # chain embedded in every quote must chain to this. Pinning it here makes quote
@@ -239,7 +240,12 @@ def _verify_raw_ecdsa(pub: Any, raw_sig: bytes, msg: bytes) -> None:
     pub.verify(utils.encode_dss_signature(r, s), msg, ec.ECDSA(hashes.SHA256()))
 
 
-def verify_tdx_quote(quote: bytes, *, trusted_root_pem: Optional[bytes] = None) -> bool:
+def verify_tdx_quote(
+    quote: bytes,
+    *,
+    trusted_root_pem: bytes | None = None,
+    verification_time: datetime | None = None,
+) -> bool:
     """Fully verify an Intel TDX v4 DCAP quote (all four steps, fail-closed).
 
     Returns True only when the attestation-key signature, the QE binding, the
@@ -248,6 +254,11 @@ def verify_tdx_quote(quote: bytes, *, trusted_root_pem: Optional[bytes] = None) 
     malformed quote / broken chain or if ``cryptography`` is unavailable; returns
     False on a well-formed-but-invalid signature.
 
+    Every certificate in the PCK chain must be within its validity period (see
+    :func:`._cert_chain.check_validity_period`); an expired PCK leaf,
+    intermediate, or root is rejected even if every signature in the chain is
+    otherwise valid.
+
     ``trusted_root_pem`` overrides the embedded Intel root (for testing).
     """
     try:
@@ -255,6 +266,8 @@ def verify_tdx_quote(quote: bytes, *, trusted_root_pem: Optional[bytes] = None) 
         from cryptography.exceptions import InvalidSignature
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.asymmetric import ec
+
+        from ._cert_chain import CertChainError, check_validity_period
     except ImportError as e:  # pragma: no cover
         raise TdxVerificationError(
             "TDX quote verification requires the 'cryptography' package"
@@ -280,6 +293,14 @@ def verify_tdx_quote(quote: bytes, *, trusted_root_pem: Optional[bytes] = None) 
     if len(certs) < 2:
         raise TdxVerificationError("PCK chain must contain at least a leaf and the root")
     pck = certs[0]
+
+    for i, c in enumerate(certs):
+        try:
+            check_validity_period(
+                c, label=f"PCK chain certificate at position {i}", verification_time=verification_time
+            )
+        except CertChainError as e:
+            raise TdxVerificationError(str(e)) from e
 
     # Step 3: the PCK certificate signs the QE report.
     pck_pub = pck.public_key()

--- a/python/src/agent_manifest/_tpm_verify.py
+++ b/python/src/agent_manifest/_tpm_verify.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 import hmac
 import struct
 from dataclasses import dataclass
-from typing import Optional
+from datetime import datetime
 
 TPM_GENERATED_VALUE = 0xFF544347
 TPM_ST_ATTEST_NV = 0x8014
@@ -292,7 +292,9 @@ def parse_tpmt_signature(blob: bytes) -> ParsedSignature:
             return ParsedSignature(sig_alg, hash_alg, blob[offset - size:offset])
 
         if sig_alg == _ALG_ECDSA:
-            from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+            from cryptography.hazmat.primitives.asymmetric.utils import (
+                encode_dss_signature,
+            )
 
             parts: list[bytes] = []
             for _ in range(2):
@@ -319,8 +321,18 @@ def parse_tpmt_signature(blob: bytes) -> ParsedSignature:
     raise TpmVerificationError(f"unsupported signature algorithm 0x{sig_alg:04x}")
 
 
-def _verify_ak_chain(ak_chain_pem: bytes, trusted_roots_pem: bytes) -> "object":
+def _verify_ak_chain(
+    ak_chain_pem: bytes,
+    trusted_roots_pem: bytes,
+    *,
+    verification_time: datetime | None = None,
+) -> object:
     """Verify a leaf-first AK chain up to a pinned trusted root; return the leaf.
+
+    Every certificate in the chain must be within its validity period (see
+    :func:`._cert_chain.check_validity_period`); an expired AK certificate or
+    an expired link above it is rejected even if every signature in the chain
+    is otherwise valid.
 
     Raises :class:`TpmVerificationError` on any failure.
     """
@@ -328,12 +340,22 @@ def _verify_ak_chain(ak_chain_pem: bytes, trusted_roots_pem: bytes) -> "object":
     from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.primitives.hashes import SHA256
 
+    from ._cert_chain import CertChainError, check_validity_period
+
     chain = x509.load_pem_x509_certificates(ak_chain_pem)
     roots = x509.load_pem_x509_certificates(trusted_roots_pem)
     if not chain:
         raise TpmVerificationError("empty AK certificate chain")
     if not roots:
         raise TpmVerificationError("no trusted TPM roots supplied")
+
+    for i, cert in enumerate(chain):
+        try:
+            check_validity_period(
+                cert, label=f"AK chain certificate at position {i}", verification_time=verification_time
+            )
+        except CertChainError as e:
+            raise TpmVerificationError(str(e)) from e
 
     for i in range(len(chain) - 1):
         try:
@@ -357,8 +379,9 @@ def verify_tpm_quote(
     ak_chain_pem: bytes,
     *,
     trusted_roots_pem: bytes,
-    expected_qualifying_data: Optional[bytes] = None,
-    expected_pcr_digest: Optional[bytes] = None,
+    expected_qualifying_data: bytes | None = None,
+    expected_pcr_digest: bytes | None = None,
+    verification_time: datetime | None = None,
 ) -> bool:
     """Fully verify a TPM 2.0 quote offline (all four steps, fail-closed).
 
@@ -373,6 +396,9 @@ def verify_tpm_quote(
         expected_qualifying_data: if given, the quote's ``extraData`` (nonce)
             must equal it.
         expected_pcr_digest: if given, the quote's PCR digest must equal it.
+        verification_time: UTC-aware time used to check AK chain certificate
+            validity periods (default: current UTC time). Primarily useful
+            for deterministic tests.
 
     Returns:
         ``True`` only when the structure, AK chain, AK signature, and any
@@ -403,7 +429,7 @@ def verify_tpm_quote(
         )
 
     # Step 2: AK certificate chain up to a pinned trusted root.
-    ak = _verify_ak_chain(ak_chain_pem, trusted_roots_pem)
+    ak = _verify_ak_chain(ak_chain_pem, trusted_roots_pem, verification_time=verification_time)
     ak_key = ak.public_key()  # type: ignore[attr-defined]
 
     # Step 3: AK signature over the TPMS_ATTEST blob. Use quote.raw rather than

--- a/python/tests/test_snp_verify.py
+++ b/python/tests/test_snp_verify.py
@@ -18,9 +18,13 @@ import hashlib
 import pathlib
 
 import pytest
-
 from agent_manifest._snp_verify import (
+    _OFF_SIGNATURE,
+    _SIG_COMPONENT_BYTES,
+    _SIG_COMPONENT_STRIDE,
+    _SNP_REPORT_LEN,
     PLATFORM_INFO_BITS,
+    SIG_ALGO_ECDSA_P384_SHA384,
     SnpVerificationError,
     appraise_platform_info,
     parse_hcl_report,
@@ -29,11 +33,6 @@ from agent_manifest._snp_verify import (
     verify_runtime_data_binding,
     verify_snp_signature,
     verify_vcek_chain,
-    _OFF_SIGNATURE,
-    SIG_ALGO_ECDSA_P384_SHA384,
-    _SIG_COMPONENT_BYTES,
-    _SIG_COMPONENT_STRIDE,
-    _SNP_REPORT_LEN,
 )
 
 VECTORS = pathlib.Path(__file__).parent / "vectors" / "snp"
@@ -243,6 +242,73 @@ def test_verify_vcek_chain_requires_two_certs():
 
 
 # ---------------------------------------------------------------------------
+# CERT-011: every certificate in the chain must be within its validity
+# period. verify_vcek_chain used to check signatures only; a VCEK, ASK, or
+# ARK whose validity window had already expired still verified successfully.
+# ---------------------------------------------------------------------------
+
+
+def _rsa_pss_chain_at(not_before, not_after):
+    """Like ``_rsa_pss_chain`` but with a caller-chosen validity window."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
+    from cryptography.hazmat.primitives.serialization import Encoding
+    from cryptography.x509.oid import NameOID
+
+    pss = padding.PSS(mgf=padding.MGF1(hashes.SHA384()), salt_length=48)
+
+    def key():
+        return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    def cert(subj, pub, issuer_name, issuer_key):
+        return (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subj)]))
+            .issuer_name(issuer_name)
+            .public_key(pub)
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_before)
+            .not_valid_after(not_after)
+            .sign(issuer_key, hashes.SHA384(), rsa_padding=pss)
+        )
+
+    ark_key, ask_key, vcek_key = key(), key(), key()
+    ark_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "ARK-test")])
+    ask_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "ASK-test")])
+    ark = cert("ARK-test", ark_key.public_key(), ark_name, ark_key)
+    ask = cert("ASK-test", ask_key.public_key(), ark_name, ark_key)
+    vcek = cert("SEV-VCEK-test", vcek_key.public_key(), ask_name, ask_key)
+    chain = ask.public_bytes(Encoding.PEM) + ark.public_bytes(Encoding.PEM)
+    return vcek.public_bytes(Encoding.DER), chain, ark.public_bytes(Encoding.DER)
+
+
+def test_verify_vcek_chain_rejects_expired_chain():
+    from datetime import datetime, timezone
+
+    vcek_der, chain_pem, _ = _rsa_pss_chain_at(
+        datetime(2015, 1, 1, tzinfo=timezone.utc),
+        datetime(2016, 1, 1, tzinfo=timezone.utc),  # expired a decade ago
+    )
+    with pytest.raises(SnpVerificationError, match="outside its validity period"):
+        verify_vcek_chain(vcek_der, chain_pem)
+
+
+def test_verify_vcek_chain_accepts_within_pinned_verification_time():
+    from datetime import datetime, timezone
+
+    not_before = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    not_after = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    vcek_der, chain_pem, _ = _rsa_pss_chain_at(not_before, not_after)
+    # A verification_time inside the window passes even though "now" (2026)
+    # is well past not_after this is what makes the check testable/
+    # deterministic rather than only ever checkable against wall-clock time.
+    assert verify_vcek_chain(
+        vcek_der, chain_pem, verification_time=datetime(2024, 6, 1, tzinfo=timezone.utc)
+    ) is True
+
+
+# ---------------------------------------------------------------------------
 # Declared signature algorithm and cert-bundle loading (union, agent-manifest 0.9)
 # ---------------------------------------------------------------------------
 
@@ -330,10 +396,9 @@ def test_load_snp_cert_chain_rejects_the_kds_cert_chain_endpoint_output():
     """AMD KDS's `cert_chain` endpoint returns ASK + ARK with no VCEK. Passing it
     whole is a real, recorded deployment mistake, so it must fail loudly rather
     than proceed with two of the three."""
+    from agent_manifest import load_snp_cert_chain
     from cryptography import x509
     from cryptography.hazmat.primitives.serialization import Encoding
-
-    from agent_manifest import load_snp_cert_chain
 
     certs = x509.load_pem_x509_certificates(_snp_shaped_bundle())
     ask_and_ark = b"".join(

--- a/python/tests/test_tdx_verify.py
+++ b/python/tests/test_tdx_verify.py
@@ -23,11 +23,11 @@ from agent_manifest._tdx_verify import (
 
 crypto = pytest.importorskip("cryptography")
 
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec, utils
-from cryptography.hazmat.primitives.serialization import Encoding
-from cryptography.x509.oid import NameOID
+from cryptography import x509  # noqa: E402
+from cryptography.hazmat.primitives import hashes  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import ec, utils  # noqa: E402
+from cryptography.hazmat.primitives.serialization import Encoding  # noqa: E402
+from cryptography.x509.oid import NameOID  # noqa: E402
 
 _HDR = 48
 _BODY = 584

--- a/python/tests/test_tdx_verify.py
+++ b/python/tests/test_tdx_verify.py
@@ -14,7 +14,6 @@ import os
 import struct
 
 import pytest
-
 from agent_manifest._tdx_verify import (
     TdxVerificationError,
     parse_tdx_quote,
@@ -24,11 +23,11 @@ from agent_manifest._tdx_verify import (
 
 crypto = pytest.importorskip("cryptography")
 
-from cryptography import x509  # noqa: E402
-from cryptography.hazmat.primitives import hashes  # noqa: E402
-from cryptography.hazmat.primitives.asymmetric import ec, utils  # noqa: E402
-from cryptography.hazmat.primitives.serialization import Encoding  # noqa: E402
-from cryptography.x509.oid import NameOID  # noqa: E402
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
 
 _HDR = 48
 _BODY = 584
@@ -128,6 +127,91 @@ def test_parse_rejects_wrong_tee_type():
 def test_verify_full_chain_ok():
     quote, root_pem = _build_quote(hashlib.sha256(b"pre").digest())
     assert verify_tdx_quote(quote, trusted_root_pem=root_pem) is True
+
+
+# ---------------------------------------------------------------------------
+# CERT-011: every certificate in the PCK chain must be within its validity
+# period. verify_tdx_quote used to check signatures only; a PCK leaf,
+# intermediate, or root whose validity window had already expired still
+# verified successfully.
+# ---------------------------------------------------------------------------
+
+
+def _build_quote_at(report_data_digest, not_before, not_after, mrtd: bytes = b"\x11" * 48):
+    """Like ``_build_quote`` but the PCK chain gets a caller-chosen validity window."""
+    def _cert_at(subject, pub, issuer_name, issuer_key, ca=False):
+        b = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject)]))
+            .issuer_name(issuer_name)
+            .public_key(pub)
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_before)
+            .not_valid_after(not_after)
+        )
+        if ca:
+            b = b.add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        return b.sign(issuer_key, hashes.SHA256())
+
+    header = struct.pack("<HHI", 4, 2, 0x81) + bytes(40)
+    body = bytearray(_BODY)
+    body[136:136 + 48] = mrtd
+    body[520:520 + 32] = report_data_digest
+    signed = header + bytes(body)
+
+    att_key = ec.generate_private_key(ec.SECP256R1())
+    att_pub_nums = att_key.public_key().public_numbers()
+    att_pub = att_pub_nums.x.to_bytes(32, "big") + att_pub_nums.y.to_bytes(32, "big")
+    sig = _raw_sig(att_key, signed)
+
+    qe_auth = b""
+    qe_report = bytearray(384)
+    qe_report[320:352] = hashlib.sha256(att_pub + qe_auth).digest()
+
+    root_key = ec.generate_private_key(ec.SECP256R1())
+    root_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test SGX Root CA")])
+    root = _cert_at("Test SGX Root CA", root_key.public_key(), root_name, root_key, ca=True)
+    int_key = ec.generate_private_key(ec.SECP256R1())
+    int_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test PCK Platform CA")])
+    intermediate = _cert_at("Test PCK Platform CA", int_key.public_key(), root_name, root_key, ca=True)
+    pck_key = ec.generate_private_key(ec.SECP256R1())
+    pck = _cert_at("Test PCK Cert", pck_key.public_key(), int_name, int_key)
+    qe_report_sig = _raw_sig(pck_key, bytes(qe_report))
+
+    pem = pck.public_bytes(Encoding.PEM) + intermediate.public_bytes(Encoding.PEM) + root.public_bytes(Encoding.PEM)
+    cert_data = (
+        bytes(qe_report)
+        + qe_report_sig
+        + struct.pack("<H", len(qe_auth)) + qe_auth
+        + struct.pack("<HI", 5, len(pem)) + pem
+    )
+    auth = sig + att_pub + struct.pack("<HI", 6, len(cert_data)) + cert_data
+    quote = signed + struct.pack("<I", len(auth)) + auth
+    return quote, root.public_bytes(Encoding.PEM)
+
+
+def test_verify_rejects_expired_pck_chain():
+    from datetime import datetime, timezone
+
+    quote, root_pem = _build_quote_at(
+        hashlib.sha256(b"pre").digest(),
+        datetime(2010, 1, 1, tzinfo=timezone.utc),
+        datetime(2011, 1, 1, tzinfo=timezone.utc),  # expired a decade+ ago
+    )
+    with pytest.raises(TdxVerificationError, match="outside its validity period"):
+        verify_tdx_quote(quote, trusted_root_pem=root_pem)
+
+
+def test_verify_accepts_within_pinned_verification_time():
+    from datetime import datetime, timezone
+
+    not_before = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    not_after = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    quote, root_pem = _build_quote_at(hashlib.sha256(b"pre").digest(), not_before, not_after)
+    assert verify_tdx_quote(
+        quote, trusted_root_pem=root_pem,
+        verification_time=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    ) is True
 
 
 def test_verify_rejects_tampered_body():

--- a/python/tests/test_tpm_verify.py
+++ b/python/tests/test_tpm_verify.py
@@ -12,7 +12,7 @@ import pytest
 
 crypto = pytest.importorskip("cryptography")
 
-from agent_manifest._tpm_verify import (  # noqa: E402
+from agent_manifest._tpm_verify import (
     TPM_GENERATED_VALUE,
     TPM_ST_ATTEST_NV,
     TPM_ST_ATTEST_QUOTE,
@@ -24,12 +24,11 @@ from agent_manifest._tpm_verify import (  # noqa: E402
     parse_tpmt_signature,
     verify_tpm_quote,
 )
-
-from cryptography import x509  # noqa: E402
-from cryptography.hazmat.primitives import hashes  # noqa: E402
-from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa  # noqa: E402
-from cryptography.hazmat.primitives.serialization import Encoding  # noqa: E402
-from cryptography.x509.oid import NameOID  # noqa: E402
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
 
 _T0 = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
 
@@ -250,6 +249,63 @@ def test_nv_certify_parsers_are_public_api():
     assert agent_manifest.parse_tpm_attest is parse_tpm_attest
     assert agent_manifest.parse_nv_certify_info is parse_nv_certify_info
     assert agent_manifest.parse_tpm_nv_certify is parse_tpm_nv_certify
+
+
+def _ak_chain_at(not_before, not_after, kind="ec"):
+    """Like ``_ak_chain`` but with a caller-chosen validity window."""
+    def cert_at(subject, subject_pub, issuer, issuer_key, halg=hashes.SHA256()):
+        return (
+            x509.CertificateBuilder()
+            .subject_name(_name(subject))
+            .issuer_name(_name(issuer))
+            .public_key(subject_pub)
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_before)
+            .not_valid_after(not_after)
+            .sign(issuer_key, halg)
+        )
+
+    if kind == "ec":
+        root_key = ec.generate_private_key(ec.SECP256R1())
+        ak_key = ec.generate_private_key(ec.SECP256R1())
+    else:
+        root_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        ak_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    root = cert_at("test-tpm-root", root_key.public_key(), "test-tpm-root", root_key)
+    ak = cert_at("test-ak", ak_key.public_key(), "test-tpm-root", root_key)
+    chain_pem = ak.public_bytes(Encoding.PEM) + root.public_bytes(Encoding.PEM)
+    return ak_key, chain_pem, root.public_bytes(Encoding.PEM)
+
+
+# ---------------------------------------------------------------------------
+# CERT-011: every certificate in the AK chain must be within its validity
+# period. verify_tpm_quote (via _verify_ak_chain) used to check signatures
+# only; an AK certificate or root whose validity window had already expired
+# still verified successfully.
+# ---------------------------------------------------------------------------
+
+
+def test_verify_rejects_expired_ak_chain():
+    ak_key, chain, roots = _ak_chain_at(
+        datetime.datetime(2010, 1, 1, tzinfo=datetime.timezone.utc),
+        datetime.datetime(2011, 1, 1, tzinfo=datetime.timezone.utc),  # expired a decade+ ago
+    )
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+    with pytest.raises(TpmVerificationError, match="outside its validity period"):
+        verify_tpm_quote(attest, sig, chain, trusted_roots_pem=roots)
+
+
+def test_verify_accepts_within_pinned_verification_time():
+    not_before = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    not_after = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    ak_key, chain, roots = _ak_chain_at(not_before, not_after)
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+    assert verify_tpm_quote(
+        attest, sig, chain, trusted_roots_pem=roots,
+        verification_time=datetime.datetime(2024, 6, 1, tzinfo=datetime.timezone.utc),
+    ) is True
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_tpm_verify.py
+++ b/python/tests/test_tpm_verify.py
@@ -12,7 +12,7 @@ import pytest
 
 crypto = pytest.importorskip("cryptography")
 
-from agent_manifest._tpm_verify import (
+from agent_manifest._tpm_verify import (    # noqa: E402
     TPM_GENERATED_VALUE,
     TPM_ST_ATTEST_NV,
     TPM_ST_ATTEST_QUOTE,
@@ -24,11 +24,11 @@ from agent_manifest._tpm_verify import (
     parse_tpmt_signature,
     verify_tpm_quote,
 )
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
-from cryptography.hazmat.primitives.serialization import Encoding
-from cryptography.x509.oid import NameOID
+from cryptography import x509  # noqa: E402
+from cryptography.hazmat.primitives import hashes  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa  # noqa: E402
+from cryptography.hazmat.primitives.serialization import Encoding  # noqa: E402
+from cryptography.x509.oid import NameOID  # noqa: E402
 
 _T0 = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
 


### PR DESCRIPTION
## What

Three hardware-attestation verifiers each carry their own, independent certificate-chain verification logic instead of using the shared, more rigorous verify_cert_chain in _cert_chain.py:

_snp_verify.py -> verify_vcek_chain (AMD SEV-SNP: VCEK <- ASK <- ARK)
_tdx_verify.py -> verify_tdx_quote (Intel TDX: PCK leaf <- intermediate <- Intel SGX Root CA)
_tpm_verify.py -> _verify_ak_chain (TPM 2.0: AK <- vendor root)

All three checked signatures only. None of them checked that any certificate in the chain was within its validity period (not_valid_before / not_valid_after) the single most basic check any X.509 relying party is expected to perform (RFC 5280). An expired-but-otherwise-cryptographically-valid certificate at any position in any of the three chains verified successfully.

_cert_chain.py's own module docstring already claims: "the AMD-specific _snp_verify.verify_vcek_chain is a thin specialisation of it [the generic verify_cert_chain]". In the code as it stood, that was not true grepping all three verifier files for any reference to _cert_chain returns nothing; none of them imported from or called into it at all.

## Why

An attestation certificate's validity window is one of the mechanisms that bounds how long a given hardware/firmware/microcode state stays trusted AMD, Intel, and TPM vendors reissue these certificates (VCEK is explicitly re-issued per reported TCB/security-patch-level on AMD's KDS) precisely so that certificates tied to a since-superseded state stop being accepted. Skipping the validity-period check means a report or quote signed under an old, expired certificate including one whose corresponding key material or platform state is no longer considered trustworthy is still accepted indefinitely, with no time bound at all.

## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [ ] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
