### PR TITLE
fix(delegation): validate structure before interpretation

### DIFF
--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -233,11 +233,9 @@ def verify_delegation_chain(
     if not delegation_chain:
         return
 
-    # Structure is a prerequisite for every later interpretation of a hop.
-    # Establish it once for the complete chain before root binding, depth,
-    # signatures, or scope comparisons consume nested fields.
-    for i, hop in enumerate(delegation_chain):
-        _validate_hop_structure(hop, i)
+    # The root is interpreted before the verification loop, so establish its
+    # structure before the root-binding and depth reads below.
+    _validate_hop_structure(delegation_chain[0], 0)
 
     # Bind the chain root to the manifest's signing identity. The root hop
     # establishes the authority the rest of the chain narrows from, so it must
@@ -271,6 +269,9 @@ def verify_delegation_chain(
     prev_scope: Optional[dict[str, Any]] = None
 
     for i, hop in enumerate(delegation_chain):
+        if i:
+            _validate_hop_structure(hop, i)
+
         if hop.get("hop") != i:
             raise ValueError(f"Hop {i} has wrong hop index: {hop.get('hop')}")
 

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -56,6 +56,15 @@ _REQUIRED_HOP_FIELDS = frozenset({
 _SCOPE_LIST_FIELDS = ("tools", "data_classifications", "constraints")
 
 
+def _is_json_integer(value: Any) -> bool:
+    """True for JSON-Schema integer values, excluding Python booleans."""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    return isinstance(value, float) and value.is_integer()
+
+
 def delegation_depth_exceeded(chain_length: int, root_max_depth: int) -> bool:
     """Single depth rule shared by the Pydantic models and this verifier.
 
@@ -132,16 +141,14 @@ def _validate_scope_structure(scope: Any, hop_index: int) -> None:
             )
 
     depth = scope.get("max_delegation_depth", DEFAULT_MAX_DELEGATION_DEPTH)
-    if isinstance(depth, bool) or not isinstance(depth, int) or depth < 0:
+    if not _is_json_integer(depth) or depth < 0:
         raise ValueError(
             f"Delegation hop {hop_index} scope_grant.max_delegation_depth "
             "must be a non-negative integer"
         )
 
     ttl = scope.get("ttl_seconds")
-    if ttl is not None and (
-        isinstance(ttl, bool) or not isinstance(ttl, int) or ttl < 1
-    ):
+    if ttl is not None and (not _is_json_integer(ttl) or ttl < 1):
         raise ValueError(
             f"Delegation hop {hop_index} scope_grant.ttl_seconds "
             "must be a positive integer or null"

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -173,6 +173,13 @@ def _validate_hop_structure(hop: Any, hop_index: int) -> None:
             f"Delegation hop {hop_index} missing required fields: {sorted(missing)}"
         )
 
+    hop_value = hop["hop"]
+    if not _is_json_integer(hop_value):
+        raise ValueError(
+            f"Delegation hop {hop_index} hop must be a JSON integer, "
+            f"got {type(hop_value).__name__}"
+        )
+
     principal_type = hop["principal_type"]
     valid_principal_types = _valid_principal_types()
     if not isinstance(principal_type, str) or principal_type not in valid_principal_types:
@@ -186,6 +193,12 @@ def _validate_hop_structure(hop: Any, hop_index: int) -> None:
     if not isinstance(principal_id, str) or not principal_id.strip():
         raise ValueError(
             f"Delegation hop {hop_index} has empty or non-string principal_id"
+        )
+
+    delegated_at = hop["delegated_at"]
+    if not isinstance(delegated_at, str):
+        raise ValueError(
+            f"Delegation hop {hop_index} delegated_at must be a string"
         )
 
     principal_manifest_id = hop.get("principal_manifest_id")

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -53,6 +53,7 @@ _REQUIRED_HOP_FIELDS = frozenset({
     "hop", "principal_id", "principal_type", "delegated_at",
     "scope_grant", "delegation_signature",
 })
+_SCOPE_LIST_FIELDS = ("tools", "data_classifications", "constraints")
 
 
 def delegation_depth_exceeded(chain_length: int, root_max_depth: int) -> bool:
@@ -115,31 +116,83 @@ class DelegationHopSigner:
         return base64.urlsafe_b64encode(sig_bytes).rstrip(b"=").decode()
 
 
-def _validate_hop_structure(hop: dict[str, Any], hop_index: int) -> None:
+def _validate_scope_structure(scope: Any, hop_index: int) -> None:
+    """Establish the scope types this verifier reads before interpreting them."""
+    if not isinstance(scope, dict):
+        raise ValueError(
+            f"Delegation hop {hop_index} scope_grant must be an object, "
+            f"got {type(scope).__name__}"
+        )
+
+    for field in _SCOPE_LIST_FIELDS:
+        value = scope.get(field, [])
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError(
+                f"Delegation hop {hop_index} scope_grant.{field} must be a list of strings"
+            )
+
+    depth = scope.get("max_delegation_depth", DEFAULT_MAX_DELEGATION_DEPTH)
+    if isinstance(depth, bool) or not isinstance(depth, int) or depth < 0:
+        raise ValueError(
+            f"Delegation hop {hop_index} scope_grant.max_delegation_depth "
+            "must be a non-negative integer"
+        )
+
+    ttl = scope.get("ttl_seconds")
+    if ttl is not None and (
+        isinstance(ttl, bool) or not isinstance(ttl, int) or ttl < 1
+    ):
+        raise ValueError(
+            f"Delegation hop {hop_index} scope_grant.ttl_seconds "
+            "must be a positive integer or null"
+        )
+
+
+def _validate_hop_structure(hop: Any, hop_index: int) -> None:
     """Raise ValueError for structural A2A conformance violations.
 
-    Validates required fields and principal_type per A2A spec §4.2.
-    Called before cryptographic verification so structural errors surface
-    as distinct ValueError rather than IndexError or KeyError.
+    Establishes the shapes and primitive types this verifier reads before
+    cryptographic verification or scope interpretation, so malformed peer data
+    stays inside the documented ``ValueError`` rejection boundary.
     """
+    if not isinstance(hop, dict):
+        raise ValueError(
+            f"Delegation hop {hop_index} must be an object, got {type(hop).__name__}"
+        )
+
     missing = _REQUIRED_HOP_FIELDS - hop.keys()
     if missing:
         raise ValueError(
             f"Delegation hop {hop_index} missing required fields: {sorted(missing)}"
         )
+
     principal_type = hop["principal_type"]
     valid_principal_types = _valid_principal_types()
-    if principal_type not in valid_principal_types:
+    if not isinstance(principal_type, str) or principal_type not in valid_principal_types:
         raise ValueError(
             f"Delegation hop {hop_index} has invalid principal_type {principal_type!r}; "
             f"must be one of {sorted(valid_principal_types)}"
         )
+
     # principal_id must be non-empty string (SPIFFE URI, DID, or mailto)
     principal_id = hop["principal_id"]
     if not isinstance(principal_id, str) or not principal_id.strip():
         raise ValueError(
             f"Delegation hop {hop_index} has empty or non-string principal_id"
         )
+
+    principal_manifest_id = hop.get("principal_manifest_id")
+    if principal_manifest_id is not None and not isinstance(principal_manifest_id, str):
+        raise ValueError(
+            f"Delegation hop {hop_index} principal_manifest_id must be a string when present"
+        )
+
+    if not isinstance(hop["delegation_signature"], str):
+        raise ValueError(
+            f"Delegation hop {hop_index} delegation_signature must be a string"
+        )
+
+    _validate_scope_structure(hop["scope_grant"], hop_index)
 
 
 def verify_delegation_chain(
@@ -173,8 +226,18 @@ def verify_delegation_chain(
         InvalidSignature: If any hop signature is invalid.
         ValueError: If scope laundering is detected or chain is malformed.
     """
+    if not isinstance(delegation_chain, list):
+        raise ValueError(
+            f"delegation_chain must be a list, got {type(delegation_chain).__name__}"
+        )
     if not delegation_chain:
         return
+
+    # Structure is a prerequisite for every later interpretation of a hop.
+    # Establish it once for the complete chain before root binding, depth,
+    # signatures, or scope comparisons consume nested fields.
+    for i, hop in enumerate(delegation_chain):
+        _validate_hop_structure(hop, i)
 
     # Bind the chain root to the manifest's signing identity. The root hop
     # establishes the authority the rest of the chain narrows from, so it must
@@ -208,9 +271,6 @@ def verify_delegation_chain(
     prev_scope: Optional[dict[str, Any]] = None
 
     for i, hop in enumerate(delegation_chain):
-        # Structural validation before any field access (raises ValueError on violation)
-        _validate_hop_structure(hop, i)
-
         if hop.get("hop") != i:
             raise ValueError(f"Hop {i} has wrong hop index: {hop.get('hop')}")
 

--- a/python/tests/test_delegation_structure_boundary.py
+++ b/python/tests/test_delegation_structure_boundary.py
@@ -102,7 +102,7 @@ def test_scope_collection_types_are_established_before_set_operations(field, val
         verify_delegation_chain([root], {}, MID)
 
 
-@pytest.mark.parametrize("value", [True, "3", []])
+@pytest.mark.parametrize("value", [True, "3", [], 3.5])
 def test_max_delegation_depth_type_is_established_before_comparison(value) -> None:
     root = _minimal_hop()
     root["scope_grant"] = {**SCOPE, "max_delegation_depth": value}
@@ -110,12 +110,25 @@ def test_max_delegation_depth_type_is_established_before_comparison(value) -> No
         verify_delegation_chain([root], {}, MID)
 
 
-@pytest.mark.parametrize("value", [True, "60", []])
+@pytest.mark.parametrize("value", [True, "60", [], 60.5])
 def test_ttl_type_is_established_before_comparison(value) -> None:
     root = _minimal_hop()
     root["scope_grant"] = {**SCOPE, "ttl_seconds": value}
     with pytest.raises(ValueError, match="ttl_seconds must be a positive integer or null"):
         verify_delegation_chain([root], {}, MID)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("max_delegation_depth", 3.0), ("ttl_seconds", 3600.0)],
+)
+def test_zero_fraction_numbers_keep_json_integer_semantics(field, value) -> None:
+    root, keys = _signed_hop()
+    root["scope_grant"] = {**SCOPE, field: value}
+    # RFC 8785 serializes 3 and 3.0 (likewise 3600 and 3600.0) identically,
+    # so the original signature remains valid and the verifier must not
+    # over-discriminate on Python's host-language representation.
+    verify_delegation_chain([root], keys, MID)
 
 
 @pytest.mark.parametrize("signature", [1, []])

--- a/python/tests/test_delegation_structure_boundary.py
+++ b/python/tests/test_delegation_structure_boundary.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_manifest import DelegationHopSigner, generate_ed25519, verify_delegation_chain
+
+MID = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+NOW = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+SCOPE = {
+    "tools": ["com.example.read"],
+    "data_classifications": ["internal"],
+    "max_delegation_depth": 3,
+    "ttl_seconds": 3600,
+    "constraints": [],
+}
+
+
+def _signed_hop(*, principal_id: str = "spiffe://x/root"):
+    key = generate_ed25519()
+    signature = DelegationHopSigner(key).sign_hop(
+        hop=0,
+        principal_id=principal_id,
+        principal_type="agent",
+        delegated_at=NOW,
+        scope_grant=SCOPE,
+        manifest_id=MID,
+    )
+    hop = {
+        "hop": 0,
+        "principal_id": principal_id,
+        "principal_type": "agent",
+        "delegated_at": NOW,
+        "scope_grant": dict(SCOPE),
+        "delegation_signature": signature,
+    }
+    return hop, {principal_id: key.public_bytes}
+
+
+def _minimal_hop() -> dict:
+    hop, _ = _signed_hop()
+    return hop
+
+
+def test_valid_single_hop_control_is_unchanged() -> None:
+    hop, keys = _signed_hop()
+    verify_delegation_chain([hop], keys, MID, manifest_issuer=hop["principal_id"])
+
+
+@pytest.mark.parametrize("chain", ["bad", 1, True, {}])
+def test_non_list_chain_uses_documented_value_error(chain) -> None:
+    with pytest.raises(ValueError, match="delegation_chain must be a list"):
+        verify_delegation_chain(chain, {}, MID)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("root", ["bad", ["bad"], 1, True])
+def test_non_object_root_uses_documented_value_error(root) -> None:
+    with pytest.raises(ValueError, match="Delegation hop 0 must be an object"):
+        verify_delegation_chain([root], {}, MID, manifest_issuer="spiffe://x/root")
+
+
+def test_missing_scope_grant_is_reported_before_root_interpretation() -> None:
+    root = _minimal_hop()
+    del root["scope_grant"]
+    with pytest.raises(ValueError, match="missing required fields.*scope_grant"):
+        verify_delegation_chain([root], {}, MID, manifest_issuer="spiffe://x/root")
+
+
+@pytest.mark.parametrize("scope", ["bad", ["bad"], 1, True])
+def test_non_object_scope_grant_uses_documented_value_error(scope) -> None:
+    root = _minimal_hop()
+    root["scope_grant"] = scope
+    with pytest.raises(ValueError, match="scope_grant must be an object"):
+        verify_delegation_chain([root], {}, MID)
+
+
+@pytest.mark.parametrize("principal_type", [["agent"], {"agent": True}])
+def test_unhashable_principal_type_does_not_escape_type_error(principal_type) -> None:
+    root = _minimal_hop()
+    root["principal_type"] = principal_type
+    with pytest.raises(ValueError, match="invalid principal_type"):
+        verify_delegation_chain([root], {}, MID)
+
+
+@pytest.mark.parametrize("principal_manifest_id", [["manifest"], {"id": "manifest"}])
+def test_unhashable_principal_manifest_id_is_refused_before_root_binding(
+    principal_manifest_id,
+) -> None:
+    root = _minimal_hop()
+    root["principal_manifest_id"] = principal_manifest_id
+    with pytest.raises(ValueError, match="principal_manifest_id must be a string"):
+        verify_delegation_chain([root], {}, MID, manifest_issuer="manifest")
+
+
+@pytest.mark.parametrize("field", ["tools", "data_classifications", "constraints"])
+@pytest.mark.parametrize("value", [1, {"x": 1}, [{"x": 1}]])
+def test_scope_collection_types_are_established_before_set_operations(field, value) -> None:
+    root = _minimal_hop()
+    root["scope_grant"] = {**SCOPE, field: value}
+    with pytest.raises(ValueError, match=rf"scope_grant\.{field} must be a list of strings"):
+        verify_delegation_chain([root], {}, MID)
+
+
+@pytest.mark.parametrize("value", [True, "3", []])
+def test_max_delegation_depth_type_is_established_before_comparison(value) -> None:
+    root = _minimal_hop()
+    root["scope_grant"] = {**SCOPE, "max_delegation_depth": value}
+    with pytest.raises(ValueError, match="max_delegation_depth must be a non-negative integer"):
+        verify_delegation_chain([root], {}, MID)
+
+
+@pytest.mark.parametrize("value", [True, "60", []])
+def test_ttl_type_is_established_before_comparison(value) -> None:
+    root = _minimal_hop()
+    root["scope_grant"] = {**SCOPE, "ttl_seconds": value}
+    with pytest.raises(ValueError, match="ttl_seconds must be a positive integer or null"):
+        verify_delegation_chain([root], {}, MID)
+
+
+@pytest.mark.parametrize("signature", [1, []])
+def test_signature_type_is_established_before_len(signature) -> None:
+    root = _minimal_hop()
+    root["delegation_signature"] = signature
+    with pytest.raises(ValueError, match="delegation_signature must be a string"):
+        verify_delegation_chain([root], {}, MID)
+
+
+def test_malformed_later_hop_is_rejected_before_crypto_interpretation() -> None:
+    root = _minimal_hop()
+    later = _minimal_hop()
+    later["hop"] = 1
+    later["scope_grant"] = "bad"
+    with pytest.raises(ValueError, match="Delegation hop 1 scope_grant must be an object"):
+        verify_delegation_chain([root, later], {}, MID)
+
+
+def test_structurally_valid_root_mismatch_keeps_existing_binding_failure() -> None:
+    root = _minimal_hop()
+    with pytest.raises(ValueError, match="does not match the manifest"):
+        verify_delegation_chain([root], {}, MID, manifest_issuer="spiffe://x/other")

--- a/python/tests/test_delegation_structure_boundary.py
+++ b/python/tests/test_delegation_structure_boundary.py
@@ -38,6 +38,34 @@ def _signed_hop(*, principal_id: str = "spiffe://x/root"):
     return hop, {principal_id: key.public_bytes}
 
 
+def _resigned_hop_with_delegated_at(delegated_at):
+    """Build a cryptographically valid hop over the supplied JSON primitive.
+
+    The malformed value is deliberately included in both the record and signed
+    preimage so a rejection proves the structural guard is load-bearing rather
+    than an incidental signature failure.
+    """
+    principal_id = "spiffe://x/root"
+    key = generate_ed25519()
+    signature = DelegationHopSigner(key).sign_hop(
+        hop=0,
+        principal_id=principal_id,
+        principal_type="agent",
+        delegated_at=delegated_at,  # type: ignore[arg-type]
+        scope_grant=SCOPE,
+        manifest_id=MID,
+    )
+    hop = {
+        "hop": 0,
+        "principal_id": principal_id,
+        "principal_type": "agent",
+        "delegated_at": delegated_at,
+        "scope_grant": dict(SCOPE),
+        "delegation_signature": signature,
+    }
+    return hop, {principal_id: key.public_bytes}
+
+
 def _minimal_hop() -> dict:
     hop, _ = _signed_hop()
     return hop
@@ -46,6 +74,12 @@ def _minimal_hop() -> dict:
 def test_valid_single_hop_control_is_unchanged() -> None:
     hop, keys = _signed_hop()
     verify_delegation_chain([hop], keys, MID, manifest_issuer=hop["principal_id"])
+
+
+def test_valid_delegated_at_timestamp_string_remains_accepted() -> None:
+    hop, keys = _signed_hop()
+    assert isinstance(hop["delegated_at"], str)
+    verify_delegation_chain([hop], keys, MID)
 
 
 @pytest.mark.parametrize("chain", ["bad", 1, True, {}])
@@ -91,6 +125,39 @@ def test_unhashable_principal_manifest_id_is_refused_before_root_binding(
     root["principal_manifest_id"] = principal_manifest_id
     with pytest.raises(ValueError, match="principal_manifest_id must be a string"):
         verify_delegation_chain([root], {}, MID, manifest_issuer="manifest")
+
+
+def test_false_hop_is_rejected_before_bool_int_equivalence_can_apply() -> None:
+    root, keys = _signed_hop()
+    # Keep the valid signature over integer hop 0. Before this guard, False == 0
+    # let the record pass the index check and the verifier rebuilt the signed
+    # preimage with integer i=0, so this malformed record verified successfully.
+    root["hop"] = False
+    with pytest.raises(ValueError, match="hop must be a JSON integer"):
+        verify_delegation_chain([root], keys, MID)
+
+
+@pytest.mark.parametrize("hop_value", [True, "0", [], {}, 0.5])
+def test_non_json_integer_hop_primitives_are_refused_before_comparison(hop_value) -> None:
+    root = _minimal_hop()
+    root["hop"] = hop_value
+    with pytest.raises(ValueError, match="hop must be a JSON integer"):
+        verify_delegation_chain([root], {}, MID)
+
+
+def test_zero_fraction_hop_keeps_json_integer_semantics() -> None:
+    root, keys = _signed_hop()
+    root["hop"] = 0.0
+    # RFC 8785 canonicalizes 0 and 0.0 identically, matching the intentional
+    # JSON-Schema integer semantics already used by the scope integer guards.
+    verify_delegation_chain([root], keys, MID)
+
+
+@pytest.mark.parametrize("delegated_at", [None, False, 0, [], {}])
+def test_resigned_non_string_delegated_at_is_refused_before_preimage(delegated_at) -> None:
+    root, keys = _resigned_hop_with_delegated_at(delegated_at)
+    with pytest.raises(ValueError, match="delegated_at must be a string"):
+        verify_delegation_chain([root], keys, MID)
 
 
 @pytest.mark.parametrize("field", ["tools", "data_classifications", "constraints"])

--- a/python/tests/test_delegation_structure_boundary.py
+++ b/python/tests/test_delegation_structure_boundary.py
@@ -126,13 +126,13 @@ def test_signature_type_is_established_before_len(signature) -> None:
         verify_delegation_chain([root], {}, MID)
 
 
-def test_malformed_later_hop_is_rejected_before_crypto_interpretation() -> None:
-    root = _minimal_hop()
+def test_malformed_later_hop_is_rejected_before_its_crypto_interpretation() -> None:
+    root, keys = _signed_hop()
     later = _minimal_hop()
     later["hop"] = 1
     later["scope_grant"] = "bad"
     with pytest.raises(ValueError, match="Delegation hop 1 scope_grant must be an object"):
-        verify_delegation_chain([root, later], {}, MID)
+        verify_delegation_chain([root, later], keys, MID)
 
 
 def test_structurally_valid_root_mismatch_keeps_existing_binding_failure() -> None:


### PR DESCRIPTION
## What

Closes #356.

`verify_delegation_chain()` now establishes structural prerequisites before each part of a chain is interpreted:

- the root is validated before root/manifest binding and root-depth reads;
- each later hop is validated when verification reaches that hop, before that hop's signature or scope is interpreted.

The existing `_validate_hop_structure()` remains the verifier-side structural authority. It now establishes the object/primitive shapes that downstream verifier code assumes before using `.get()`, set construction, numeric comparison, or signature decoding.

For integer-valued scope fields, the guard follows JSON/JSON-Schema semantics rather than Python's host-language type hierarchy: booleans are refused, ordinary integers are accepted, and zero-fraction numeric values such as `3.0` / `3600.0` remain accepted. No parsed/normalized model is substituted into the signed preimage.

## Why

The old ordering read the root before `_validate_hop_structure()` ran. A non-object root, a missing/non-object `scope_grant`, or other malformed nested values could therefore escape as incidental `AttributeError`, `KeyError`, or `TypeError` even though this public API documents malformed chains as `ValueError`.

The main verification engine catches `InvalidSignature` and `ValueError` around delegation verification, so those host-language exceptions could also escape its intended fail-closed boundary.

## Regression evidence

The public-API matrix covers:

- non-list chains and non-object roots;
- missing/non-object `scope_grant`;
- malformed `principal_type`, optional `principal_manifest_id`, collection-valued scope fields, depth/TTL values, and signatures that would otherwise reach host-language operations;
- boolean/fractional numeric refusal plus `3`/`3.0` and `3600`/`3600.0` equivalence controls;
- a malformed later hop reached only after a valid signed root and trusted root key;
- valid single-hop control;
- the existing structurally-valid root/issuer mismatch behavior.

The later-hop control deliberately supplies a valid root and trusted key so its structural boundary, rather than an earlier key/signature failure, is load-bearing.

## Scope / non-claims

No schema, wire-format, delegation-authority, signature-preimage, or scope-narrowing rule is changed. This is prerequisite ordering and exception-safety.

The implementation deliberately preserves sequential failure ordering: a malformed later hop does not pre-empt an earlier failure while interpreting the root.

This is separate from #353, which changes TTL narrowing semantics.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial matrix design, mutation-oriented review, and drafting. `altrudev` reviewed the bounded claim and remains responsible for the contribution.