### PR TITLE
fix(verify): negotiate version before current schema

### DIFF
--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -631,6 +631,16 @@ def verify_manifest(
     if isinstance(manifest, (bytes, bytearray)):
         return _verify_cose_envelope(bytes(manifest), context, revocation_store)
 
+    # Version negotiation is the prerequisite for every current-schema
+    # interpretation below (spec 2.4). Read only the discriminator first. A
+    # future-shaped manifest must not be classified against today's schema.
+    version = manifest.get("version")
+    if version not in SUPPORTED_MANIFEST_VERSIONS:
+        return VerificationResult(
+            manifest_id="unknown",
+            result=OverallResult.INCOMPATIBLE_VERSION,
+        )
+
     manifest_id = manifest.get("manifest_id", "unknown")
     result = VerificationResult(manifest_id=manifest_id, result=OverallResult.VALID)
     agent_uid = manifest.get("agent_id")
@@ -649,11 +659,11 @@ def verify_manifest(
     transparency_unverifiable = False
 
     # --- Schema validation (fail-closed). verify_manifest accepts a raw dict,
-    # so it must run the manifest through the Pydantic guards before trusting
-    # any field. This makes extra="forbid" (unknown fields), enum/type
-    # constraints, the expiry window, and timestamp parsing actually apply on
-    # the verify path. A malformed expires_at is a schema failure here, not a
-    # silently non-expiring manifest.
+    # so it must run a supported manifest through the Pydantic guards before
+    # trusting current-version fields. This makes extra="forbid" (unknown
+    # fields), enum/type constraints, the expiry window, and timestamp parsing
+    # actually apply on the verify path. A malformed expires_at is a schema
+    # failure here, not a silently non-expiring manifest.
     #
     # Required top-level claims fail closed. Missing runtime observations in the
     # VerificationContext still produce NOT_BOUND; legacy omissions nested in
@@ -668,13 +678,6 @@ def verify_manifest(
                 actual_hash=f"<{msg}>",
             ))
         result.mismatch_details = mismatches
-        return result
-
-    # --- Version negotiation (spec 2.2 / 2.4) - MUST be checked before
-    # verifying so unsupported manifests are never silently misinterpreted.
-    version = manifest.get("version")
-    if version not in SUPPORTED_MANIFEST_VERSIONS:
-        result.result = OverallResult.INCOMPATIBLE_VERSION
         return result
 
     # --- Revocation check (must happen before VALID can be returned)

--- a/python/tests/test_version_negotiation_order.py
+++ b/python/tests/test_version_negotiation_order.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any
+
+import agent_manifest._verify as verify_module
+from agent_manifest._verify import (
+    OverallResult,
+    RevocationStore,
+    VerificationContext,
+    VerificationResult,
+    verify_manifest,
+)
+
+
+FUTURE_VERSION = "9.9"
+VALID_MANIFEST_ID = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+
+def _verify(manifest: dict[str, Any]) -> VerificationResult:
+    return verify_manifest(manifest, VerificationContext(), RevocationStore())
+
+
+def test_unsupported_version_preempts_future_only_schema_fields() -> None:
+    manifest = {
+        "version": FUTURE_VERSION,
+        "manifest_id": VALID_MANIFEST_ID,
+        "future_only": {"new_profile": ["value"]},
+    }
+
+    result = _verify(manifest)
+
+    assert result.result == OverallResult.INCOMPATIBLE_VERSION
+    assert result.mismatch_details == []
+
+
+def test_unsupported_version_preempts_current_schema_failures() -> None:
+    manifest = {
+        "version": FUTURE_VERSION,
+        "manifest_id": 12345,
+        "agent_id": ["not", "a", "current", "agent_id"],
+        "artifacts": "future-shape",
+    }
+
+    result = _verify(manifest)
+
+    assert result.result == OverallResult.INCOMPATIBLE_VERSION
+    assert result.mismatch_details == []
+
+
+def test_missing_version_uses_the_same_incompatible_version_gate() -> None:
+    result = _verify({"future_only": True})
+
+    assert result.result == OverallResult.INCOMPATIBLE_VERSION
+    assert result.mismatch_details == []
+
+
+def test_unsupported_version_does_not_invoke_current_schema(monkeypatch) -> None:
+    def schema_must_not_run(_manifest: dict[str, Any]) -> list[tuple[str, str]]:
+        raise AssertionError("current-version schema ran before version negotiation")
+
+    monkeypatch.setattr(verify_module, "_strict_schema_violations", schema_must_not_run)
+
+    result = _verify({"version": FUTURE_VERSION, "manifest_id": VALID_MANIFEST_ID})
+
+    assert result.result == OverallResult.INCOMPATIBLE_VERSION
+
+
+def test_unsupported_version_reads_only_the_version_discriminator() -> None:
+    class VersionOnlyManifest(dict[str, Any]):
+        def get(self, key: str, default: Any = None) -> Any:
+            if key != "version":
+                raise AssertionError(f"unsupported-version path read {key!r}")
+            return super().get(key, default)
+
+    manifest = VersionOnlyManifest(
+        version=FUTURE_VERSION,
+        manifest_id=VALID_MANIFEST_ID,
+        future_only={"shape": "unknown"},
+    )
+
+    result = _verify(manifest)
+
+    assert result.result == OverallResult.INCOMPATIBLE_VERSION
+    assert result.manifest_id == "unknown"
+
+
+def test_supported_version_still_applies_current_schema() -> None:
+    manifest = {
+        "version": "0.1",
+        "manifest_id": VALID_MANIFEST_ID,
+        "agent_id": "spiffe://trust.example/agent/test",
+        "issued_at": "2026-01-01T00:00:00Z",
+        "expires_at": "2099-01-01T00:00:00Z",
+        "issuer": "spiffe://trust.example/issuer",
+        "crypto_profile": "standard",
+        "artifacts": {},
+        "future_only": True,
+    }
+
+    result = _verify(manifest)
+
+    assert result.result == OverallResult.MISMATCH
+    assert any(detail.field == "schema:future_only" for detail in result.mismatch_details)

--- a/python/tests/vectors/AM-VEC-007.json
+++ b/python/tests/vectors/AM-VEC-007.json
@@ -23,6 +23,10 @@
         "model_hash": null,
         "version": "claude-3",
         "deployment_type": "api"
+      },
+      "future_artifact": {
+        "format": "future-v1",
+        "binding": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
       }
     },
     "delegation_chain": [],
