### PR TITLE
fix(docs): resolve the standards-landscape diagram path, and check for it in CI

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -28,11 +28,18 @@ jobs:
           python-version: "3.11"
           cache: pip
 
+      # Matches the install in docs.yml. Without the package, mkdocstrings
+      # cannot resolve API references and the build diverges from the deploy.
       - name: Install docs dependencies
-        run: pip install -r requirements-docs.txt
+        run: |
+          pip install -r requirements-docs.txt
+          pip install -e "python/[server]"
 
+      # Deliberately not --strict. The deploy in docs.yml does not use it, so
+      # requiring it here would gate merges on pre-existing warnings this job
+      # was not added to fix. The check below inspects the built output.
       - name: Build docs
-        run: mkdocs build --strict -d site
+        run: mkdocs build -d site
 
       # The deploy job in docs.yml only runs after merge, so without this a
       # broken asset path is not visible until it is already published.

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -1,0 +1,40 @@
+name: Docs links
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "overrides/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - "scripts/check_built_links.py"
+      - ".github/workflows/docs-links.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  asset-paths:
+    name: Check built asset references
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build docs
+        run: mkdocs build --strict -d site
+
+      # The deploy job in docs.yml only runs after merge, so without this a
+      # broken asset path is not visible until it is already published.
+      - name: Check that local asset references resolve
+        run: python scripts/check_built_links.py site

--- a/docs/integrations/standards-landscape.md
+++ b/docs/integrations/standards-landscape.md
@@ -22,8 +22,8 @@ In simple terms:
 4. **Runtime records say what happened next.** TRACE or OCSF evidence links each
    action back to the exact manifest and agent instance that was admitted.
 
-<a href="../assets/standards-integration-landscape.svg" target="_blank">
-  <img src="../assets/standards-integration-landscape.svg"
+<a href="../../assets/standards-integration-landscape.svg" target="_blank">
+  <img src="../../assets/standards-integration-landscape.svg"
        alt="Four-layer standards integration map showing discovery, deployment evidence, decision-time verification, and runtime evidence">
 </a>
 

--- a/docs/integrations/standards-landscape.md
+++ b/docs/integrations/standards-landscape.md
@@ -178,7 +178,7 @@ At a relying party such as an admission controller, MCP gateway, or A2A peer:
 
 - [Agent Credentials integration](agent-credentials.md) describes the
   credential-to-manifest and runtime-evidence bridge in detail.
-- [Agent Manifest specification](../../spec/agent-manifest-spec-v0.2.md) defines
+- [Agent Manifest specification](../spec/agent-manifest-v0.2.md) defines
   the normative manifest and verification behavior.
 - [CoSAI WS4 Agent Manifest review](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149)
   carries the review and disposition record for this boundary.

--- a/scripts/check_built_links.py
+++ b/scripts/check_built_links.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Check that local asset references in the built docs site actually resolve.
+
+mkdocs rewrites relative paths in Markdown links, but it does not touch paths
+inside raw HTML tags. So an ``<img src="../assets/x.svg">`` written in a page at
+``docs/integrations/page.md`` keeps that exact path in the output, and because
+the page is published at ``/integrations/page/`` the browser resolves it to
+``/integrations/assets/x.svg``, which does not exist. The Markdown link on the
+same line resolves correctly, which is what makes the bug easy to miss.
+
+This checks the built site rather than the source, so it catches the mistake at
+any nesting depth and for both Markdown and raw HTML.
+
+Usage:
+    mkdocs build -d site
+    python scripts/check_built_links.py site
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+# Only follow references to concrete files. Page links resolve to directories
+# under mkdocs' default use_directory_urls and are checked by mkdocs itself.
+ASSET_SUFFIXES = {
+    ".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".ico",
+    ".pdf", ".json", ".csv", ".txt", ".css", ".js", ".map",
+    ".woff", ".woff2", ".ttf", ".otf", ".zip", ".tar", ".gz",
+}
+
+REFERENCE = re.compile(r"""\b(?:src|href)\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>]+))""")
+
+
+def is_local_asset(target: str) -> bool:
+    if not target or target.startswith(("#", "//", "data:", "mailto:", "tel:")):
+        return False
+    parsed = urlparse(target)
+    if parsed.scheme or parsed.netloc:
+        return False
+    return Path(unquote(parsed.path)).suffix.lower() in ASSET_SUFFIXES
+
+
+def check(site_dir: Path) -> list[str]:
+    failures: list[str] = []
+    for page in sorted(site_dir.rglob("*.html")):
+        html = page.read_text(encoding="utf-8", errors="replace")
+        for match in REFERENCE.finditer(html):
+            target = next(g for g in match.groups() if g is not None)
+            if not is_local_asset(target):
+                continue
+            path = unquote(urlparse(target).path)
+            if path.startswith("/"):
+                resolved = site_dir / path.lstrip("/")
+            else:
+                resolved = page.parent / path
+            if not resolved.resolve().is_file():
+                failures.append(
+                    f"{page.relative_to(site_dir).as_posix()}: {target}"
+                )
+    return failures
+
+
+def main() -> int:
+    site_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "site")
+    if not site_dir.is_dir():
+        print(f"Built site not found at {site_dir}. Run mkdocs build first.")
+        return 2
+
+    failures = check(site_dir)
+    if failures:
+        print(f"{len(failures)} asset reference(s) do not resolve in the built site:\n")
+        for failure in failures:
+            print(f"  {failure}")
+        print(
+            "\nA path inside a raw HTML tag is used verbatim. It must resolve from "
+            "the published URL of the page, not from the source file location."
+        )
+        return 1
+
+    print("All local asset references resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The integration landscape diagram renders as a broken image on the published site.

## Cause

The page uses raw HTML for the figure. mkdocs rewrites relative paths in Markdown links but leaves paths inside HTML tags untouched, so `src="../assets/..."` is emitted verbatim. From the published URL `/integrations/standards-landscape/` the browser resolves that to `/integrations/assets/...`.

Confirmed against the live site:

| URL | Status |
|---|---|
| `/integrations/standards-landscape/` | 200 |
| `/integrations/assets/standards-integration-landscape.svg` | **404** |
| `/assets/standards-integration-landscape.svg` | 200 |

The Markdown "open full size" link on the next line was rewritten correctly and worked, which is what made this easy to miss.

## Fix

The two raw HTML references become `../../assets/`, which is the depth the browser sees. The Markdown link is left as is, since mkdocs already resolves it from the source location.

## Preventing a repeat

`scripts/check_built_links.py` walks the built site and asserts every local asset reference resolves. It checks the output rather than the source, so it works at any nesting depth and for both Markdown and raw HTML. Verified both ways:

- against the previous revision it reports both references and exits 1
- against this revision it passes

A new `docs-links` workflow runs it on docs pull requests. `ci.yml` does not watch `docs/**` and `docs.yml` only runs after merge, so a docs-only change previously reached the published site with no checks at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc16CsknaQ9PTLxGj8TXXj