### PR TITLE
feat: add memory checkpoint behavioral assessment harness

### DIFF
--- a/docs/memory-checkpoint-assessment.md
+++ b/docs/memory-checkpoint-assessment.md
@@ -1,0 +1,186 @@
+# Memory checkpoint assessment
+
+`MemoryCheckpointAssessment/0.1` is a non-normative reference assessment for the retrieval behavior of a candidate memory checkpoint. It is tracked in [issue #298](https://github.com/agentrust-io/agent-manifest/issues/298).
+
+The problem is deliberately narrow. A checkpoint can be cryptographically valid, append-only, fresh, and within its update budget while still changing what the retriever selects in a harmful way. This assessment adds evidence about that retrieval behavior without changing the meaning of Agent Manifest verification.
+
+## What the assessment answers
+
+The assessment asks whether a candidate checkpoint preserves a declared set of retrieval invariants under a pinned retriever configuration.
+
+It does **not** decide whether stored content is true, whether an application response is correct, whether a memory write was authorized, or whether a checkpoint is safe in every possible sense. It also does not approve a checkpoint. The deterministic result depends only on the declared probes and retrieval evidence, not on a probabilistic judge.
+
+## Keep evidence and approval separate
+
+The assessment artifact records facts about a run. The approval gate decides whether those facts satisfy an adopted policy.
+
+That separation is important because a failed assessment can still be perfectly valid evidence. The checkpoint can remain cryptographically sound and its consistency proof can still verify. What changes is whether an approval action is allowed to proceed.
+
+The reference implementation keeps five concerns distinct:
+
+1. **Evidence validity**: is the assessment well formed and correctly bound to what it claims?
+2. **Behavioral outcome**: did the required probes return `pass`, `fail`, or `indeterminate`?
+3. **Applicability**: does this assessment match the checkpoint, probe suite, retriever profile, retrieval state, and evidence window required by the adopted gate?
+4. **Gate result**: does this one assessment gate allow the approval process to continue?
+5. **Audit history**: what actually happened, including an approval that should have been blocked?
+
+## Approval decision tree
+
+The gate is intentionally pass-only:
+
+```text
+Presented assessment evidence
+|
++-- no applicable assessment
+|   +-- gate is not satisfied
+|
++-- applicable assessment exists
+    |
+    +-- any applicable result is fail
+    |   +-- gate is not satisfied
+    |   +-- checkpoint MUST NOT be approved while this gate applies
+    |
+    +-- any applicable result is indeterminate
+    |   +-- gate is not satisfied
+    |   +-- the required property was not established
+    |
+    +-- every applicable result is pass
+        +-- this gate is satisfied
+        +-- continue with the remaining approval checks
+```
+
+A `pass` does not grant approval. It only satisfies this one control.
+
+A `fail` is not rewritten into an invalid checkpoint or an invalid assessment. It remains evidence, but an applicable failure blocks the approval action.
+
+An `indeterminate` result also remains its own state. It means the behavioral property was not established. The gate fails closed operationally without pretending that an unestablished result is the same thing as a demonstrated behavioral failure.
+
+Only probes marked `required` contribute to the aggregate behavioral result and therefore to this gate. Non-required probes are diagnostic. A non-required confidentiality probe can fail while the aggregate result remains `pass`; that failure is still recorded in `probe_results` and raises `security_flags.contains_confidentiality_failure`. A policy that intends confidentiality failures to block approval should mark those probes required and may also inspect the security flag directly.
+
+When several applicable assessments are presented, any applicable `fail` or `indeterminate` keeps the gate closed. If both appear, the evaluator reports both reasons rather than collapsing them into one outcome.
+
+## Why applicability matters
+
+A control is easy to bypass if any vaguely related assessment can satisfy it. The gate therefore binds the evidence it expects.
+
+An assessment is applicable only when it matches the policy requirements for:
+
+- baseline checkpoint digest;
+- candidate checkpoint digest;
+- probe-suite digest;
+- retriever-profile digest;
+- baseline and candidate retrieval-state digests, when required;
+- assessment time window, when required.
+
+Assessment-window bounds are inclusive. Evidence timestamped exactly at `assessed_not_before` or `assessed_not_after` remains applicable.
+
+This prevents three especially important bypasses: omitting the assessment, substituting a different probe suite, or assessing under a different retriever profile.
+
+Evidence that does not match the gate is not declared invalid. It simply cannot satisfy that gate.
+
+## Historical records remain truthful
+
+A control violation should be visible after the fact.
+
+If a valid checkpoint was approved despite an applicable failing assessment, the historical record should preserve both facts. Rewriting either artifact into invalidity would erase the evidence needed to show that the approval control was bypassed.
+
+## Retriever profile
+
+Retrieval behavior is only reproducible when the load-bearing retrieval path is pinned. `RetrieverProfile` therefore records, where applicable:
+
+- implementation identity and version;
+- adapter and harness version;
+- embedding model identity and revision;
+- quantization or precision mode;
+- tokenizer identity;
+- query preprocessing;
+- distance metric;
+- index implementation and build configuration;
+- filtering rules;
+- top-k and truncation behavior;
+- reranker identity and configuration;
+- deterministic tie policy;
+- deterministic seed;
+- declared opaque components.
+
+A profile that claims deterministic behavior must declare a deterministic tie policy. The reference harness also records repeatability evidence and requires at least 20 trials for a result reported as stable or unstable.
+
+The typed `index_build_config` and `reranker_config` maps use string, integer, boolean, or null scalar values in 0.1. Fractional settings should be encoded in a stable string form or represented as an opaque component rather than relying on implicit numeric coercion.
+
+The harness snapshots the baseline and candidate state references before running probes and checks them again before emitting an assessment. If either reference changes during the run, no assessment artifact is emitted. This prevents retrieval evidence gathered from one state from being bound to a later checkpoint reference.
+
+## Initial probe set
+
+The 0.1 harness covers four behavioral invariants:
+
+### Correction precedence
+
+A correction should remain retrievable and should outrank the fact it supersedes when the probe requires that relationship.
+
+### Anchor preservation
+
+A declared continuity, identity, or safety anchor should remain retrievable within its allowed rank.
+
+### Scope isolation
+
+A retrieval must not expose an item key or scope label that the probe declares forbidden. Scope failures retain confidentiality severity rather than being flattened into a generic regression.
+
+Scope isolation is intentionally a negative confidentiality property. An empty retrieval contains no forbidden material, so it satisfies this probe. That does **not** establish that retrieval is otherwise healthy. A suite that needs to prove liveness or useful retrieval should also include a positive invariant such as correction precedence, anchor preservation, or state-conditioned differentiation.
+
+### State-conditioned differentiation
+
+Distinct contexts that are expected to retrieve differently should continue to do so, including required and forbidden item checks for each context. The schema rejects a state-conditioned probe whose two contexts are identical.
+
+Cross-state persistence is decided by stable logical item key, not semantic similarity. Item version digests are recorded and participate in repeatability fingerprints within a state, but 0.1 does not compare version digests between baseline and candidate. A content change under a stable key is therefore not, by itself, a failure of the current persistence checks.
+
+Retrieval results must also contain unique ranks and unique logical item keys. Ambiguous duplicate identities are rejected before probe evaluation.
+
+## `indeterminate` results
+
+`indeterminate` is used when the harness cannot establish the behavioral property without falsely calling it a pass or a fail. Current reasons include:
+
+- adapter capability is unsupported or unknown;
+- repeatability was not run;
+- repeatability was unstable;
+- a baseline precondition was not met;
+- stable logical identity could not be maintained across the transition.
+
+Material availability is intentionally separate. A private run can still produce a behavioral `pass` or `fail`; restricted material limits independent rerun strength rather than changing what the run observed.
+
+## Material access and reproducibility
+
+The artifact currently records whether the underlying material is public, restricted, or unavailable to the verifier. That tells a relying party what access is available for an independent rerun.
+
+Issue #298 also identified a useful higher-level distinction between `public-reproducible`, `restricted-reproducible`, and `attested-run-only` evidence. The 0.1 implementation does not serialize those modes yet because `attested-run-only` needs an agreed authenticated producer assertion. This contribution does not invent a new signature envelope to solve that separate provenance problem.
+
+## Canonicalization dependency
+
+Assessment digests use the repository canonicalization implementation rather than defining a second one.
+
+Current `main` has fixed the UTF-16 key-ordering and exponent-formatting defects previously exercised by the assessment tests. The remaining U+2028 escaping issue is still tracked by Agent Manifest #322, so the assessment tests keep one strict expected failure for that live interoperability boundary.
+
+Until that remaining defect is fixed, the implementation should not claim full RFC 8785 portability for inputs that exercise the unresolved escaping case.
+
+## Scope of this contribution
+
+The first contribution is intentionally limited to:
+
+- typed assessment evidence models;
+- a minimal retriever adapter protocol;
+- the deterministic reference harness;
+- reference positive and negative vectors;
+- tests against independently shaped retriever implementations;
+- the separate applicability gate;
+- tests for omission, substitution, failure, indeterminate results, and historical evidence semantics.
+
+It intentionally does not:
+
+- change `spec/` or Agent Manifest conformance;
+- expose an `approve_checkpoint()` API;
+- turn `pass` into deployment authorization;
+- turn `fail` into invalid evidence;
+- collapse `indeterminate` into `fail`;
+- add TRACE or runtime-evidence integration;
+- introduce a new signing or envelope format.
+
+That boundary keeps the assessment useful on its own and leaves later governance, provenance, and runtime integration work to separate proposals.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,6 +172,7 @@ nav:
       - Agent Credentials: integrations/agent-credentials.md
       - Standards landscape: integrations/standards-landscape.md
   - Architecture:
+      - Memory checkpoint assessment: memory-checkpoint-assessment.md
       - Decision Records: adr/index.md
       - ADR-0001 - RFC 8785 Canonical JSON: adr/0001-rfc8785-canonical-json.md
       - ADR-0002 - Ed25519 Standard Profile: adr/0002-ed25519-standard-profile.md

--- a/python/src/agent_manifest/_memory_assessment.py
+++ b/python/src/agent_manifest/_memory_assessment.py
@@ -1,0 +1,745 @@
+"""Non-normative memory checkpoint behavioral assessment helpers.
+
+This module implements the reference harness boundary proposed in issue #298.
+It deliberately does not modify Agent Manifest conformance or checkpoint
+promotion policy.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Annotated, Callable, Literal, Protocol, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from ._canonicalize import canonical_hash
+from ._types import HashValue
+
+
+MIN_REPEATABILITY_TRIALS = 20
+JsonScalar: TypeAlias = str | int | bool | None
+
+
+class AssessmentModel(BaseModel):
+    """Strict, immutable base model for assessment evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class BehavioralResult(str, Enum):
+    # Bandit B105 is a false positive here: this is a public result token.
+    pass_ = "pass"  # nosec B105
+    fail = "fail"
+    indeterminate = "indeterminate"
+
+
+class MaterialAccess(str, Enum):
+    public = "public"
+    restricted = "restricted"
+    unavailable_to_verifier = "unavailable_to_verifier"
+
+
+class AdapterCapability(str, Enum):
+    deterministic = "deterministic"
+    unsupported_or_unknown = "unsupported_or_unknown"
+
+
+class ObservedStatus(str, Enum):
+    stable = "stable"
+    unstable = "unstable"
+    not_run = "not_run"
+
+
+class RequiredIn(str, Enum):
+    baseline = "baseline"
+    candidate = "candidate"
+    both = "both"
+
+
+class SeverityClass(str, Enum):
+    behavioral = "behavioral"
+    confidentiality = "confidentiality"
+
+
+class IndeterminateReason(str, Enum):
+    adapter_unsupported = "adapter_unsupported"
+    repeatability_unstable = "repeatability_unstable"
+    repeatability_not_run = "repeatability_not_run"
+    baseline_precondition_unmet = "baseline_precondition_unmet"
+    id_churn = "id_churn"
+
+
+class RetrieverProfile(AssessmentModel):
+    implementation_id: str
+    implementation_version: str
+    adapter_version: str
+    harness_version: str = "0.1"
+    adapter_capability: AdapterCapability
+    embedding_model_id: str | None = None
+    embedding_model_revision: str | None = None
+    quantization: str | None = None
+    tokenizer_id: str | None = None
+    query_preprocessing: tuple[str, ...] = ()
+    distance_metric: str
+    index_implementation: str
+    index_build_config: dict[str, JsonScalar] = Field(default_factory=dict)
+    filtering_rules: tuple[str, ...] = ()
+    top_k: int = Field(gt=0)
+    truncation_rule: str
+    reranker_id: str | None = None
+    reranker_config: dict[str, JsonScalar] = Field(default_factory=dict)
+    tie_policy: str | None = None
+    seed: int | None = None
+    opaque_components: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _require_tie_policy_for_deterministic(self) -> "RetrieverProfile":
+        if (
+            self.adapter_capability is AdapterCapability.deterministic
+            and not (self.tie_policy or "").strip()
+        ):
+            raise ValueError("deterministic profiles require an explicit tie_policy")
+        return self
+
+
+class StateReference(AssessmentModel):
+    checkpoint_digest: HashValue
+    retrieval_state_digest: HashValue | None = None
+    indexed_item_count: int | None = Field(default=None, ge=0)
+
+
+class RuntimeObservation(AssessmentModel):
+    runtime_id: str | None = None
+    embedding_dimension: int | None = Field(default=None, gt=0)
+    indexed_item_count: int | None = Field(default=None, ge=0)
+    fingerprint_probe_digest: HashValue | None = None
+
+
+class RetrievedItem(AssessmentModel):
+    item_key: str
+    item_version_digest: HashValue
+    rank: int = Field(ge=1)
+    scope_labels: tuple[str, ...] = ()
+
+
+class RetrievalRequest(AssessmentModel):
+    query: str
+    context: dict[str, str] = Field(default_factory=dict)
+
+
+class RepeatabilityEvidence(AssessmentModel):
+    trials: int = Field(ge=0)
+    distinct_orderings_observed: int = Field(ge=0)
+    observed_status: ObservedStatus
+    tie_events_observed: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _validate_status(self) -> "RepeatabilityEvidence":
+        if self.observed_status is ObservedStatus.not_run:
+            if self.trials != 0 or self.distinct_orderings_observed != 0:
+                raise ValueError("not_run repeatability evidence must record zero trials/orderings")
+            return self
+        if self.trials < MIN_REPEATABILITY_TRIALS:
+            raise ValueError(
+                f"repeatability evidence requires at least {MIN_REPEATABILITY_TRIALS} trials"
+            )
+        if self.observed_status is ObservedStatus.stable and self.distinct_orderings_observed != 1:
+            raise ValueError("stable repeatability evidence requires exactly one observed ordering")
+        if self.observed_status is ObservedStatus.unstable and self.distinct_orderings_observed < 2:
+            raise ValueError("unstable repeatability evidence requires at least two observed orderings")
+        return self
+
+
+class InvocationEvidence(AssessmentModel):
+    state_name: str
+    request_digest: HashValue
+    repeatability: RepeatabilityEvidence
+
+
+class ItemReference(AssessmentModel):
+    key: str
+    required_in: RequiredIn
+
+
+class ProbeCommon(AssessmentModel):
+    probe_id: str
+    required: bool = True
+
+
+class CorrectionPrecedenceProbe(ProbeCommon):
+    kind: Literal["correction_precedence"] = "correction_precedence"
+    query: str
+    context: dict[str, str] = Field(default_factory=dict)
+    superseded: ItemReference
+    correction: ItemReference
+    severity: SeverityClass = SeverityClass.behavioral
+
+
+class AnchorPreservationProbe(ProbeCommon):
+    kind: Literal["anchor_preservation"] = "anchor_preservation"
+    query: str
+    context: dict[str, str] = Field(default_factory=dict)
+    anchor: ItemReference
+    max_rank: int = Field(gt=0)
+    severity: SeverityClass = SeverityClass.behavioral
+
+
+class ScopeIsolationProbe(ProbeCommon):
+    kind: Literal["scope_isolation"] = "scope_isolation"
+    query: str
+    context: dict[str, str] = Field(default_factory=dict)
+    forbidden_item_keys: tuple[str, ...] = ()
+    forbidden_scope_labels: tuple[str, ...] = ()
+    severity: SeverityClass = SeverityClass.confidentiality
+
+    @model_validator(mode="after")
+    def _require_forbidden_target(self) -> "ScopeIsolationProbe":
+        if not self.forbidden_item_keys and not self.forbidden_scope_labels:
+            raise ValueError("scope isolation probes require a forbidden key or scope label")
+        return self
+
+
+class StateConditionedDifferentiationProbe(ProbeCommon):
+    kind: Literal["state_conditioned_differentiation"] = "state_conditioned_differentiation"
+    query: str
+    context_a: dict[str, str]
+    context_b: dict[str, str]
+    a_required_keys: tuple[str, ...] = ()
+    a_forbidden_keys: tuple[str, ...] = ()
+    b_required_keys: tuple[str, ...] = ()
+    b_forbidden_keys: tuple[str, ...] = ()
+    require_distinct_ordering: bool = True
+    severity: SeverityClass = SeverityClass.behavioral
+
+    @model_validator(mode="after")
+    def _require_expectation(self) -> "StateConditionedDifferentiationProbe":
+        if self.context_a == self.context_b:
+            raise ValueError("state-conditioned probes require distinct context_a and context_b")
+        if not (
+            self.a_required_keys
+            or self.a_forbidden_keys
+            or self.b_required_keys
+            or self.b_forbidden_keys
+            or self.require_distinct_ordering
+        ):
+            raise ValueError("state-conditioned probes require at least one explicit expectation")
+        return self
+
+
+Probe: TypeAlias = Annotated[
+    CorrectionPrecedenceProbe
+    | AnchorPreservationProbe
+    | ScopeIsolationProbe
+    | StateConditionedDifferentiationProbe,
+    Field(discriminator="kind"),
+]
+
+
+class ProbeSuite(AssessmentModel):
+    version: Literal["0.1"] = "0.1"
+    probes: tuple[Probe, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _require_gating_probe(self) -> "ProbeSuite":
+        probe_ids = [probe.probe_id for probe in self.probes]
+        if len(probe_ids) != len(set(probe_ids)):
+            raise ValueError("probe suites require unique probe_id values")
+        if not any(probe.required for probe in self.probes):
+            raise ValueError("probe suites require at least one required probe")
+        return self
+
+
+class ProbeResult(AssessmentModel):
+    probe_id: str
+    required: bool
+    result: BehavioralResult
+    severity: SeverityClass
+    reasons: tuple[IndeterminateReason, ...] = ()
+    violations: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_reasons(self) -> "ProbeResult":
+        if self.result is BehavioralResult.indeterminate and not self.reasons:
+            raise ValueError("indeterminate results require at least one reason")
+        if self.result is not BehavioralResult.indeterminate and self.reasons:
+            raise ValueError("only indeterminate results may carry indeterminate reasons")
+        return self
+
+
+class Coverage(AssessmentModel):
+    required_probe_count: int = Field(ge=0)
+    passed: int = Field(ge=0)
+    failed: int = Field(ge=0)
+    indeterminate: int = Field(ge=0)
+    indeterminate_rate: float = Field(ge=0.0, le=1.0)
+
+
+class SecurityFlags(AssessmentModel):
+    contains_confidentiality_failure: bool = False
+
+
+class MemoryCheckpointAssessment(AssessmentModel):
+    type: Literal["MemoryCheckpointAssessment"] = "MemoryCheckpointAssessment"
+    version: Literal["0.1"] = "0.1"
+    baseline_state: StateReference
+    candidate_state: StateReference
+    probe_suite_digest: HashValue
+    retriever_profile_digest: HashValue
+    assessed_at: datetime
+    material_access: MaterialAccess
+    runtime_observation: RuntimeObservation | None = None
+    invocation_evidence: tuple[InvocationEvidence, ...]
+    probe_results: tuple[ProbeResult, ...]
+    coverage: Coverage
+    security_flags: SecurityFlags
+    result: BehavioralResult
+
+    @field_validator("assessed_at")
+    @classmethod
+    def _require_timezone_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("assessed_at must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_internal_consistency(self) -> "MemoryCheckpointAssessment":
+        probe_ids = [item.probe_id for item in self.probe_results]
+        if len(probe_ids) != len(set(probe_ids)):
+            raise ValueError("probe_results must contain unique probe_id values")
+
+        invocation_ids = [
+            (item.state_name, str(item.request_digest))
+            for item in self.invocation_evidence
+        ]
+        if len(invocation_ids) != len(set(invocation_ids)):
+            raise ValueError(
+                "invocation_evidence must contain unique state/request pairs"
+            )
+
+        required = [item for item in self.probe_results if item.required]
+        if not required:
+            raise ValueError("assessment must contain at least one required probe result")
+
+        passed = sum(item.result is BehavioralResult.pass_ for item in required)
+        failed = sum(item.result is BehavioralResult.fail for item in required)
+        indeterminate = sum(
+            item.result is BehavioralResult.indeterminate for item in required
+        )
+        count = len(required)
+        expected_rate = indeterminate / count
+
+        if self.coverage.required_probe_count != count:
+            raise ValueError("coverage.required_probe_count does not match probe_results")
+        if self.coverage.passed != passed:
+            raise ValueError("coverage.passed does not match probe_results")
+        if self.coverage.failed != failed:
+            raise ValueError("coverage.failed does not match probe_results")
+        if self.coverage.indeterminate != indeterminate:
+            raise ValueError("coverage.indeterminate does not match probe_results")
+        if abs(self.coverage.indeterminate_rate - expected_rate) > 1e-12:
+            raise ValueError("coverage.indeterminate_rate does not match probe_results")
+
+        expected_result = (
+            BehavioralResult.fail
+            if failed
+            else BehavioralResult.indeterminate
+            if indeterminate
+            else BehavioralResult.pass_
+        )
+        if self.result is not expected_result:
+            raise ValueError("assessment result does not match required probe results")
+
+        confidentiality_failure = any(
+            item.result is BehavioralResult.fail
+            and item.severity is SeverityClass.confidentiality
+            for item in self.probe_results
+        )
+        if (
+            self.security_flags.contains_confidentiality_failure
+            != confidentiality_failure
+        ):
+            raise ValueError(
+                "security_flags.contains_confidentiality_failure does not match probe_results"
+            )
+        return self
+
+
+class RetrieverAdapter(Protocol):
+    """Minimal execution boundary for a memory assessment retriever."""
+
+    @property
+    def profile(self) -> RetrieverProfile: ...
+
+    def state_reference(self, state_name: str) -> StateReference: ...
+
+    def contains_item_key(self, state_name: str, item_key: str) -> bool: ...
+
+    def retrieve(
+        self,
+        state_name: str,
+        request: RetrievalRequest,
+    ) -> Sequence[RetrievedItem]: ...
+
+    def runtime_observation(self) -> RuntimeObservation | None: ...
+
+
+def canonical_model_hash(model: BaseModel) -> HashValue:
+    """Return a repository-canonical SHA-256 digest for a Pydantic model."""
+
+    digest = canonical_hash(model.model_dump(mode="json", exclude_none=True))
+    return HashValue(digest)
+
+
+def _ordered_identity(
+    items: Sequence[RetrievedItem],
+) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
+    ordered = sorted(items, key=lambda item: item.rank)
+    ranks = [item.rank for item in ordered]
+    if len(ranks) != len(set(ranks)):
+        raise ValueError("retrieval result contains duplicate ranks")
+    item_keys = [item.item_key for item in ordered]
+    if len(item_keys) != len(set(item_keys)):
+        raise ValueError("retrieval result contains duplicate item_key values")
+    return tuple(
+        (
+            item.item_key,
+            str(item.item_version_digest),
+            tuple(sorted(item.scope_labels)),
+        )
+        for item in ordered
+    )
+
+
+def _by_key(items: Sequence[RetrievedItem]) -> dict[str, RetrievedItem]:
+    result: dict[str, RetrievedItem] = {}
+    for item in items:
+        if item.item_key in result:
+            raise ValueError(f"retrieval result contains duplicate item_key {item.item_key!r}")
+        result[item.item_key] = item
+    return result
+
+
+class AssessmentHarness:
+    """Reference deterministic harness for `MemoryCheckpointAssessment/0.1`."""
+
+    def __init__(self, *, repeatability_trials: int = MIN_REPEATABILITY_TRIALS) -> None:
+        if repeatability_trials < MIN_REPEATABILITY_TRIALS:
+            raise ValueError(
+                f"repeatability_trials must be at least {MIN_REPEATABILITY_TRIALS}"
+            )
+        self._repeatability_trials = repeatability_trials
+
+    def run(
+        self,
+        adapter: RetrieverAdapter,
+        suite: ProbeSuite,
+        *,
+        baseline_state_name: str = "baseline",
+        candidate_state_name: str = "candidate",
+        material_access: MaterialAccess = MaterialAccess.public,
+        assessed_at: datetime | None = None,
+    ) -> MemoryCheckpointAssessment:
+        profile = adapter.profile.model_copy(deep=True)
+        suite_snapshot = suite.model_copy(deep=True)
+        baseline_state = adapter.state_reference(baseline_state_name).model_copy(deep=True)
+        candidate_state = adapter.state_reference(candidate_state_name).model_copy(deep=True)
+        cache: dict[
+            tuple[str, str], tuple[tuple[RetrievedItem, ...], RepeatabilityEvidence]
+        ] = {}
+        invocation_evidence: dict[tuple[str, str], InvocationEvidence] = {}
+
+        def collect(
+            state_name: str,
+            request: RetrievalRequest,
+        ) -> tuple[tuple[RetrievedItem, ...], RepeatabilityEvidence]:
+            request_snapshot = request.model_copy(deep=True)
+            request_digest = canonical_model_hash(request_snapshot)
+            key = (state_name, str(request_digest))
+            if key in cache:
+                return cache[key]
+            if profile.adapter_capability is AdapterCapability.unsupported_or_unknown:
+                evidence = RepeatabilityEvidence(
+                    trials=0,
+                    distinct_orderings_observed=0,
+                    observed_status=ObservedStatus.not_run,
+                )
+                result: tuple[RetrievedItem, ...] = ()
+            else:
+                observations: dict[
+                    tuple[tuple[str, str, tuple[str, ...]], ...],
+                    tuple[RetrievedItem, ...],
+                ] = {}
+                for _ in range(self._repeatability_trials):
+                    current = tuple(
+                        adapter.retrieve(
+                            state_name,
+                            request_snapshot.model_copy(deep=True),
+                        )
+                    )
+                    ordering = _ordered_identity(current)
+                    observations.setdefault(ordering, current)
+                distinct = len(observations)
+                evidence = RepeatabilityEvidence(
+                    trials=self._repeatability_trials,
+                    distinct_orderings_observed=distinct,
+                    observed_status=(
+                        ObservedStatus.stable if distinct == 1 else ObservedStatus.unstable
+                    ),
+                )
+                result = next(iter(observations.values()))
+            cache[key] = (result, evidence)
+            invocation_evidence[key] = InvocationEvidence(
+                state_name=state_name,
+                request_digest=request_digest,
+                repeatability=evidence,
+            )
+            return result, evidence
+
+        results = [
+            self._evaluate_probe(
+                adapter,
+                probe,
+                baseline_state_name,
+                candidate_state_name,
+                collect,
+                profile.adapter_capability,
+            )
+            for probe in suite_snapshot.probes
+        ]
+
+        required = [result for result in results if result.required]
+        passed = sum(result.result is BehavioralResult.pass_ for result in required)
+        failed = sum(result.result is BehavioralResult.fail for result in required)
+        indeterminate = sum(
+            result.result is BehavioralResult.indeterminate for result in required
+        )
+        count = len(required)
+        coverage = Coverage(
+            required_probe_count=count,
+            passed=passed,
+            failed=failed,
+            indeterminate=indeterminate,
+            indeterminate_rate=(indeterminate / count if count else 0.0),
+        )
+        aggregate = (
+            BehavioralResult.fail
+            if failed
+            else BehavioralResult.indeterminate
+            if indeterminate
+            else BehavioralResult.pass_
+        )
+        security_flags = SecurityFlags(
+            contains_confidentiality_failure=any(
+                result.result is BehavioralResult.fail
+                and result.severity is SeverityClass.confidentiality
+                for result in results
+            )
+        )
+        runtime_observation = adapter.runtime_observation()
+        if (
+            adapter.state_reference(baseline_state_name) != baseline_state
+            or adapter.state_reference(candidate_state_name) != candidate_state
+        ):
+            raise RuntimeError("adapter state reference changed during assessment")
+        return MemoryCheckpointAssessment(
+            baseline_state=baseline_state,
+            candidate_state=candidate_state,
+            probe_suite_digest=canonical_model_hash(suite_snapshot),
+            retriever_profile_digest=canonical_model_hash(profile),
+            assessed_at=assessed_at or datetime.now(timezone.utc),
+            material_access=material_access,
+            runtime_observation=runtime_observation,
+            invocation_evidence=tuple(invocation_evidence.values()),
+            probe_results=tuple(results),
+            coverage=coverage,
+            security_flags=security_flags,
+            result=aggregate,
+        )
+
+    def _identity_precondition(
+        self,
+        adapter: RetrieverAdapter,
+        references: Sequence[ItemReference],
+        baseline_state_name: str,
+        candidate_state_name: str,
+    ) -> bool:
+        for reference in references:
+            if reference.required_in in (RequiredIn.baseline, RequiredIn.both):
+                if not adapter.contains_item_key(baseline_state_name, reference.key):
+                    return False
+            if reference.required_in in (RequiredIn.candidate, RequiredIn.both):
+                if not adapter.contains_item_key(candidate_state_name, reference.key):
+                    return False
+        return True
+
+    @staticmethod
+    def _repeatability_reason(
+        evidence: Sequence[RepeatabilityEvidence],
+        capability: AdapterCapability,
+    ) -> IndeterminateReason | None:
+        if capability is AdapterCapability.unsupported_or_unknown:
+            return IndeterminateReason.adapter_unsupported
+        if any(item.observed_status is ObservedStatus.not_run for item in evidence):
+            return IndeterminateReason.repeatability_not_run
+        if any(item.observed_status is ObservedStatus.unstable for item in evidence):
+            return IndeterminateReason.repeatability_unstable
+        return None
+
+    def _evaluate_probe(
+        self,
+        adapter: RetrieverAdapter,
+        probe: Probe,
+        baseline_state_name: str,
+        candidate_state_name: str,
+        collect: Callable[
+            [str, RetrievalRequest],
+            tuple[tuple[RetrievedItem, ...], RepeatabilityEvidence],
+        ],
+        capability: AdapterCapability,
+    ) -> ProbeResult:
+        if isinstance(probe, CorrectionPrecedenceProbe):
+            refs = (probe.superseded, probe.correction)
+            if not self._identity_precondition(
+                adapter, refs, baseline_state_name, candidate_state_name
+            ):
+                return self._indeterminate(probe, IndeterminateReason.id_churn)
+            request = RetrievalRequest(query=probe.query, context=probe.context)
+            baseline, base_rep = collect(baseline_state_name, request)
+            candidate, cand_rep = collect(candidate_state_name, request)
+            repeat_reason = self._repeatability_reason((base_rep, cand_rep), capability)
+            if repeat_reason is not None:
+                return self._indeterminate(probe, repeat_reason)
+            base_by_key = _by_key(baseline)
+            if probe.superseded.key not in base_by_key:
+                return self._indeterminate(
+                    probe, IndeterminateReason.baseline_precondition_unmet
+                )
+            candidate_by_key = _by_key(candidate)
+            correction = candidate_by_key.get(probe.correction.key)
+            if correction is None:
+                return self._fail(
+                    probe, f"correction {probe.correction.key!r} was not retrieved"
+                )
+            superseded = candidate_by_key.get(probe.superseded.key)
+            if superseded is not None and correction.rank >= superseded.rank:
+                return self._fail(
+                    probe,
+                    f"correction rank {correction.rank} did not outrank superseded rank {superseded.rank}",
+                )
+            return self._pass(probe)
+
+        if isinstance(probe, AnchorPreservationProbe):
+            if not self._identity_precondition(
+                adapter, (probe.anchor,), baseline_state_name, candidate_state_name
+            ):
+                return self._indeterminate(probe, IndeterminateReason.id_churn)
+            request = RetrievalRequest(query=probe.query, context=probe.context)
+            baseline, base_rep = collect(baseline_state_name, request)
+            candidate, cand_rep = collect(candidate_state_name, request)
+            repeat_reason = self._repeatability_reason((base_rep, cand_rep), capability)
+            if repeat_reason is not None:
+                return self._indeterminate(probe, repeat_reason)
+            baseline_anchor = _by_key(baseline).get(probe.anchor.key)
+            if baseline_anchor is None or baseline_anchor.rank > probe.max_rank:
+                return self._indeterminate(
+                    probe, IndeterminateReason.baseline_precondition_unmet
+                )
+            candidate_anchor = _by_key(candidate).get(probe.anchor.key)
+            if candidate_anchor is None:
+                return self._fail(probe, f"anchor {probe.anchor.key!r} was not retrieved")
+            if candidate_anchor.rank > probe.max_rank:
+                return self._fail(
+                    probe,
+                    f"anchor rank {candidate_anchor.rank} exceeds max_rank {probe.max_rank}",
+                )
+            return self._pass(probe)
+
+        if isinstance(probe, ScopeIsolationProbe):
+            request = RetrievalRequest(query=probe.query, context=probe.context)
+            candidate, evidence = collect(candidate_state_name, request)
+            repeat_reason = self._repeatability_reason((evidence,), capability)
+            if repeat_reason is not None:
+                return self._indeterminate(probe, repeat_reason)
+            forbidden_keys = set(probe.forbidden_item_keys)
+            forbidden_scopes = set(probe.forbidden_scope_labels)
+            scope_violations: list[str] = []
+            for item in candidate:
+                if item.item_key in forbidden_keys:
+                    scope_violations.append(f"forbidden item {item.item_key!r} was retrieved")
+                overlap = forbidden_scopes.intersection(item.scope_labels)
+                if overlap:
+                    scope_violations.append(
+                        f"item {item.item_key!r} carried forbidden scope labels {sorted(overlap)!r}"
+                    )
+            if scope_violations:
+                return self._fail(probe, *scope_violations)
+            return self._pass(probe)
+
+        if isinstance(probe, StateConditionedDifferentiationProbe):
+            required_keys = set(probe.a_required_keys).union(probe.b_required_keys)
+            if any(
+                not adapter.contains_item_key(candidate_state_name, key)
+                for key in required_keys
+            ):
+                return self._indeterminate(probe, IndeterminateReason.id_churn)
+            request_a = RetrievalRequest(query=probe.query, context=probe.context_a)
+            request_b = RetrievalRequest(query=probe.query, context=probe.context_b)
+            items_a, evidence_a = collect(candidate_state_name, request_a)
+            items_b, evidence_b = collect(candidate_state_name, request_b)
+            repeat_reason = self._repeatability_reason((evidence_a, evidence_b), capability)
+            if repeat_reason is not None:
+                return self._indeterminate(probe, repeat_reason)
+            keys_a = tuple(item.item_key for item in sorted(items_a, key=lambda item: item.rank))
+            keys_b = tuple(item.item_key for item in sorted(items_b, key=lambda item: item.rank))
+            set_a = set(keys_a)
+            set_b = set(keys_b)
+            state_violations: list[str] = []
+            for key in probe.a_required_keys:
+                if key not in set_a:
+                    state_violations.append(f"context A did not retrieve required item {key!r}")
+            for key in probe.a_forbidden_keys:
+                if key in set_a:
+                    state_violations.append(f"context A retrieved forbidden item {key!r}")
+            for key in probe.b_required_keys:
+                if key not in set_b:
+                    state_violations.append(f"context B did not retrieve required item {key!r}")
+            for key in probe.b_forbidden_keys:
+                if key in set_b:
+                    state_violations.append(f"context B retrieved forbidden item {key!r}")
+            if probe.require_distinct_ordering and keys_a == keys_b:
+                state_violations.append("context A and B produced identical ordered item identities")
+            if state_violations:
+                return self._fail(probe, *state_violations)
+            return self._pass(probe)
+
+        raise TypeError(f"unsupported probe type {type(probe).__name__}")
+
+    @staticmethod
+    def _pass(probe: Probe) -> ProbeResult:
+        return ProbeResult(
+            probe_id=probe.probe_id,
+            required=probe.required,
+            result=BehavioralResult.pass_,
+            severity=probe.severity,
+        )
+
+    @staticmethod
+    def _fail(probe: Probe, *violations: str) -> ProbeResult:
+        return ProbeResult(
+            probe_id=probe.probe_id,
+            required=probe.required,
+            result=BehavioralResult.fail,
+            severity=probe.severity,
+            violations=tuple(violations),
+        )
+
+    @staticmethod
+    def _indeterminate(probe: Probe, reason: IndeterminateReason) -> ProbeResult:
+        return ProbeResult(
+            probe_id=probe.probe_id,
+            required=probe.required,
+            result=BehavioralResult.indeterminate,
+            severity=probe.severity,
+            reasons=(reason,),
+        )

--- a/python/src/agent_manifest/_memory_assessment_gate.py
+++ b/python/src/agent_manifest/_memory_assessment_gate.py
@@ -1,0 +1,219 @@
+"""Non-normative applicability gate for memory checkpoint assessments.
+
+The assessment artifact records what was evaluated and what happened. This
+module models the separate relying-party question: whether the presented
+assessment evidence satisfies one explicitly adopted approval gate.
+
+It does not approve checkpoints, mutate evidence, or change Agent Manifest
+conformance. A caller that adopts this gate remains responsible for enforcing
+its result at the actual approval boundary.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from enum import Enum
+
+from pydantic import field_validator, model_validator
+
+from ._memory_assessment import AssessmentModel, BehavioralResult, MemoryCheckpointAssessment
+from ._types import HashValue
+
+
+class ApplicabilityMismatch(str, Enum):
+    """Why a presented assessment does not satisfy the required evidence shape."""
+
+    baseline_checkpoint = "baseline_checkpoint"
+    candidate_checkpoint = "candidate_checkpoint"
+    baseline_retrieval_state = "baseline_retrieval_state"
+    candidate_retrieval_state = "candidate_retrieval_state"
+    probe_suite = "probe_suite"
+    retriever_profile = "retriever_profile"
+    before_evidence_window = "before_evidence_window"
+    after_evidence_window = "after_evidence_window"
+
+
+class GateFailureReason(str, Enum):
+    """Why an adopted assessment gate is not satisfied."""
+
+    no_applicable_assessment = "no_applicable_assessment"
+    applicable_assessment_failed = "applicable_assessment_failed"
+    applicable_assessment_indeterminate = "applicable_assessment_indeterminate"
+
+
+class AssessmentGatePolicy(AssessmentModel):
+    """Content requirements for one explicitly adopted assessment gate.
+
+    The policy binds the evidence shape that must be presented at approval
+    time. Retrieval-state digests and the time window are optional policy
+    refinements. When supplied, they are load-bearing applicability criteria.
+    """
+
+    baseline_checkpoint_digest: HashValue
+    candidate_checkpoint_digest: HashValue
+    probe_suite_digest: HashValue
+    retriever_profile_digest: HashValue
+    baseline_retrieval_state_digest: HashValue | None = None
+    candidate_retrieval_state_digest: HashValue | None = None
+    assessed_not_before: datetime | None = None
+    assessed_not_after: datetime | None = None
+
+    @field_validator("assessed_not_before", "assessed_not_after")
+    @classmethod
+    def _require_timezone_aware(cls, value: datetime | None) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("assessment gate timestamps must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_evidence_window(self) -> "AssessmentGatePolicy":
+        if (
+            self.assessed_not_before is not None
+            and self.assessed_not_after is not None
+            and self.assessed_not_before > self.assessed_not_after
+        ):
+            raise ValueError("assessed_not_before must not be after assessed_not_after")
+        return self
+
+
+class AssessmentGateEvaluation(AssessmentModel):
+    """Result of applying one adopted gate to presented assessment evidence."""
+
+    satisfied: bool
+    presented_assessment_count: int
+    applicable_assessment_count: int
+    applicable_results: tuple[BehavioralResult, ...] = ()
+    non_applicable_mismatches: tuple[ApplicabilityMismatch, ...] = ()
+    reasons: tuple[GateFailureReason, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_internal_consistency(self) -> "AssessmentGateEvaluation":
+        if self.presented_assessment_count < 0:
+            raise ValueError("presented_assessment_count must be non-negative")
+        if self.applicable_assessment_count < 0:
+            raise ValueError("applicable_assessment_count must be non-negative")
+        if self.applicable_assessment_count > self.presented_assessment_count:
+            raise ValueError("applicable assessment count cannot exceed presented count")
+        if len(self.applicable_results) != self.applicable_assessment_count:
+            raise ValueError("applicable_results must match applicable_assessment_count")
+
+        has_fail = BehavioralResult.fail in self.applicable_results
+        has_indeterminate = BehavioralResult.indeterminate in self.applicable_results
+
+        if self.satisfied:
+            if not self.applicable_results:
+                raise ValueError("a satisfied gate requires applicable assessment evidence")
+            if has_fail or has_indeterminate:
+                raise ValueError("a satisfied gate requires every applicable result to pass")
+            if self.reasons:
+                raise ValueError("a satisfied gate cannot carry failure reasons")
+            return self
+
+        if not self.reasons:
+            raise ValueError("an unsatisfied gate requires at least one failure reason")
+        if not self.applicable_results:
+            if GateFailureReason.no_applicable_assessment not in self.reasons:
+                raise ValueError("missing applicable evidence must be reported explicitly")
+            return self
+        if GateFailureReason.no_applicable_assessment in self.reasons:
+            raise ValueError("no_applicable_assessment conflicts with applicable evidence")
+        if has_fail and GateFailureReason.applicable_assessment_failed not in self.reasons:
+            raise ValueError("applicable fail must be reported explicitly")
+        if (
+            has_indeterminate
+            and GateFailureReason.applicable_assessment_indeterminate not in self.reasons
+        ):
+            raise ValueError("applicable indeterminate must be reported explicitly")
+        return self
+
+
+def _applicability_mismatches(
+    policy: AssessmentGatePolicy,
+    assessment: MemoryCheckpointAssessment,
+) -> tuple[ApplicabilityMismatch, ...]:
+    mismatches: list[ApplicabilityMismatch] = []
+    if assessment.baseline_state.checkpoint_digest != policy.baseline_checkpoint_digest:
+        mismatches.append(ApplicabilityMismatch.baseline_checkpoint)
+    if assessment.candidate_state.checkpoint_digest != policy.candidate_checkpoint_digest:
+        mismatches.append(ApplicabilityMismatch.candidate_checkpoint)
+    if assessment.probe_suite_digest != policy.probe_suite_digest:
+        mismatches.append(ApplicabilityMismatch.probe_suite)
+    if assessment.retriever_profile_digest != policy.retriever_profile_digest:
+        mismatches.append(ApplicabilityMismatch.retriever_profile)
+    if (
+        policy.baseline_retrieval_state_digest is not None
+        and assessment.baseline_state.retrieval_state_digest
+        != policy.baseline_retrieval_state_digest
+    ):
+        mismatches.append(ApplicabilityMismatch.baseline_retrieval_state)
+    if (
+        policy.candidate_retrieval_state_digest is not None
+        and assessment.candidate_state.retrieval_state_digest
+        != policy.candidate_retrieval_state_digest
+    ):
+        mismatches.append(ApplicabilityMismatch.candidate_retrieval_state)
+    if (
+        policy.assessed_not_before is not None
+        and assessment.assessed_at < policy.assessed_not_before
+    ):
+        mismatches.append(ApplicabilityMismatch.before_evidence_window)
+    if (
+        policy.assessed_not_after is not None
+        and assessment.assessed_at > policy.assessed_not_after
+    ):
+        mismatches.append(ApplicabilityMismatch.after_evidence_window)
+    return tuple(mismatches)
+
+
+def evaluate_assessment_gate(
+    policy: AssessmentGatePolicy,
+    assessments: Sequence[MemoryCheckpointAssessment],
+) -> AssessmentGateEvaluation:
+    """Evaluate whether presented evidence satisfies an adopted assessment gate.
+
+    Applicability is evaluated before behavioral outcome. Evidence that binds a
+    different checkpoint, suite, retriever profile, required retrieval state,
+    or evidence window does not satisfy this gate and remains valid evidence of
+    whatever it actually assessed.
+
+    The gate is pass-only: at least one applicable assessment must be present,
+    and every presented applicable assessment must be ``pass``. ``fail`` and
+    ``indeterminate`` remain distinct behavioral outcomes, but neither satisfies
+    the approval gate. This function reports admissibility for this gate only;
+    it never grants checkpoint approval.
+    """
+
+    applicable_results: list[BehavioralResult] = []
+    mismatches: set[ApplicabilityMismatch] = set()
+
+    for assessment in assessments:
+        current_mismatches = _applicability_mismatches(policy, assessment)
+        if current_mismatches:
+            mismatches.update(current_mismatches)
+            continue
+        applicable_results.append(assessment.result)
+
+    ordered_mismatches = tuple(sorted(mismatches, key=lambda item: item.value))
+    if not applicable_results:
+        return AssessmentGateEvaluation(
+            satisfied=False,
+            presented_assessment_count=len(assessments),
+            applicable_assessment_count=0,
+            non_applicable_mismatches=ordered_mismatches,
+            reasons=(GateFailureReason.no_applicable_assessment,),
+        )
+
+    reasons: list[GateFailureReason] = []
+    if BehavioralResult.fail in applicable_results:
+        reasons.append(GateFailureReason.applicable_assessment_failed)
+    if BehavioralResult.indeterminate in applicable_results:
+        reasons.append(GateFailureReason.applicable_assessment_indeterminate)
+
+    return AssessmentGateEvaluation(
+        satisfied=not reasons,
+        presented_assessment_count=len(assessments),
+        applicable_assessment_count=len(applicable_results),
+        applicable_results=tuple(applicable_results),
+        non_applicable_mismatches=ordered_mismatches,
+        reasons=tuple(reasons),
+    )

--- a/python/tests/fixtures/memory_assessment/README.md
+++ b/python/tests/fixtures/memory_assessment/README.md
@@ -1,0 +1,51 @@
+# Memory checkpoint assessment reference vectors
+
+These fixtures exercise `MemoryCheckpointAssessment/0.1`, the non-normative reference harness tracked by Agent Manifest issue #298.
+
+They are reference vectors for the assessment implementation, not AgentTrust conformance vectors.
+
+## What is included
+
+`reference-vectors-v0.1.json` contains one deterministic retriever profile, one probe suite, a baseline state, a candidate state, and nine expected outcomes.
+
+The cases cover:
+
+- a clean pass;
+- a missing correction;
+- a correction ranked below the fact it supersedes;
+- a missing anchor;
+- an anchor demoted below its allowed rank;
+- a forbidden item-key leak;
+- a forbidden scope-label leak;
+- collapsed state-conditioned retrieval;
+- a missing state-conditioned required item.
+
+The committed JSON is the reference artifact. `memory_assessment_vector_builder.py` produces the same bundle, and the test suite checks that the committed file still matches a fresh build. This makes accidental hand edits or refactors visible.
+
+## What the vectors are meant to prove
+
+The fixtures are intentionally small and deterministic. They should be understandable without a particular retrieval framework and should contain enough material for another implementation to reproduce the expected result.
+
+The broader test suite covers behavior that does not need to live in the JSON bundle, including:
+
+- unsupported adapters and `indeterminate` outcomes;
+- repeatability instability;
+- stable logical identity and identity churn;
+- request/profile/suite mutation resistance;
+- timezone requirements;
+- confidentiality signaling;
+- applicability-gate behavior;
+- canonicalization boundaries;
+- the same invariant suite exercised against two independently shaped deterministic retrievers.
+
+## Independence rule
+
+The assessment contract should describe retrieval behavior rather than one library's mechanics. For that reason, the hardening tests run the same invariant suite through two retrieval implementations that do not share retrieval logic.
+
+A new vector should be added when it catches a materially different defect, not merely to increase case count.
+
+## Canonicalization note
+
+Assessment digests use the repository canonicalizer. Current upstream has corrected the UTF-16 key-ordering and exponent-formatting cases previously guarded here. The remaining U+2028 escaping defect is tracked by Agent Manifest #322 and remains a strict expected failure in the canonicalization dependency test.
+
+Do not add an assessment-specific canonicalizer. The assessment should continue to use the project-wide primitive so interoperability fixes apply consistently across the repository.

--- a/python/tests/fixtures/memory_assessment/reference-vectors-v0.1.json
+++ b/python/tests/fixtures/memory_assessment/reference-vectors-v0.1.json
@@ -1,0 +1,207 @@
+{
+  "format": "MemoryCheckpointAssessmentReferenceVectors/0.1",
+  "profile": {
+    "implementation_id": "reference-vector-table",
+    "implementation_version": "1",
+    "adapter_version": "0.1",
+    "adapter_capability": "deterministic",
+    "distance_metric": "fixture-order",
+    "index_implementation": "reference-vector-table",
+    "top_k": 4,
+    "truncation_rule": "top-k",
+    "tie_policy": "rank_then_item_key_lexical"
+  },
+  "probe_suite": {
+    "version": "0.1",
+    "probes": [
+      {
+        "kind": "correction_precedence",
+        "probe_id": "corr",
+        "query": "correction",
+        "superseded": {"key": "old", "required_in": "both"},
+        "correction": {"key": "new", "required_in": "candidate"}
+      },
+      {
+        "kind": "anchor_preservation",
+        "probe_id": "anchor",
+        "query": "anchor",
+        "anchor": {"key": "anchor", "required_in": "both"},
+        "max_rank": 2
+      },
+      {
+        "kind": "scope_isolation",
+        "probe_id": "scope-key",
+        "query": "scope-key",
+        "forbidden_item_keys": ["tenant-b"]
+      },
+      {
+        "kind": "scope_isolation",
+        "probe_id": "scope-label",
+        "query": "scope-label",
+        "forbidden_scope_labels": ["tenant:b"]
+      },
+      {
+        "kind": "state_conditioned_differentiation",
+        "probe_id": "state",
+        "query": "state",
+        "context_a": {"mood": "a"},
+        "context_b": {"mood": "b"},
+        "a_required_keys": ["state-a"],
+        "b_required_keys": ["state-b"]
+      }
+    ]
+  },
+  "baseline": {
+    "checkpoint_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "retrieval_state_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "item_keys": ["old", "anchor", "other", "tenant-b"],
+    "responses": [
+      {
+        "query": "correction",
+        "context": {},
+        "items": [
+          {"key": "old", "version": "sha256:1111111111111111111111111111111111111111111111111111111111111111", "rank": 1},
+          {"key": "anchor", "version": "sha256:3333333333333333333333333333333333333333333333333333333333333333", "rank": 2}
+        ]
+      },
+      {
+        "query": "anchor",
+        "context": {},
+        "items": [
+          {"key": "anchor", "version": "sha256:3333333333333333333333333333333333333333333333333333333333333333", "rank": 1},
+          {"key": "other", "version": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "rank": 2}
+        ]
+      }
+    ]
+  },
+  "candidate": {
+    "checkpoint_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "retrieval_state_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "item_keys": ["old", "new", "anchor", "other", "tenant-b", "state-a", "state-b"],
+    "responses": [
+      {
+        "query": "correction",
+        "context": {},
+        "items": [
+          {"key": "new", "version": "sha256:2222222222222222222222222222222222222222222222222222222222222222", "rank": 1},
+          {"key": "old", "version": "sha256:1111111111111111111111111111111111111111111111111111111111111111", "rank": 2}
+        ]
+      },
+      {
+        "query": "anchor",
+        "context": {},
+        "items": [
+          {"key": "other", "version": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "rank": 1},
+          {"key": "anchor", "version": "sha256:3333333333333333333333333333333333333333333333333333333333333333", "rank": 2}
+        ]
+      },
+      {
+        "query": "scope-key",
+        "context": {},
+        "items": [
+          {"key": "other", "version": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "rank": 1}
+        ]
+      },
+      {
+        "query": "scope-label",
+        "context": {},
+        "items": [
+          {"key": "other", "version": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "rank": 1}
+        ]
+      },
+      {
+        "query": "state",
+        "context": {"mood": "a"},
+        "items": [
+          {"key": "state-a", "version": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "rank": 1},
+          {"key": "state-b", "version": "sha256:7777777777777777777777777777777777777777777777777777777777777777", "rank": 2}
+        ]
+      },
+      {
+        "query": "state",
+        "context": {"mood": "b"},
+        "items": [
+          {"key": "state-b", "version": "sha256:7777777777777777777777777777777777777777777777777777777777777777", "rank": 1},
+          {"key": "state-a", "version": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "rank": 2}
+        ]
+      }
+    ]
+  },
+  "cases": [
+    {"id": "pass", "expected_result": "pass", "expected_failed_probes": [], "overrides": []},
+    {
+      "id": "correction-missing",
+      "expected_result": "fail",
+      "expected_failed_probes": ["corr"],
+      "overrides": [
+        {"query": "correction", "context": {}, "items": [{"key": "old", "version": "sha256:1111111111111111111111111111111111111111111111111111111111111111", "rank": 1}]}
+      ]
+    },
+    {
+      "id": "correction-outranked",
+      "expected_result": "fail",
+      "expected_failed_probes": ["corr"],
+      "overrides": [
+        {"query": "correction", "context": {}, "items": [
+          {"key": "old", "version": "sha256:1111111111111111111111111111111111111111111111111111111111111111", "rank": 1},
+          {"key": "new", "version": "sha256:2222222222222222222222222222222222222222222222222222222222222222", "rank": 2}
+        ]}
+      ]
+    },
+    {
+      "id": "anchor-missing",
+      "expected_result": "fail",
+      "expected_failed_probes": ["anchor"],
+      "overrides": [
+        {"query": "anchor", "context": {}, "items": [{"key": "other", "version": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "rank": 1}]}
+      ]
+    },
+    {
+      "id": "anchor-demoted",
+      "expected_result": "fail",
+      "expected_failed_probes": ["anchor"],
+      "overrides": [
+        {"query": "anchor", "context": {}, "items": [
+          {"key": "other", "version": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "rank": 1},
+          {"key": "tenant-b", "version": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "rank": 2},
+          {"key": "anchor", "version": "sha256:3333333333333333333333333333333333333333333333333333333333333333", "rank": 3}
+        ]}
+      ]
+    },
+    {
+      "id": "scope-key-leak",
+      "expected_result": "fail",
+      "expected_failed_probes": ["scope-key"],
+      "overrides": [
+        {"query": "scope-key", "context": {}, "items": [{"key": "tenant-b", "version": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "rank": 1}]}
+      ]
+    },
+    {
+      "id": "scope-label-leak",
+      "expected_result": "fail",
+      "expected_failed_probes": ["scope-label"],
+      "overrides": [
+        {"query": "scope-label", "context": {}, "items": [{"key": "other", "version": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "rank": 1, "scope_labels": ["tenant:b"]}]}
+      ]
+    },
+    {
+      "id": "state-collapse",
+      "expected_result": "fail",
+      "expected_failed_probes": ["state"],
+      "overrides": [
+        {"query": "state", "context": {"mood": "b"}, "items": [
+          {"key": "state-a", "version": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "rank": 1},
+          {"key": "state-b", "version": "sha256:7777777777777777777777777777777777777777777777777777777777777777", "rank": 2}
+        ]}
+      ]
+    },
+    {
+      "id": "state-required-missing",
+      "expected_result": "fail",
+      "expected_failed_probes": ["state"],
+      "overrides": [
+        {"query": "state", "context": {"mood": "a"}, "items": [{"key": "state-b", "version": "sha256:7777777777777777777777777777777777777777777777777777777777777777", "rank": 1}]}
+      ]
+    }
+  ]
+}

--- a/python/tests/memory_assessment_vector_builder.py
+++ b/python/tests/memory_assessment_vector_builder.py
@@ -1,0 +1,247 @@
+"""Build the deterministic public MemoryCheckpointAssessment reference vectors.
+
+The committed JSON is the portable artifact. This builder exists so a hand edit,
+refactor, or future generator change cannot silently make the committed vectors
+irreproducible.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+HASHES = {
+    "baseline": "sha256:" + "a" * 64,
+    "candidate": "sha256:" + "b" * 64,
+    "baseline_state": "sha256:" + "c" * 64,
+    "candidate_state": "sha256:" + "d" * 64,
+    "old": "sha256:" + "1" * 64,
+    "new": "sha256:" + "2" * 64,
+    "anchor": "sha256:" + "3" * 64,
+    "other": "sha256:" + "4" * 64,
+    "tenant-b": "sha256:" + "5" * 64,
+    "state-a": "sha256:" + "6" * 64,
+    "state-b": "sha256:" + "7" * 64,
+}
+
+
+def _item(
+    key: str,
+    rank: int,
+    *,
+    scope_labels: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "key": key,
+        "version": HASHES[key],
+        "rank": rank,
+    }
+    if scope_labels:
+        item["scope_labels"] = list(scope_labels)
+    return item
+
+
+def _response(
+    query: str,
+    items: list[dict[str, Any]],
+    *,
+    context: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "query": query,
+        "context": context or {},
+        "items": items,
+    }
+
+
+def _case(
+    case_id: str,
+    expected_result: str,
+    failed: tuple[str, ...] = (),
+    overrides: tuple[dict[str, Any], ...] = (),
+) -> dict[str, Any]:
+    return {
+        "id": case_id,
+        "expected_result": expected_result,
+        "expected_failed_probes": list(failed),
+        "overrides": list(overrides),
+    }
+
+
+def build_reference_vectors() -> dict[str, Any]:
+    """Return the complete deterministic reference-vector bundle."""
+
+    profile = {
+        "implementation_id": "reference-vector-table",
+        "implementation_version": "1",
+        "adapter_version": "0.1",
+        "adapter_capability": "deterministic",
+        "distance_metric": "fixture-order",
+        "index_implementation": "reference-vector-table",
+        "top_k": 4,
+        "truncation_rule": "top-k",
+        "tie_policy": "rank_then_item_key_lexical",
+    }
+
+    probe_suite = {
+        "version": "0.1",
+        "probes": [
+            {
+                "kind": "correction_precedence",
+                "probe_id": "corr",
+                "query": "correction",
+                "superseded": {"key": "old", "required_in": "both"},
+                "correction": {"key": "new", "required_in": "candidate"},
+            },
+            {
+                "kind": "anchor_preservation",
+                "probe_id": "anchor",
+                "query": "anchor",
+                "anchor": {"key": "anchor", "required_in": "both"},
+                "max_rank": 2,
+            },
+            {
+                "kind": "scope_isolation",
+                "probe_id": "scope-key",
+                "query": "scope-key",
+                "forbidden_item_keys": ["tenant-b"],
+            },
+            {
+                "kind": "scope_isolation",
+                "probe_id": "scope-label",
+                "query": "scope-label",
+                "forbidden_scope_labels": ["tenant:b"],
+            },
+            {
+                "kind": "state_conditioned_differentiation",
+                "probe_id": "state",
+                "query": "state",
+                "context_a": {"mood": "a"},
+                "context_b": {"mood": "b"},
+                "a_required_keys": ["state-a"],
+                "b_required_keys": ["state-b"],
+            },
+        ],
+    }
+
+    baseline = {
+        "checkpoint_digest": HASHES["baseline"],
+        "retrieval_state_digest": HASHES["baseline_state"],
+        "item_keys": ["old", "anchor", "other", "tenant-b"],
+        "responses": [
+            _response("correction", [_item("old", 1), _item("anchor", 2)]),
+            _response("anchor", [_item("anchor", 1), _item("other", 2)]),
+        ],
+    }
+
+    candidate = {
+        "checkpoint_digest": HASHES["candidate"],
+        "retrieval_state_digest": HASHES["candidate_state"],
+        "item_keys": [
+            "old",
+            "new",
+            "anchor",
+            "other",
+            "tenant-b",
+            "state-a",
+            "state-b",
+        ],
+        "responses": [
+            _response("correction", [_item("new", 1), _item("old", 2)]),
+            _response("anchor", [_item("other", 1), _item("anchor", 2)]),
+            _response("scope-key", [_item("other", 1)]),
+            _response("scope-label", [_item("other", 1)]),
+            _response(
+                "state",
+                [_item("state-a", 1), _item("state-b", 2)],
+                context={"mood": "a"},
+            ),
+            _response(
+                "state",
+                [_item("state-b", 1), _item("state-a", 2)],
+                context={"mood": "b"},
+            ),
+        ],
+    }
+
+    cases = [
+        _case("pass", "pass"),
+        _case(
+            "correction-missing",
+            "fail",
+            ("corr",),
+            (_response("correction", [_item("old", 1)]),),
+        ),
+        _case(
+            "correction-outranked",
+            "fail",
+            ("corr",),
+            (_response("correction", [_item("old", 1), _item("new", 2)]),),
+        ),
+        _case(
+            "anchor-missing",
+            "fail",
+            ("anchor",),
+            (_response("anchor", [_item("other", 1)]),),
+        ),
+        _case(
+            "anchor-demoted",
+            "fail",
+            ("anchor",),
+            (
+                _response(
+                    "anchor",
+                    [_item("other", 1), _item("tenant-b", 2), _item("anchor", 3)],
+                ),
+            ),
+        ),
+        _case(
+            "scope-key-leak",
+            "fail",
+            ("scope-key",),
+            (_response("scope-key", [_item("tenant-b", 1)]),),
+        ),
+        _case(
+            "scope-label-leak",
+            "fail",
+            ("scope-label",),
+            (
+                _response(
+                    "scope-label",
+                    [_item("other", 1, scope_labels=("tenant:b",))],
+                ),
+            ),
+        ),
+        _case(
+            "state-collapse",
+            "fail",
+            ("state",),
+            (
+                _response(
+                    "state",
+                    [_item("state-a", 1), _item("state-b", 2)],
+                    context={"mood": "b"},
+                ),
+            ),
+        ),
+        _case(
+            "state-required-missing",
+            "fail",
+            ("state",),
+            (
+                _response(
+                    "state",
+                    [_item("state-b", 1)],
+                    context={"mood": "a"},
+                ),
+            ),
+        ),
+    ]
+
+    return {
+        "format": "MemoryCheckpointAssessmentReferenceVectors/0.1",
+        "profile": profile,
+        "probe_suite": probe_suite,
+        "baseline": baseline,
+        "candidate": candidate,
+        "cases": cases,
+    }

--- a/python/tests/test_memory_assessment.py
+++ b/python/tests/test_memory_assessment.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+from pydantic import ValidationError
+
+from agent_manifest._memory_assessment import (
+    AdapterCapability,
+    AnchorPreservationProbe,
+    AssessmentHarness,
+    BehavioralResult,
+    CorrectionPrecedenceProbe,
+    IndeterminateReason,
+    ItemReference,
+    MaterialAccess,
+    ProbeSuite,
+    RequiredIn,
+    RetrievedItem,
+    RetrievalRequest,
+    RetrieverProfile,
+    RuntimeObservation,
+    ScopeIsolationProbe,
+    SeverityClass,
+    StateConditionedDifferentiationProbe,
+    StateReference,
+)
+
+
+def _hash(char: str) -> str:
+    return "sha256:" + char * 64
+
+
+class FixtureAdapter:
+    """Deterministic in-memory adapter used only by the assessment tests."""
+
+    def __init__(
+        self,
+        *,
+        capability: AdapterCapability = AdapterCapability.deterministic,
+        unstable: bool = False,
+    ) -> None:
+        self._profile = RetrieverProfile(
+            implementation_id="fixture",
+            implementation_version="1",
+            adapter_version="0.1",
+            adapter_capability=capability,
+            distance_metric="fixture-order",
+            index_implementation="fixture",
+            top_k=4,
+            truncation_rule="none",
+            tie_policy="item_key_lexical",
+        )
+        self.unstable = unstable
+        self.calls = 0
+        self.store = {
+            "baseline": {"old", "anchor", "other", "tenant-b"},
+            "candidate": {
+                "old",
+                "new",
+                "anchor",
+                "other",
+                "tenant-b",
+                "state-a",
+                "state-b",
+            },
+        }
+
+    @property
+    def profile(self) -> RetrieverProfile:
+        return self._profile
+
+    def state_reference(self, state_name: str) -> StateReference:
+        return StateReference(
+            checkpoint_digest=_hash("a" if state_name == "baseline" else "b"),
+            retrieval_state_digest=_hash("c" if state_name == "baseline" else "d"),
+            indexed_item_count=len(self.store[state_name]),
+        )
+
+    def contains_item_key(self, state_name: str, item_key: str) -> bool:
+        return item_key in self.store[state_name]
+
+    def retrieve(
+        self,
+        state_name: str,
+        request: RetrievalRequest,
+    ) -> Sequence[RetrievedItem]:
+        self.calls += 1
+
+        def item(
+            key: str,
+            rank: int,
+            scopes: tuple[str, ...] = (),
+        ) -> RetrievedItem:
+            chars = {
+                "old": "1",
+                "new": "2",
+                "anchor": "3",
+                "other": "4",
+                "tenant-b": "5",
+                "state-a": "6",
+                "state-b": "7",
+            }
+            return RetrievedItem(
+                item_key=key,
+                item_version_digest=_hash(chars[key]),
+                rank=rank,
+                scope_labels=scopes,
+            )
+
+        if request.query == "correction":
+            if state_name == "baseline":
+                return [item("old", 1), item("anchor", 2)]
+            return [item("new", 1), item("old", 2), item("anchor", 3)]
+
+        if request.query == "anchor":
+            if state_name == "baseline":
+                return [item("anchor", 1), item("other", 2)]
+            return [item("other", 1), item("anchor", 2)]
+
+        if request.query == "scope":
+            return [item("tenant-b", 1, ("tenant:b",)), item("other", 2)]
+
+        if request.query == "other-safe":
+            return [item("other", 1)]
+
+        if request.query == "state":
+            mood = request.context.get("mood")
+            if mood == "a":
+                result = [item("state-a", 1), item("state-b", 2)]
+            else:
+                result = [item("state-b", 1), item("state-a", 2)]
+            if self.unstable and self.calls % 2 == 0:
+                return [
+                    result[1].model_copy(update={"rank": 1}),
+                    result[0].model_copy(update={"rank": 2}),
+                ]
+            return result
+
+        return []
+
+    def runtime_observation(self) -> RuntimeObservation | None:
+        return RuntimeObservation(runtime_id="fixture-1", indexed_item_count=7)
+
+
+class VersionChangingAnchorAdapter(FixtureAdapter):
+    """Keeps the anchor key stable while changing its recorded content version."""
+
+    def retrieve(
+        self,
+        state_name: str,
+        request: RetrievalRequest,
+    ) -> Sequence[RetrievedItem]:
+        items = list(super().retrieve(state_name, request))
+        if request.query == "anchor" and state_name == "candidate":
+            return [
+                item.model_copy(update={"item_version_digest": _hash("8")})
+                if item.item_key == "anchor"
+                else item
+                for item in items
+            ]
+        return items
+
+
+class DriftingStateAdapter(FixtureAdapter):
+    """Changes the candidate state reference after probe execution begins."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.state_reference_calls = {"baseline": 0, "candidate": 0}
+
+    def state_reference(self, state_name: str) -> StateReference:
+        self.state_reference_calls[state_name] += 1
+        reference = super().state_reference(state_name)
+        if state_name == "candidate" and self.state_reference_calls[state_name] > 1:
+            return reference.model_copy(update={"checkpoint_digest": _hash("e")})
+        return reference
+
+
+def test_all_four_invariants_can_pass() -> None:
+    adapter = FixtureAdapter()
+    suite = ProbeSuite(
+        probes=(
+            CorrectionPrecedenceProbe(
+                probe_id="corr",
+                query="correction",
+                superseded=ItemReference(key="old", required_in=RequiredIn.both),
+                correction=ItemReference(key="new", required_in=RequiredIn.candidate),
+            ),
+            AnchorPreservationProbe(
+                probe_id="anchor",
+                query="anchor",
+                anchor=ItemReference(key="anchor", required_in=RequiredIn.both),
+                max_rank=2,
+            ),
+            ScopeIsolationProbe(
+                probe_id="scope",
+                query="other-safe",
+                forbidden_scope_labels=("tenant:b",),
+            ),
+            StateConditionedDifferentiationProbe(
+                probe_id="state",
+                query="state",
+                context_a={"mood": "a"},
+                context_b={"mood": "b"},
+                a_required_keys=("state-a",),
+                b_required_keys=("state-b",),
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(
+        adapter,
+        suite,
+        material_access=MaterialAccess.restricted,
+    )
+
+    assert assessment.result is BehavioralResult.pass_
+    assert assessment.coverage.passed == 4
+    assert assessment.material_access is MaterialAccess.restricted
+
+
+def test_scope_failure_surfaces_confidentiality_flag() -> None:
+    adapter = FixtureAdapter()
+    suite = ProbeSuite(
+        probes=(
+            ScopeIsolationProbe(
+                probe_id="scope",
+                query="scope",
+                forbidden_scope_labels=("tenant:b",),
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(adapter, suite)
+
+    assert assessment.result is BehavioralResult.fail
+    assert assessment.security_flags.contains_confidentiality_failure is True
+    assert assessment.probe_results[0].severity is SeverityClass.confidentiality
+
+
+def test_empty_retrieval_satisfies_scope_isolation_only() -> None:
+    suite = ProbeSuite(
+        probes=(
+            ScopeIsolationProbe(
+                probe_id="scope",
+                query="no-results",
+                forbidden_scope_labels=("tenant:b",),
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(FixtureAdapter(), suite)
+
+    assert assessment.result is BehavioralResult.pass_
+    assert assessment.coverage.passed == 1
+    assert assessment.security_flags.contains_confidentiality_failure is False
+
+
+def test_missing_baseline_anchor_is_indeterminate_not_failure() -> None:
+    adapter = FixtureAdapter()
+    suite = ProbeSuite(
+        probes=(
+            AnchorPreservationProbe(
+                probe_id="anchor",
+                query="other-safe",
+                anchor=ItemReference(key="anchor", required_in=RequiredIn.both),
+                max_rank=2,
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(adapter, suite)
+
+    assert assessment.result is BehavioralResult.indeterminate
+    assert assessment.probe_results[0].reasons == (
+        IndeterminateReason.baseline_precondition_unmet,
+    )
+
+
+def test_anchor_persistence_is_key_based_not_version_equality() -> None:
+    suite = ProbeSuite(
+        probes=(
+            AnchorPreservationProbe(
+                probe_id="anchor",
+                query="anchor",
+                anchor=ItemReference(key="anchor", required_in=RequiredIn.both),
+                max_rank=2,
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(VersionChangingAnchorAdapter(), suite)
+
+    assert assessment.result is BehavioralResult.pass_
+
+
+def test_identity_break_is_explicit_indeterminate() -> None:
+    adapter = FixtureAdapter()
+    adapter.store["candidate"].remove("anchor")
+    suite = ProbeSuite(
+        probes=(
+            AnchorPreservationProbe(
+                probe_id="anchor",
+                query="anchor",
+                anchor=ItemReference(key="anchor", required_in=RequiredIn.both),
+                max_rank=2,
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(adapter, suite)
+
+    assert assessment.result is BehavioralResult.indeterminate
+    assert assessment.probe_results[0].reasons == (IndeterminateReason.id_churn,)
+
+
+def test_unsupported_adapter_does_not_fake_failure() -> None:
+    adapter = FixtureAdapter(capability=AdapterCapability.unsupported_or_unknown)
+    suite = ProbeSuite(
+        probes=(
+            ScopeIsolationProbe(
+                probe_id="scope",
+                query="scope",
+                forbidden_scope_labels=("tenant:b",),
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(adapter, suite)
+
+    assert assessment.result is BehavioralResult.indeterminate
+    assert assessment.probe_results[0].reasons == (
+        IndeterminateReason.adapter_unsupported,
+    )
+    assert assessment.coverage.indeterminate_rate == 1.0
+
+
+def test_profile_and_suite_digests_are_bound() -> None:
+    adapter = FixtureAdapter()
+    suite = ProbeSuite(
+        probes=(
+            ScopeIsolationProbe(
+                probe_id="scope",
+                query="other-safe",
+                forbidden_scope_labels=("tenant:b",),
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(adapter, suite)
+
+    assert str(assessment.retriever_profile_digest).startswith("sha256:")
+    assert str(assessment.probe_suite_digest).startswith("sha256:")
+    assert len(str(assessment.retriever_profile_digest)) == 71
+
+
+def test_unstable_repeatability_is_indeterminate() -> None:
+    adapter = FixtureAdapter(unstable=True)
+    suite = ProbeSuite(
+        probes=(
+            StateConditionedDifferentiationProbe(
+                probe_id="state",
+                query="state",
+                context_a={"mood": "a"},
+                context_b={"mood": "b"},
+                a_required_keys=("state-a",),
+                b_required_keys=("state-b",),
+            ),
+        )
+    )
+
+    assessment = AssessmentHarness().run(adapter, suite)
+
+    assert assessment.result is BehavioralResult.indeterminate
+    assert assessment.probe_results[0].reasons == (
+        IndeterminateReason.repeatability_unstable,
+    )
+
+
+def test_probe_suite_cannot_vacuously_pass() -> None:
+    with pytest.raises(ValidationError):
+        ProbeSuite(probes=())
+
+
+def test_probe_suite_requires_unique_probe_ids() -> None:
+    with pytest.raises(ValidationError, match="unique probe_id"):
+        ProbeSuite(
+            probes=(
+                ScopeIsolationProbe(
+                    probe_id="scope",
+                    query="other-safe",
+                    forbidden_scope_labels=("tenant:b",),
+                ),
+                ScopeIsolationProbe(
+                    probe_id="scope",
+                    query="scope",
+                    forbidden_scope_labels=("tenant:b",),
+                ),
+            )
+        )
+
+
+def test_state_conditioned_probe_requires_distinct_contexts() -> None:
+    with pytest.raises(ValidationError, match="distinct context_a and context_b"):
+        StateConditionedDifferentiationProbe(
+            probe_id="state",
+            query="state",
+            context_a={"mood": "a"},
+            context_b={"mood": "a"},
+            require_distinct_ordering=True,
+        )
+
+
+def test_state_reference_drift_aborts_assessment() -> None:
+    suite = ProbeSuite(
+        probes=(
+            ScopeIsolationProbe(
+                probe_id="scope",
+                query="other-safe",
+                forbidden_scope_labels=("tenant:b",),
+            ),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="state reference changed during assessment"):
+        AssessmentHarness().run(DriftingStateAdapter(), suite)

--- a/python/tests/test_memory_assessment_artifact_shape.py
+++ b/python/tests/test_memory_assessment_artifact_shape.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from agent_manifest._memory_assessment import (
+    BehavioralResult,
+    Coverage,
+    InvocationEvidence,
+    MaterialAccess,
+    MemoryCheckpointAssessment,
+    ObservedStatus,
+    ProbeResult,
+    RepeatabilityEvidence,
+    SecurityFlags,
+    SeverityClass,
+    StateReference,
+)
+
+
+def _hash(char: str) -> str:
+    return "sha256:" + char * 64
+
+
+def _artifact() -> MemoryCheckpointAssessment:
+    return MemoryCheckpointAssessment(
+        baseline_state=StateReference(
+            checkpoint_digest=_hash("a"),
+            retrieval_state_digest=_hash("b"),
+            indexed_item_count=3,
+        ),
+        candidate_state=StateReference(
+            checkpoint_digest=_hash("c"),
+            retrieval_state_digest=_hash("d"),
+            indexed_item_count=4,
+        ),
+        probe_suite_digest=_hash("e"),
+        retriever_profile_digest=_hash("f"),
+        assessed_at=datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc),
+        material_access=MaterialAccess.public,
+        invocation_evidence=(
+            InvocationEvidence(
+                state_name="candidate",
+                request_digest=_hash("1"),
+                repeatability=RepeatabilityEvidence(
+                    trials=20,
+                    distinct_orderings_observed=1,
+                    observed_status=ObservedStatus.stable,
+                ),
+            ),
+        ),
+        probe_results=(
+            ProbeResult(
+                probe_id="p1",
+                required=True,
+                result=BehavioralResult.pass_,
+                severity=SeverityClass.behavioral,
+            ),
+        ),
+        coverage=Coverage(
+            required_probe_count=1,
+            passed=1,
+            failed=0,
+            indeterminate=0,
+            indeterminate_rate=0.0,
+        ),
+        security_flags=SecurityFlags(),
+        result=BehavioralResult.pass_,
+    )
+
+
+def _dict() -> dict[str, object]:
+    return deepcopy(_artifact().model_dump(mode="json"))
+
+
+def test_artifact_json_round_trip_is_lossless() -> None:
+    artifact = _artifact()
+    encoded = artifact.model_dump_json(exclude_none=True)
+    assert MemoryCheckpointAssessment.model_validate_json(encoded) == artifact
+
+
+def test_artifact_json_schema_is_closed_and_versioned() -> None:
+    schema = MemoryCheckpointAssessment.model_json_schema()
+
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["type"]["const"] == "MemoryCheckpointAssessment"
+    assert schema["properties"]["version"]["const"] == "0.1"
+    assert schema["properties"]["assessed_at"]["format"] == "date-time"
+
+    required = set(schema["required"])
+    assert {
+        "baseline_state",
+        "candidate_state",
+        "probe_suite_digest",
+        "retriever_profile_digest",
+        "assessed_at",
+        "material_access",
+        "invocation_evidence",
+        "probe_results",
+        "coverage",
+        "security_flags",
+        "result",
+    }.issubset(required)
+
+    for definition in (
+        "Coverage",
+        "InvocationEvidence",
+        "ProbeResult",
+        "RepeatabilityEvidence",
+        "RuntimeObservation",
+        "SecurityFlags",
+        "StateReference",
+    ):
+        assert schema["$defs"][definition]["additionalProperties"] is False
+
+
+def test_behavioral_result_schema_has_only_three_outcomes() -> None:
+    schema = MemoryCheckpointAssessment.model_json_schema()
+    assert set(schema["$defs"]["BehavioralResult"]["enum"]) == {
+        "pass",
+        "fail",
+        "indeterminate",
+    }
+
+
+def test_artifact_rejects_result_that_disagrees_with_required_probes() -> None:
+    value = _dict()
+    value["result"] = "fail"
+    with pytest.raises(ValidationError, match="result does not match"):
+        MemoryCheckpointAssessment.model_validate(value)
+
+
+def test_artifact_rejects_coverage_that_disagrees_with_probe_results() -> None:
+    value = _dict()
+    coverage = value["coverage"]
+    assert isinstance(coverage, dict)
+    coverage["passed"] = 0
+    coverage["failed"] = 1
+    with pytest.raises(ValidationError, match="coverage.passed"):
+        MemoryCheckpointAssessment.model_validate(value)
+
+
+def test_artifact_rejects_duplicate_probe_ids() -> None:
+    value = _dict()
+    probe_results = value["probe_results"]
+    assert isinstance(probe_results, list)
+    probe_results.append(deepcopy(probe_results[0]))
+    coverage = value["coverage"]
+    assert isinstance(coverage, dict)
+    coverage["required_probe_count"] = 2
+    coverage["passed"] = 2
+    with pytest.raises(ValidationError, match="unique probe_id"):
+        MemoryCheckpointAssessment.model_validate(value)
+
+
+def test_artifact_rejects_duplicate_invocation_evidence() -> None:
+    value = _dict()
+    invocation_evidence = value["invocation_evidence"]
+    assert isinstance(invocation_evidence, list)
+    invocation_evidence.append(deepcopy(invocation_evidence[0]))
+    with pytest.raises(ValidationError, match="unique state/request pairs"):
+        MemoryCheckpointAssessment.model_validate(value)
+
+
+def test_artifact_rejects_vacuous_no_required_probe_result() -> None:
+    value = _dict()
+    probe_results = value["probe_results"]
+    assert isinstance(probe_results, list)
+    probe_results[0]["required"] = False
+    coverage = value["coverage"]
+    assert isinstance(coverage, dict)
+    coverage.update(
+        {
+            "required_probe_count": 0,
+            "passed": 0,
+            "failed": 0,
+            "indeterminate": 0,
+            "indeterminate_rate": 0.0,
+        }
+    )
+    with pytest.raises(ValidationError, match="at least one required probe result"):
+        MemoryCheckpointAssessment.model_validate(value)
+
+
+def test_artifact_rejects_hidden_confidentiality_failure() -> None:
+    value = _dict()
+    probe_results = value["probe_results"]
+    assert isinstance(probe_results, list)
+    probe_results[0].update(
+        {
+            "result": "fail",
+            "severity": "confidentiality",
+            "violations": ["forbidden scope retrieved"],
+        }
+    )
+    coverage = value["coverage"]
+    assert isinstance(coverage, dict)
+    coverage.update({"passed": 0, "failed": 1})
+    value["result"] = "fail"
+    with pytest.raises(ValidationError, match="contains_confidentiality_failure"):
+        MemoryCheckpointAssessment.model_validate(value)

--- a/python/tests/test_memory_assessment_canonicalization_dependency.py
+++ b/python/tests/test_memory_assessment_canonicalization_dependency.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from agent_manifest._canonicalize import canonicalize
+
+
+_REMAINING_BLOCKER = pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "agent-manifest#322: current main still over-escapes U+2028, so the "
+        "shared canonicalizer is not yet fully RFC 8785 conformant"
+    ),
+)
+
+
+def test_shared_canonicalizer_now_orders_keys_by_utf16_code_units() -> None:
+    """Keep the resolved #322 dependency visible at the assessment boundary."""
+    value = {"\ue000": 2, "😀": 1}
+    assert canonicalize(value) == '{"😀":1,"\ue000":2}'.encode()
+
+
+def test_shared_canonicalizer_now_normalizes_exponent_leading_zero() -> None:
+    """Current upstream fixed the exponent spelling used by assessment digests."""
+    assert canonicalize(1e-7) == b"1e-7"
+
+
+@_REMAINING_BLOCKER
+def test_rfc8785_does_not_overescape_line_separator() -> None:
+    """Retain a strict guard for the unresolved escaping axis of #322."""
+    assert canonicalize({"value": "\u2028"}) == '{"value":"\u2028"}'.encode()

--- a/python/tests/test_memory_assessment_gate.py
+++ b/python/tests/test_memory_assessment_gate.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+import agent_manifest._memory_assessment_gate as gate_module
+from agent_manifest._memory_assessment import (
+    BehavioralResult,
+    Coverage,
+    IndeterminateReason,
+    MaterialAccess,
+    MemoryCheckpointAssessment,
+    ProbeResult,
+    SecurityFlags,
+    SeverityClass,
+    StateReference,
+)
+from agent_manifest._memory_assessment_gate import (
+    ApplicabilityMismatch,
+    AssessmentGatePolicy,
+    GateFailureReason,
+    evaluate_assessment_gate,
+)
+
+
+def _hash(char: str) -> str:
+    return "sha256:" + char * 64
+
+
+def _assessment(
+    result: BehavioralResult = BehavioralResult.pass_,
+    *,
+    baseline_checkpoint: str | None = None,
+    candidate_checkpoint: str | None = None,
+    baseline_retrieval_state: str | None = None,
+    candidate_retrieval_state: str | None = None,
+    probe_suite: str | None = None,
+    retriever_profile: str | None = None,
+    assessed_at: datetime | None = None,
+    diagnostic_confidentiality_failure: bool = False,
+) -> MemoryCheckpointAssessment:
+    reasons = (
+        (IndeterminateReason.repeatability_unstable,)
+        if result is BehavioralResult.indeterminate
+        else ()
+    )
+    violations = ("required behavioral predicate failed",) if result is BehavioralResult.fail else ()
+    probe_results = [
+        ProbeResult(
+            probe_id="p1",
+            required=True,
+            result=result,
+            severity=SeverityClass.behavioral,
+            reasons=reasons,
+            violations=violations,
+        )
+    ]
+    if diagnostic_confidentiality_failure:
+        probe_results.append(
+            ProbeResult(
+                probe_id="diagnostic-scope",
+                required=False,
+                result=BehavioralResult.fail,
+                severity=SeverityClass.confidentiality,
+                violations=("diagnostic confidentiality predicate failed",),
+            )
+        )
+    return MemoryCheckpointAssessment(
+        baseline_state=StateReference(
+            checkpoint_digest=baseline_checkpoint or _hash("a"),
+            retrieval_state_digest=baseline_retrieval_state or _hash("b"),
+            indexed_item_count=3,
+        ),
+        candidate_state=StateReference(
+            checkpoint_digest=candidate_checkpoint or _hash("c"),
+            retrieval_state_digest=candidate_retrieval_state or _hash("d"),
+            indexed_item_count=4,
+        ),
+        probe_suite_digest=probe_suite or _hash("e"),
+        retriever_profile_digest=retriever_profile or _hash("f"),
+        assessed_at=assessed_at or datetime(2026, 8, 30, 12, 0, tzinfo=timezone.utc),
+        material_access=MaterialAccess.public,
+        invocation_evidence=(),
+        probe_results=tuple(probe_results),
+        coverage=Coverage(
+            required_probe_count=1,
+            passed=int(result is BehavioralResult.pass_),
+            failed=int(result is BehavioralResult.fail),
+            indeterminate=int(result is BehavioralResult.indeterminate),
+            indeterminate_rate=(1.0 if result is BehavioralResult.indeterminate else 0.0),
+        ),
+        security_flags=SecurityFlags(
+            contains_confidentiality_failure=diagnostic_confidentiality_failure
+        ),
+        result=result,
+    )
+
+
+def _policy(**overrides: object) -> AssessmentGatePolicy:
+    values: dict[str, object] = {
+        "baseline_checkpoint_digest": _hash("a"),
+        "candidate_checkpoint_digest": _hash("c"),
+        "baseline_retrieval_state_digest": _hash("b"),
+        "candidate_retrieval_state_digest": _hash("d"),
+        "probe_suite_digest": _hash("e"),
+        "retriever_profile_digest": _hash("f"),
+    }
+    values.update(overrides)
+    return AssessmentGatePolicy.model_validate(values)
+
+
+def test_applicable_pass_satisfies_only_this_gate() -> None:
+    evaluation = evaluate_assessment_gate(_policy(), [_assessment()])
+
+    assert evaluation.satisfied is True
+    assert evaluation.applicable_assessment_count == 1
+    assert evaluation.applicable_results == (BehavioralResult.pass_,)
+    assert evaluation.reasons == ()
+    assert not hasattr(gate_module, "approve_checkpoint")
+
+
+def test_applicable_fail_blocks_gate_but_remains_valid_evidence() -> None:
+    assessment = _assessment(BehavioralResult.fail)
+    before = assessment.model_dump_json()
+
+    evaluation = evaluate_assessment_gate(_policy(), [assessment])
+
+    assert evaluation.satisfied is False
+    assert evaluation.reasons == (GateFailureReason.applicable_assessment_failed,)
+    assert assessment.result is BehavioralResult.fail
+    assert assessment.model_dump_json() == before
+
+
+def test_applicable_indeterminate_is_not_promoted_to_pass_or_fail() -> None:
+    assessment = _assessment(BehavioralResult.indeterminate)
+
+    evaluation = evaluate_assessment_gate(_policy(), [assessment])
+
+    assert evaluation.satisfied is False
+    assert evaluation.applicable_results == (BehavioralResult.indeterminate,)
+    assert evaluation.reasons == (
+        GateFailureReason.applicable_assessment_indeterminate,
+    )
+    assert assessment.result is BehavioralResult.indeterminate
+
+
+def test_omitted_assessment_is_policy_failure_not_evidence_failure() -> None:
+    evaluation = evaluate_assessment_gate(_policy(), [])
+
+    assert evaluation.satisfied is False
+    assert evaluation.presented_assessment_count == 0
+    assert evaluation.applicable_assessment_count == 0
+    assert evaluation.reasons == (GateFailureReason.no_applicable_assessment,)
+
+
+@pytest.mark.parametrize(
+    ("assessment", "expected_mismatch"),
+    [
+        (
+            _assessment(baseline_checkpoint=_hash("0")),
+            ApplicabilityMismatch.baseline_checkpoint,
+        ),
+        (
+            _assessment(candidate_checkpoint=_hash("1")),
+            ApplicabilityMismatch.candidate_checkpoint,
+        ),
+        (
+            _assessment(probe_suite=_hash("2")),
+            ApplicabilityMismatch.probe_suite,
+        ),
+        (
+            _assessment(retriever_profile=_hash("3")),
+            ApplicabilityMismatch.retriever_profile,
+        ),
+        (
+            _assessment(baseline_retrieval_state=_hash("4")),
+            ApplicabilityMismatch.baseline_retrieval_state,
+        ),
+        (
+            _assessment(candidate_retrieval_state=_hash("5")),
+            ApplicabilityMismatch.candidate_retrieval_state,
+        ),
+    ],
+)
+def test_wrong_bound_evidence_cannot_satisfy_gate(
+    assessment: MemoryCheckpointAssessment,
+    expected_mismatch: ApplicabilityMismatch,
+) -> None:
+    evaluation = evaluate_assessment_gate(_policy(), [assessment])
+
+    assert evaluation.satisfied is False
+    assert evaluation.applicable_assessment_count == 0
+    assert GateFailureReason.no_applicable_assessment in evaluation.reasons
+    assert expected_mismatch in evaluation.non_applicable_mismatches
+
+
+def test_evidence_window_rejects_evidence_before_lower_bound() -> None:
+    assessed_at = datetime(2026, 8, 30, 12, 0, tzinfo=timezone.utc)
+    policy = _policy(
+        assessed_not_before=assessed_at + timedelta(minutes=1),
+        assessed_not_after=assessed_at + timedelta(hours=1),
+    )
+
+    evaluation = evaluate_assessment_gate(
+        policy,
+        [_assessment(assessed_at=assessed_at)],
+    )
+
+    assert evaluation.satisfied is False
+    assert ApplicabilityMismatch.before_evidence_window in evaluation.non_applicable_mismatches
+
+
+def test_evidence_window_rejects_evidence_after_upper_bound() -> None:
+    assessed_at = datetime(2026, 8, 30, 13, 1, tzinfo=timezone.utc)
+    policy = _policy(
+        assessed_not_before=datetime(2026, 8, 30, 12, 0, tzinfo=timezone.utc),
+        assessed_not_after=datetime(2026, 8, 30, 13, 0, tzinfo=timezone.utc),
+    )
+
+    evaluation = evaluate_assessment_gate(
+        policy,
+        [_assessment(assessed_at=assessed_at)],
+    )
+
+    assert evaluation.satisfied is False
+    assert ApplicabilityMismatch.after_evidence_window in evaluation.non_applicable_mismatches
+
+
+def test_evidence_window_bounds_are_inclusive() -> None:
+    boundary = datetime(2026, 8, 30, 12, 0, tzinfo=timezone.utc)
+    policy = _policy(
+        assessed_not_before=boundary,
+        assessed_not_after=boundary,
+    )
+
+    evaluation = evaluate_assessment_gate(
+        policy,
+        [_assessment(assessed_at=boundary)],
+    )
+
+    assert evaluation.satisfied is True
+
+
+def test_gate_policy_requires_timezone_aware_window() -> None:
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        _policy(assessed_not_before=datetime(2026, 8, 30, 12, 0))
+
+
+def test_gate_policy_rejects_reversed_window() -> None:
+    later = datetime(2026, 8, 30, 13, 0, tzinfo=timezone.utc)
+    earlier = later - timedelta(hours=1)
+    with pytest.raises(ValidationError, match="must not be after"):
+        _policy(assessed_not_before=later, assessed_not_after=earlier)
+
+
+def test_policy_can_omit_optional_retrieval_state_bindings() -> None:
+    policy = _policy(
+        baseline_retrieval_state_digest=None,
+        candidate_retrieval_state_digest=None,
+    )
+    assessment = _assessment(
+        baseline_retrieval_state=_hash("8"),
+        candidate_retrieval_state=_hash("9"),
+    )
+
+    evaluation = evaluate_assessment_gate(policy, [assessment])
+
+    assert evaluation.satisfied is True
+    assert evaluation.non_applicable_mismatches == ()
+
+
+def test_any_presented_applicable_fail_keeps_gate_closed() -> None:
+    evaluation = evaluate_assessment_gate(
+        _policy(),
+        [_assessment(), _assessment(BehavioralResult.fail)],
+    )
+
+    assert evaluation.satisfied is False
+    assert evaluation.applicable_assessment_count == 2
+    assert evaluation.applicable_results == (
+        BehavioralResult.pass_,
+        BehavioralResult.fail,
+    )
+    assert GateFailureReason.applicable_assessment_failed in evaluation.reasons
+
+
+def test_any_presented_applicable_indeterminate_keeps_gate_closed() -> None:
+    evaluation = evaluate_assessment_gate(
+        _policy(),
+        [_assessment(), _assessment(BehavioralResult.indeterminate)],
+    )
+
+    assert evaluation.satisfied is False
+    assert evaluation.applicable_assessment_count == 2
+    assert GateFailureReason.applicable_assessment_indeterminate in evaluation.reasons
+
+
+def test_fail_and_indeterminate_report_both_gate_reasons() -> None:
+    evaluation = evaluate_assessment_gate(
+        _policy(),
+        [
+            _assessment(BehavioralResult.fail),
+            _assessment(BehavioralResult.indeterminate),
+        ],
+    )
+
+    assert evaluation.satisfied is False
+    assert evaluation.reasons == (
+        GateFailureReason.applicable_assessment_failed,
+        GateFailureReason.applicable_assessment_indeterminate,
+    )
+
+
+def test_non_applicable_failure_does_not_poison_applicable_pass() -> None:
+    evaluation = evaluate_assessment_gate(
+        _policy(),
+        [
+            _assessment(BehavioralResult.fail, probe_suite=_hash("9")),
+            _assessment(),
+        ],
+    )
+
+    assert evaluation.satisfied is True
+    assert evaluation.applicable_assessment_count == 1
+    assert evaluation.applicable_results == (BehavioralResult.pass_,)
+    assert ApplicabilityMismatch.probe_suite in evaluation.non_applicable_mismatches
+
+
+def test_non_required_confidentiality_failure_is_visible_but_not_gate_binding() -> None:
+    assessment = _assessment(diagnostic_confidentiality_failure=True)
+
+    evaluation = evaluate_assessment_gate(_policy(), [assessment])
+
+    assert assessment.result is BehavioralResult.pass_
+    assert assessment.security_flags.contains_confidentiality_failure is True
+    assert evaluation.satisfied is True

--- a/python/tests/test_memory_assessment_hardening.py
+++ b/python/tests/test_memory_assessment_hardening.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from agent_manifest._memory_assessment import (
+    AdapterCapability,
+    AnchorPreservationProbe,
+    AssessmentHarness,
+    BehavioralResult,
+    CorrectionPrecedenceProbe,
+    IndeterminateReason,
+    ItemReference,
+    ProbeSuite,
+    RequiredIn,
+    RetrievedItem,
+    RetrievalRequest,
+    RetrieverProfile,
+    RuntimeObservation,
+    ScopeIsolationProbe,
+    StateConditionedDifferentiationProbe,
+    StateReference,
+    canonical_model_hash,
+)
+
+
+def _hash(char: str) -> str:
+    return "sha256:" + char * 64
+
+
+def _correction_probe() -> CorrectionPrecedenceProbe:
+    return CorrectionPrecedenceProbe(
+        probe_id="corr",
+        query="correction",
+        superseded=ItemReference(key="old", required_in=RequiredIn.both),
+        correction=ItemReference(key="new", required_in=RequiredIn.candidate),
+    )
+
+
+def _anchor_probe() -> AnchorPreservationProbe:
+    return AnchorPreservationProbe(
+        probe_id="anchor",
+        query="anchor",
+        anchor=ItemReference(key="anchor", required_in=RequiredIn.both),
+        max_rank=2,
+    )
+
+
+def _state_probe() -> StateConditionedDifferentiationProbe:
+    return StateConditionedDifferentiationProbe(
+        probe_id="state",
+        query="state",
+        context_a={"mood": "a"},
+        context_b={"mood": "b"},
+        a_required_keys=("state-a",),
+        b_required_keys=("state-b",),
+    )
+
+
+def _passing_suite() -> ProbeSuite:
+    return ProbeSuite(
+        probes=(
+            _correction_probe(),
+            _anchor_probe(),
+            ScopeIsolationProbe(
+                probe_id="scope",
+                query="safe",
+                forbidden_scope_labels=("tenant:b",),
+            ),
+            _state_probe(),
+        )
+    )
+
+
+class FixtureAdapter:
+    """Table-driven adapter used to isolate harness behavior."""
+
+    def __init__(
+        self,
+        *,
+        capability: AdapterCapability = AdapterCapability.deterministic,
+        mode: str = "pass",
+    ) -> None:
+        self._profile = RetrieverProfile(
+            implementation_id="fixture-table",
+            implementation_version="1",
+            adapter_version="0.1",
+            adapter_capability=capability,
+            distance_metric="fixture-order",
+            index_implementation="fixture-table",
+            top_k=4,
+            truncation_rule="none",
+            tie_policy=(
+                "item_key_lexical"
+                if capability is AdapterCapability.deterministic
+                else None
+            ),
+        )
+        self.mode = mode
+        self.calls = 0
+        self.store = {
+            "baseline": {"old", "anchor", "other", "tenant-b"},
+            "candidate": {
+                "old",
+                "new",
+                "anchor",
+                "other",
+                "tenant-b",
+                "state-a",
+                "state-b",
+            },
+        }
+
+    @property
+    def profile(self) -> RetrieverProfile:
+        return self._profile
+
+    def state_reference(self, state_name: str) -> StateReference:
+        return StateReference(
+            checkpoint_digest=_hash("a" if state_name == "baseline" else "b"),
+            retrieval_state_digest=_hash("c" if state_name == "baseline" else "d"),
+            indexed_item_count=len(self.store[state_name]),
+        )
+
+    def contains_item_key(self, state_name: str, item_key: str) -> bool:
+        return item_key in self.store[state_name]
+
+    @staticmethod
+    def _item(
+        key: str,
+        rank: int,
+        scopes: tuple[str, ...] = (),
+    ) -> RetrievedItem:
+        chars = {
+            "old": "1",
+            "new": "2",
+            "anchor": "3",
+            "other": "4",
+            "tenant-b": "5",
+            "state-a": "6",
+            "state-b": "7",
+        }
+        return RetrievedItem(
+            item_key=key,
+            item_version_digest=_hash(chars[key]),
+            rank=rank,
+            scope_labels=scopes,
+        )
+
+    def retrieve(
+        self,
+        state_name: str,
+        request: RetrievalRequest,
+    ) -> Sequence[RetrievedItem]:
+        self.calls += 1
+        if self.mode == "mutate-request":
+            request.context["mutated"] = "yes"
+
+        if request.query == "correction":
+            if state_name == "baseline":
+                return [self._item("old", 1), self._item("anchor", 2)]
+            if self.mode == "correction-missing":
+                return [self._item("old", 1), self._item("anchor", 2)]
+            if self.mode == "correction-outranked":
+                return [self._item("old", 1), self._item("new", 2)]
+            return [
+                self._item("new", 1),
+                self._item("old", 2),
+                self._item("anchor", 3),
+            ]
+
+        if request.query == "anchor":
+            if state_name == "baseline":
+                return [self._item("anchor", 1), self._item("other", 2)]
+            if self.mode == "anchor-missing":
+                return [self._item("other", 1)]
+            if self.mode == "anchor-demoted":
+                return [
+                    self._item("other", 1),
+                    self._item("tenant-b", 2),
+                    self._item("anchor", 3),
+                ]
+            return [self._item("other", 1), self._item("anchor", 2)]
+
+        if request.query == "scope":
+            scopes = ("tenant:b",)
+            if self.mode == "scope-label-flap" and self.calls % 2 == 0:
+                scopes = ()
+            return [self._item("tenant-b", 1, scopes), self._item("other", 2)]
+
+        if request.query == "safe":
+            return [self._item("other", 1)]
+
+        if request.query == "state":
+            if self.mode == "state-collapse":
+                return [self._item("state-a", 1), self._item("state-b", 2)]
+            if request.context.get("mood") == "a":
+                return [self._item("state-a", 1), self._item("state-b", 2)]
+            return [self._item("state-b", 1), self._item("state-a", 2)]
+
+        return []
+
+    def runtime_observation(self) -> RuntimeObservation | None:
+        return RuntimeObservation(runtime_id="fixture-table-1", indexed_item_count=7)
+
+
+class KeywordAdapter:
+    """Independent token-overlap retriever for abstraction portability checks."""
+
+    _documents = {
+        "baseline": {
+            "old": ("correction old current", ()),
+            "anchor": ("anchor identity continuity", ()),
+            "other": ("safe general other", ()),
+            "tenant-b": ("private tenant b", ("tenant:b",)),
+        },
+        "candidate": {
+            "old": ("correction old obsolete", ()),
+            "new": ("correction new current preferred", ()),
+            "anchor": ("anchor identity continuity", ()),
+            "other": ("safe general other", ()),
+            "tenant-b": ("private tenant b", ("tenant:b",)),
+            "state-a": ("state mood a", ()),
+            "state-b": ("state mood b", ()),
+        },
+    }
+
+    def __init__(self) -> None:
+        self._profile = RetrieverProfile(
+            implementation_id="fixture-keyword",
+            implementation_version="1",
+            adapter_version="0.1",
+            adapter_capability=AdapterCapability.deterministic,
+            tokenizer_id="whitespace-lower/1",
+            query_preprocessing=(
+                "lowercase",
+                "whitespace-tokenize",
+                "append-context-values",
+            ),
+            distance_metric="token-overlap-desc",
+            index_implementation="python-set-overlap",
+            top_k=4,
+            truncation_rule="top-k",
+            tie_policy="score_desc_then_item_key_lexical",
+        )
+
+    @property
+    def profile(self) -> RetrieverProfile:
+        return self._profile
+
+    def state_reference(self, state_name: str) -> StateReference:
+        return StateReference(
+            checkpoint_digest=_hash("8" if state_name == "baseline" else "9"),
+            retrieval_state_digest=_hash("a" if state_name == "baseline" else "b"),
+            indexed_item_count=len(self._documents[state_name]),
+        )
+
+    def contains_item_key(self, state_name: str, item_key: str) -> bool:
+        return item_key in self._documents[state_name]
+
+    def retrieve(
+        self,
+        state_name: str,
+        request: RetrievalRequest,
+    ) -> Sequence[RetrievedItem]:
+        query_terms = set(request.query.lower().split())
+        query_terms.update(value.lower() for value in request.context.values())
+        ranked: list[tuple[int, str, tuple[str, ...]]] = []
+        for key, (text, scopes) in self._documents[state_name].items():
+            score = len(query_terms.intersection(text.lower().split()))
+            if score:
+                ranked.append((score, key, scopes))
+        ranked.sort(key=lambda row: (-row[0], row[1]))
+        items: list[RetrievedItem] = []
+        for rank, (_, key, scopes) in enumerate(
+            ranked[: self.profile.top_k],
+            start=1,
+        ):
+            digest_char = format((sum(key.encode()) % 15) + 1, "x")
+            items.append(
+                RetrievedItem(
+                    item_key=key,
+                    item_version_digest=_hash(digest_char),
+                    rank=rank,
+                    scope_labels=scopes,
+                )
+            )
+        return items
+
+    def runtime_observation(self) -> RuntimeObservation | None:
+        return RuntimeObservation(runtime_id="fixture-keyword-1")
+
+
+def test_same_invariant_suite_passes_two_independent_retrievers() -> None:
+    for adapter in (FixtureAdapter(), KeywordAdapter()):
+        assessment = AssessmentHarness().run(adapter, _passing_suite())
+        assert assessment.result is BehavioralResult.pass_
+        assert assessment.coverage.passed == 4
+
+
+@pytest.mark.parametrize(
+    ("mode", "needle"),
+    (
+        ("correction-missing", "not retrieved"),
+        ("correction-outranked", "did not outrank"),
+    ),
+)
+def test_correction_failures_are_independent(mode: str, needle: str) -> None:
+    assessment = AssessmentHarness().run(
+        FixtureAdapter(mode=mode),
+        ProbeSuite(probes=(_correction_probe(),)),
+    )
+    assert assessment.result is BehavioralResult.fail
+    assert needle in assessment.probe_results[0].violations[0]
+
+
+@pytest.mark.parametrize(
+    ("mode", "needle"),
+    (
+        ("anchor-missing", "not retrieved"),
+        ("anchor-demoted", "exceeds max_rank"),
+    ),
+)
+def test_anchor_failures_are_independent(mode: str, needle: str) -> None:
+    assessment = AssessmentHarness().run(
+        FixtureAdapter(mode=mode),
+        ProbeSuite(probes=(_anchor_probe(),)),
+    )
+    assert assessment.result is BehavioralResult.fail
+    assert needle in assessment.probe_results[0].violations[0]
+
+
+def test_state_conditioned_collapse_fails() -> None:
+    assessment = AssessmentHarness().run(
+        FixtureAdapter(mode="state-collapse"),
+        ProbeSuite(probes=(_state_probe(),)),
+    )
+    assert assessment.result is BehavioralResult.fail
+    assert any(
+        "identical ordered item identities" in violation
+        for violation in assessment.probe_results[0].violations
+    )
+
+
+def test_scope_label_changes_make_repeatability_unstable() -> None:
+    probe = ScopeIsolationProbe(
+        probe_id="scope",
+        query="scope",
+        forbidden_scope_labels=("unrelated-secret",),
+    )
+    assessment = AssessmentHarness().run(
+        FixtureAdapter(mode="scope-label-flap"),
+        ProbeSuite(probes=(probe,)),
+    )
+    assert assessment.result is BehavioralResult.indeterminate
+    assert assessment.probe_results[0].reasons == (
+        IndeterminateReason.repeatability_unstable,
+    )
+
+
+def test_non_required_confidentiality_failure_remains_visible() -> None:
+    diagnostic = ScopeIsolationProbe(
+        probe_id="scope",
+        query="scope",
+        forbidden_scope_labels=("tenant:b",),
+        required=False,
+    )
+    assessment = AssessmentHarness().run(
+        FixtureAdapter(),
+        ProbeSuite(probes=(_correction_probe(), diagnostic)),
+    )
+    assert assessment.result is BehavioralResult.pass_
+    assert assessment.security_flags.contains_confidentiality_failure is True
+
+
+def test_unsupported_profile_may_omit_tie_policy() -> None:
+    profile = RetrieverProfile(
+        implementation_id="unsupported",
+        implementation_version="1",
+        adapter_version="1",
+        adapter_capability=AdapterCapability.unsupported_or_unknown,
+        distance_metric="unknown",
+        index_implementation="unknown",
+        top_k=1,
+        truncation_rule="none",
+    )
+    assert profile.tie_policy is None
+
+
+def test_deterministic_profile_requires_tie_policy() -> None:
+    with pytest.raises(ValidationError):
+        RetrieverProfile(
+            implementation_id="deterministic",
+            implementation_version="1",
+            adapter_version="1",
+            adapter_capability=AdapterCapability.deterministic,
+            distance_metric="fixture",
+            index_implementation="fixture",
+            top_k=1,
+            truncation_rule="none",
+        )
+
+
+def test_naive_assessed_at_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        AssessmentHarness().run(
+            FixtureAdapter(),
+            ProbeSuite(probes=(_correction_probe(),)),
+            assessed_at=datetime(2026, 8, 20, 12, 0, 0),
+        )
+
+
+def test_timezone_aware_assessed_at_is_preserved() -> None:
+    assessed_at = datetime(2026, 8, 20, 12, 0, 0, tzinfo=timezone.utc)
+    assessment = AssessmentHarness().run(
+        FixtureAdapter(),
+        ProbeSuite(probes=(_correction_probe(),)),
+        assessed_at=assessed_at,
+    )
+    assert assessment.assessed_at == assessed_at
+
+
+def test_adapter_request_mutation_does_not_change_repeatability() -> None:
+    assessment = AssessmentHarness().run(
+        FixtureAdapter(mode="mutate-request"),
+        ProbeSuite(probes=(_state_probe(),)),
+    )
+    assert assessment.result is BehavioralResult.pass_
+    assert all(
+        evidence.repeatability.observed_status.value == "stable"
+        for evidence in assessment.invocation_evidence
+    )
+
+
+def test_profile_digest_changes_with_quantization() -> None:
+    profile = FixtureAdapter().profile
+    changed = profile.model_copy(update={"quantization": "int8"})
+    assert canonical_model_hash(profile) != canonical_model_hash(changed)
+
+
+def test_probe_suite_cannot_vacuously_pass() -> None:
+    with pytest.raises(ValidationError):
+        ProbeSuite(probes=())
+
+
+def test_identity_churn_is_indeterminate() -> None:
+    adapter = FixtureAdapter()
+    adapter.store["candidate"].remove("anchor")
+    assessment = AssessmentHarness().run(
+        adapter,
+        ProbeSuite(probes=(_anchor_probe(),)),
+    )
+    assert assessment.probe_results[0].reasons == (IndeterminateReason.id_churn,)

--- a/python/tests/test_memory_assessment_vectors.py
+++ b/python/tests/test_memory_assessment_vectors.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent_manifest._memory_assessment import (
+    AssessmentHarness,
+    BehavioralResult,
+    ProbeSuite,
+    RetrievedItem,
+    RetrievalRequest,
+    RetrieverProfile,
+    RuntimeObservation,
+    StateReference,
+)
+from tests.memory_assessment_vector_builder import build_reference_vectors
+
+
+_FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "memory_assessment"
+    / "reference-vectors-v0.1.json"
+)
+
+
+def _request_key(
+    query: str,
+    context: dict[str, str],
+) -> tuple[str, tuple[tuple[str, str], ...]]:
+    return query, tuple(sorted(context.items()))
+
+
+class VectorAdapter:
+    """Adapter that executes the portable JSON reference vectors verbatim."""
+
+    def __init__(self, vector: dict[str, Any], case: dict[str, Any]) -> None:
+        self._profile = RetrieverProfile.model_validate(vector["profile"])
+        self._baseline = deepcopy(vector["baseline"])
+        self._candidate = deepcopy(vector["candidate"])
+        responses = {
+            _request_key(entry["query"], entry.get("context", {})): entry["items"]
+            for entry in self._candidate["responses"]
+        }
+        for override in case.get("overrides", []):
+            responses[
+                _request_key(override["query"], override.get("context", {}))
+            ] = override["items"]
+        self._candidate["responses"] = [
+            {"query": query, "context": dict(context), "items": items}
+            for (query, context), items in responses.items()
+        ]
+
+    @property
+    def profile(self) -> RetrieverProfile:
+        return self._profile
+
+    def _state(self, state_name: str) -> dict[str, Any]:
+        if state_name == "baseline":
+            return self._baseline
+        if state_name == "candidate":
+            return self._candidate
+        raise KeyError(state_name)
+
+    def state_reference(self, state_name: str) -> StateReference:
+        state = self._state(state_name)
+        return StateReference(
+            checkpoint_digest=state["checkpoint_digest"],
+            retrieval_state_digest=state["retrieval_state_digest"],
+            indexed_item_count=len(state["item_keys"]),
+        )
+
+    def contains_item_key(self, state_name: str, item_key: str) -> bool:
+        return item_key in self._state(state_name)["item_keys"]
+
+    def retrieve(
+        self,
+        state_name: str,
+        request: RetrievalRequest,
+    ) -> Sequence[RetrievedItem]:
+        key = _request_key(request.query, request.context)
+        for response in self._state(state_name)["responses"]:
+            if _request_key(response["query"], response.get("context", {})) != key:
+                continue
+            return [
+                RetrievedItem(
+                    item_key=item["key"],
+                    item_version_digest=item["version"],
+                    rank=item["rank"],
+                    scope_labels=tuple(item.get("scope_labels", ())),
+                )
+                for item in response["items"]
+            ]
+        return []
+
+    def runtime_observation(self) -> RuntimeObservation | None:
+        return RuntimeObservation(runtime_id="reference-vector-table/1")
+
+
+def _vectors() -> dict[str, Any]:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _case_ids() -> list[str]:
+    return [case["id"] for case in _vectors()["cases"]]
+
+
+def test_committed_reference_vectors_match_builder() -> None:
+    """The portable JSON must remain reproducible from its source builder."""
+
+    assert _vectors() == build_reference_vectors(), (
+        "committed MemoryCheckpointAssessment reference vectors differ from "
+        "the deterministic builder; regenerate the JSON and review the diff"
+    )
+
+
+@pytest.mark.parametrize("case_id", _case_ids())
+def test_reference_vector(case_id: str) -> None:
+    vector = _vectors()
+    case = next(case for case in vector["cases"] if case["id"] == case_id)
+    suite = ProbeSuite.model_validate(vector["probe_suite"])
+    assessment = AssessmentHarness().run(VectorAdapter(vector, case), suite)
+
+    assert assessment.result.value == case["expected_result"]
+    failed = sorted(
+        result.probe_id
+        for result in assessment.probe_results
+        if result.result is BehavioralResult.fail
+    )
+    assert failed == sorted(case["expected_failed_probes"])


### PR DESCRIPTION
## Summary

Implements the external, non-normative `MemoryCheckpointAssessment/0.1` reference harness discussed in #298.

The contribution adds deterministic behavioral evidence for candidate memory checkpoints without changing Agent Manifest verification or conformance semantics.

## What it adds

- typed assessment evidence models and a minimal retriever adapter boundary
- four retrieval invariants: correction precedence, anchor preservation, scope isolation, and state-conditioned differentiation
- full retriever-profile binding, including tie behavior and repeatability evidence
- state-reference stability checks so evidence cannot be bound to a checkpoint that changes during assessment
- a separate applicability gate for an explicitly adopted approval policy
- deterministic public reference vectors and a reproducible vector builder
- artifact-shape, portability, hardening, applicability, and canonicalization-boundary tests
- architecture documentation and MkDocs navigation

## Decision boundary

- assessment evidence records what was evaluated and what happened
- applicability determines whether that evidence can satisfy an adopted gate
- `pass` satisfies this gate only; it does not authorize deployment
- an applicable `fail` blocks the approval action while remaining valid evidence
- an applicable `indeterminate` remains a distinct “not established” result and does not satisfy the gate
- absence of applicable assessment evidence leaves the gate unsatisfied rather than implicitly passing
- historical evidence remains intact if an approval control is bypassed

Scope isolation is intentionally a negative confidentiality property. An empty retrieval contains no forbidden material and therefore satisfies that probe, but does not establish retrieval liveness; suites requiring liveness must include a positive invariant.

## Explicit limits

- no `spec/` or conformance change
- no checkpoint approval API
- no TRACE/runtime integration
- no new signing or envelope format
- no completeness or anti-selective-disclosure claim
- no full RFC 8785 portability claim while the remaining #322 U+2028 escaping defect is open

## Validation

Validated head: `321e3b3137b2c455b92db311ecc12fd9d6195f78`

- Ruff: passed
- strict mypy: passed
- Bandit: passed
- pip-audit: passed
- build/twine: passed
- AGT governance verify: passed
- Python 3.11, 3.12, 3.13 Ubuntu: passed
- Python 3.11 macOS: passed
- Python 3.11 Windows: passed
- CodeQL: passed

Python 3.11 Ubuntu: 1,312 collected, 1,305 passed, 6 skipped, 1 deliberate strict xfail for the remaining #322 canonicalization boundary. Total package coverage is 89.82%; the assessment harness is at 93% and the applicability gate at 90%.

Addresses #298.