### PR TITLE
fix(transparency): fail closed on malformed Rekor responses

### DIFF
--- a/python/src/agent_manifest/_transparency.py
+++ b/python/src/agent_manifest/_transparency.py
@@ -175,7 +175,7 @@ def verify_transparency_log_entry(
         body = response.json()
         if not isinstance(body, dict):
             return False
-        entry_data = next(iter(body.values()), {})
+        entry_data: Any = next(iter(body.values()), {})
         if not isinstance(entry_data, dict):
             return False
         encoded_body = entry_data.get("body", "e30=")

--- a/python/src/agent_manifest/_transparency.py
+++ b/python/src/agent_manifest/_transparency.py
@@ -171,12 +171,32 @@ def verify_transparency_log_entry(
     if response.status_code != 200:
         return False
 
-    body = response.json()
-    entry_data: dict[str, Any] = next(iter(body.values()), {})
-    decoded = json.loads(base64.b64decode(entry_data.get("body", "e30=")))
-    actual_hash = (
-        decoded.get("spec", {}).get("data", {}).get("hash", {}).get("value", "")
-    )
+    try:
+        body = response.json()
+        if not isinstance(body, dict):
+            return False
+        entry_data = next(iter(body.values()), {})
+        if not isinstance(entry_data, dict):
+            return False
+        encoded_body = entry_data.get("body", "e30=")
+        if not isinstance(encoded_body, (str, bytes)):
+            return False
+        decoded = json.loads(base64.b64decode(encoded_body))
+        if not isinstance(decoded, dict):
+            return False
+        spec = decoded.get("spec", {})
+        if not isinstance(spec, dict):
+            return False
+        data = spec.get("data", {})
+        if not isinstance(data, dict):
+            return False
+        hash_data = data.get("hash", {})
+        if not isinstance(hash_data, dict):
+            return False
+        actual_hash = hash_data.get("value", "")
+    except (AttributeError, TypeError, ValueError):
+        return False
+
     return bool(actual_hash == expected_hash)
 
 

--- a/python/tests/test_transparency_malformed_response.py
+++ b/python/tests/test_transparency_malformed_response.py
@@ -1,0 +1,118 @@
+"""Regression vectors for malformed Rekor verification responses (#358)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_manifest._canonicalize import canonicalize
+from agent_manifest._transparency import (
+    TransparencyLogEntry,
+    verify_transparency_log_entry,
+)
+
+
+ENTRY = TransparencyLogEntry(
+    log_id="test-log",
+    entry_id="test-entry",
+    inclusion_proof="proof",
+)
+MANIFEST: dict = {}
+
+
+def _response_with_json(value) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = value
+    return response
+
+
+def _encoded(value) -> str:
+    return base64.b64encode(json.dumps(value).encode()).decode()
+
+
+def _verify(response: MagicMock) -> bool:
+    with patch("httpx.get", return_value=response):
+        return verify_transparency_log_entry(MANIFEST, ENTRY)
+
+
+def test_valid_matching_200_control_remains_true() -> None:
+    expected_hash = hashlib.sha256(canonicalize({})).hexdigest()
+    response = _response_with_json(
+        {
+            ENTRY.entry_id: {
+                "body": _encoded(
+                    {
+                        "spec": {
+                            "data": {
+                                "hash": {
+                                    "algorithm": "sha256",
+                                    "value": expected_hash,
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+        }
+    )
+
+    assert _verify(response) is True
+
+
+def test_invalid_response_json_returns_false() -> None:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.side_effect = ValueError("invalid JSON")
+
+    assert _verify(response) is False
+
+
+@pytest.mark.parametrize("body", [[], "bad", None, 1, True])
+def test_non_object_top_level_response_returns_false(body) -> None:
+    assert _verify(_response_with_json(body)) is False
+
+
+@pytest.mark.parametrize("entry_data", ["bad", [], None, 1, True])
+def test_non_object_entry_data_returns_false(entry_data) -> None:
+    assert _verify(_response_with_json({ENTRY.entry_id: entry_data})) is False
+
+
+@pytest.mark.parametrize(
+    "encoded_body",
+    [
+        "not valid base64 !!!",
+        base64.b64encode(b"not-json").decode(),
+    ],
+)
+def test_unparseable_encoded_body_returns_false(encoded_body: str) -> None:
+    response = _response_with_json({ENTRY.entry_id: {"body": encoded_body}})
+    assert _verify(response) is False
+
+
+@pytest.mark.parametrize("decoded", [[], "bad", None, 1, True])
+def test_non_object_decoded_body_returns_false(decoded) -> None:
+    response = _response_with_json(
+        {ENTRY.entry_id: {"body": _encoded(decoded)}}
+    )
+    assert _verify(response) is False
+
+
+@pytest.mark.parametrize(
+    "decoded",
+    [
+        {"spec": "bad"},
+        {"spec": {"data": "bad"}},
+        {"spec": {"data": {"hash": "bad"}}},
+        {"spec": {"data": {"hash": []}}},
+    ],
+)
+def test_non_object_nested_hash_containers_return_false(decoded: dict) -> None:
+    response = _response_with_json(
+        {ENTRY.entry_id: {"body": _encoded(decoded)}}
+    )
+    assert _verify(response) is False


### PR DESCRIPTION
## What

Closes #358.

`verify_transparency_log_entry()` now keeps malformed successful Rekor responses inside its existing boolean verification boundary instead of allowing response-parsing or nested-shape exceptions to escape.

The valid path and all existing status/network behavior are unchanged:

- matching 200 response -> `True`;
- non-200/network failure -> `False`;
- missing/mismatching evidence -> `False`;
- malformed/unparseable 200 response -> `False`.

## Why

The function already treats Rekor as external verification evidence and returns `False` for network errors, 404/500 responses, hash mismatches, and a missing body. But response parsing after a 200 was outside that failure boundary. Invalid JSON, non-object response shapes, invalid encoded bodies, or malformed nested hash containers could therefore leak `ValueError`, `AttributeError`, or `TypeError`.

A successful HTTP status does not establish the structure or meaning of the evidence body.

## Implementation

After the existing status check, response parsing now:

- establishes the top-level response and entry data as objects;
- establishes the encoded body as string/bytes;
- decodes/parses it fail-closed;
- establishes `spec`, `data`, and `hash` as objects before reading the expected hash value;
- returns `False` for malformed parsing/shape failures.

No new Rekor response schema or normalization layer is introduced.

## Regression matrix

A separate test file covers:

- valid matching 200 control;
- invalid response JSON;
- top-level array/string/null/integer/boolean;
- scalar/list/null entry data;
- invalid base64 and base64-decoded non-JSON;
- decoded JSON scalar/list/null values;
- malformed nested `spec`, `data`, and `hash` containers.

Existing tests already cover network errors, non-200 responses, missing body, and hash mismatch.

## Scope / non-claims

No manifest schema, Rekor wire format, signed preimage, cryptographic algorithm, or transparency trust policy changes. This is exception-safety at the existing external-evidence verification boundary.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial matrix design, implementation drafting, and DDC review. `altrudev` reviewed the bounded claim and remains responsible for the contribution.