@@ -32,7 +36,7 @@
       "key_id": "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
       "key_type": "software",
       "signed_at": "2025-01-01T00:00:00Z",
-      "signature_value": "mVMfp3Rk4iPzy4ry106W4cx774CBni_h7pd3zTGI95Y2pfqUTSTk-460M0_Pyftdsz5LT8wh8lb4BdHbBAlxDQ",
+      "signature_value": "GqQcU6-LkVAsqXvCRALTKmoXkBR62WhBAGC-uhMAo4TaG_ej7mQGUZeSHVlTTPqRC2heOa3wO8vQcdM4L6y3BA",
       "signed_fields": [
         "@context",
         "@type",

--- a/python/tests/vectors/generate.py
+++ b/python/tests/vectors/generate.py
@@ -681,12 +681,22 @@ def build() -> list[dict[str, Any]]:
         {"result": "UNVERIFIABLE", "signature_verified": False},
     ))
 
-    # 007 - unsupported version
+    # 007 - unsupported version. Make the fixture future-shaped as well as
+    # future-versioned: current schema rejects the extra artifact, so this
+    # vector only reaches INCOMPATIBLE_VERSION when version negotiation truly
+    # precedes current-schema interpretation. Re-sign after the mutation so a
+    # signature failure cannot accidentally satisfy the expected result.
+    future = base_manifest(version="0.3")
+    future["artifacts"]["future_artifact"] = {
+        "format": "future-v1",
+        "binding": "sha256:" + "f" * 64,
+    }
+    _sign(future)
     vectors.append(_vector(
         "AM-VEC-007", "Unsupported manifest version is rejected before verifying.",
         # 0.2 is the COSE envelope and is supported; 0.3 does not exist, which
         # is what makes it the right stand-in for "a version from the future".
-        ["2.4"], base_manifest(version="0.3"), base_context(),
+        ["2.4"], future, base_context(),
         {"result": "INCOMPATIBLE_VERSION"},
     ))
 


### PR DESCRIPTION
## What

Closes #365.

For dict manifests, `verify_manifest()` now performs version negotiation before applying the current Pydantic schema or interpreting any current-version field other than the `version` discriminator.

An unsupported or missing version returns `INCOMPATIBLE_VERSION` immediately with `manifest_id="unknown"`. Supported versions continue through the existing schema, revocation, validity, signature, artifact, delegation, HITL, attestation, and transparency pipeline unchanged.

## Why

Spec §2.4 requires implementations to inspect `version` before processing other fields. The existing ordering ran `_strict_schema_violations()` first, so a future manifest carrying fields unknown to today's closed-world schema could be classified as `MISMATCH` before the verifier reached its version gate.

The ordering matters because current schema is not authoritative over a format the verifier has already declared it does not understand.

## Regression evidence

A focused regression matrix now establishes that:

- a future-only field does not invoke current schema;
- malformed current-version shapes under an unsupported version still return `INCOMPATIBLE_VERSION`;
- missing version follows the same incompatible-version gate;
- the unsupported-version path reads only the `version` discriminator;
- supported `0.1` manifests still apply the current schema and reject an unknown field.

The existing language-neutral `AM-VEC-007` is strengthened rather than adding a duplicate vector. It now carries a signed future-only artifact member that today's schema rejects, so its expected `INCOMPATIBLE_VERSION` result is load-bearing on the required ordering.

## Scope

No schema rule, wire format, signature algorithm, current-version validation rule, result vocabulary, or supported-version set changes. This is prerequisite ordering only.

The branch is one commit directly on current upstream `ad01af774d198aafb3b9191040d88cfbc515f4ec`, one commit ahead / zero behind, and changes exactly four files: the verifier, focused regression test, vector generator, and `AM-VEC-007`.

Upstream moved once after the original review freeze: #367 changed only `spec/agent-manifest-spec-v0.2.md`. That file does not overlap any #365 file. The candidate was therefore reconstructed on the new upstream tree using the exact four previously reviewed blobs, then the one-commit/four-file diff gate was repeated.

## Review notes

Relevant gates:

- Need ≠ Authority: PASS. §2.4 supplies the normative ordering authority.
- Semantic propagation: PASS. The change stops at version prerequisite ordering; supported-version semantics remain in the existing pipeline.
- Non-Redundant Build: PASS. Existing `AM-VEC-007` was strengthened instead of adding a duplicate conformance rule.
- Failure-path independence: PASS for the static design. The portable vector and focused read-guard exercise the ordering through different mechanisms.
- Transition lineage: PASS. Current predecessor `ad01af77…` is pinned; the only intervening upstream change was independently checked as spec-only/non-overlapping; the reconstructed candidate is one commit ahead / zero behind with the same four reviewed blobs.
- Executable gate: pending this PR's repository CI and maintainer review at the time of this description; no manual workflow rerun is claimed here.

AI-assistance disclosure: ChatGPT assisted with source triage, falsification design, regression construction, rebase lineage verification, and drafting. `altrudev` reviewed the bounded claim and remains responsible for the contribution.