### PR TITLE
docs(spec): §3.5 clarify that approval_duration_seconds bounds the window, not the currency, of an approval

### DIFF
--- a/spec/agent-manifest-spec-v0.2.md
+++ b/spec/agent-manifest-spec-v0.2.md
@@ -1026,6 +1026,8 @@ If the permitted actions span tiers, the highest tier applies. If reversibility 
 
 At Level 2, a verifier MUST return `APPROVAL_INSUFFICIENT` when any otherwise-current approval uses `software-key`, or when a `high` or `critical` approval uses anything other than `hardware-key`. The overall result MUST be `MISMATCH`. Level 0 records the declared method without making a regulatory-strength claim; Level 1 deployments define their minimum method in relying-party policy.
 
+`approval_duration_seconds` bounds the window in which an approval may be presented, not the period for which the reasoning behind it remains sound. Expiry and admissibility are separate questions: an approval can run out while nothing it relied on has changed, and it can remain unexpired after the basis on which it was given has ceased to hold. A verifier evaluating `approved_at + approval_duration_seconds > now` establishes only that the approval is within its declared window. It does not establish that the approval is still applicable, and a `VALID` result therefore MUST NOT be represented as proof that the grounds for the approval still obtain.
+
 `hitl_runtime` block declares the runtime human oversight capabilities required by EU AI Act Art. 14(4) operational oversight obligations. The `hitl_record.approvals` structure satisfies Art. 14 pre-deployment documentation obligations (Art. 14(4)(b)-(e)). The `hitl_runtime` block separately addresses the runtime stop/override capability requirement (Art. 14(4)(a)). Both are required for full Art. 14 compliance. See section 9.1 for the regulatory mapping. <!-- CHANGED: REG-001 -->
 
 Each `approval_signature` is produced by the approver's hardware-backed key (FIDO2/passkey at minimum, HSM for high-risk approvals).


### PR DESCRIPTION
## What

Adds one paragraph to §3.5 stating that `approval_duration_seconds` bounds the window in which an approval may be presented, not the period for which its grounds remain sound, and that a `VALID` result is not proof that those grounds still obtain.

## Why

§3.5 defines `approval_duration_seconds` as a required positive integer without saying what it bounds. Verification checks `approved_at + approval_duration_seconds > now`, so a reader can reasonably infer that an unexpired approval is a sound one. Expiry and admissibility are different questions, and the spec does not currently say so.

Follows the maintainer ruling in #348, which listed this among the items that can move without an organisational sponsor on the grounds that it states what is already true.

The wording deliberately mirrors the existing `risk_tier` caveat a few paragraphs above, which already establishes this pattern in the same section: a verifier proves only what was signed, and a `VALID` result MUST NOT be represented as proof that the declaration was correct.

## Spec impact

Section changed: §3.5 Human-in-the-Loop Approval Records, v0.2.

Normative delta: none. No RFC 2119 keyword is added that binds a producer. The single MUST NOT is a constraint on how a verification result may be represented, which restates the existing `risk_tier` treatment rather than introducing a new obligation.

Conformance test IDs: none. No existing vector changes behaviour and no new vector is required.

The same clarification would hold for v0.1 §3.5. I have left that out to keep the diff to one file, and can add it if preferred.

## Test plan

- [ ] `pytest -v` passes
- [ ] `mypy src/agent_manifest` passes
- [ ] `ruff check src/ tests/` passes
- [ ] New or updated tests cover the change
- [ ] If spec change: `CHANGELOG.md` updated

Documentation only, so the code checks above do not apply and no tests are affected. On the last item: this touches spec prose without a normative delta, so I have not added a CHANGELOG entry. Happy to add one if you would rather every spec-file edit be recorded there.

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).

Drafting and repository inspection were AI-assisted. §3.5, the `risk_tier` paragraph, and the verification behaviour in `_verify.py` were read against current main before writing.