### PR TITLE
docs(examples): fix broken links to renamed/nonexistent spec and tutorial files

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,4 +32,4 @@ pip install -e "python/"
 
 - [Getting started](../docs/getting-started.md)  -  step-by-step walkthrough of creating and verifying manifests with the Python SDK and CLI
 - [Tutorials](../docs/tutorials/)  -  detailed guides for delegation chains, revocation, HITL, hardware attestation, and server-side verification
-- [Spec](../spec/agent-manifest-spec-v0.1.md)  -  full data model and field cardinality rules
+- [Spec](../spec/agent-manifest-spec-v0.2.md)  -  full data model and field cardinality rules

--- a/examples/revocation/README.md
+++ b/examples/revocation/README.md
@@ -39,4 +39,4 @@ The `crl.jsonl` file is append-only JSON-Lines: one `SignedRevocationRecord` per
 {"manifest_id":"019236ab...","revoked_at":"2026-06-05T11:30:00Z",...}
 ```
 
-See [Tutorial: Revocation and key rotation](../../docs/tutorials/revocation.md) for the full implementation.
+See [Tutorial: Revocation and key rotation](../../docs/tutorials/revocation-and-key-rotation.md) for the full implementation.


### PR DESCRIPTION
## What

This PR fixes a dead link in `examples/README.md` that points to a spec file which doesnt exist and another of tutorial

## Why

`examples/README.md` links to `spec/agent-manifest-spec-v0.1.md`, but that file isn't in the repo only `spec/agent-manifest-spec-v0.2.md` is.

`examples/revocation/README.md` linked to `docs/tutorials/revocation.md`; but the actual file is `docs/tutorials/revocation-and-key-rotation.md` (the link text already said "Revocation and key rotation" just the path was stale).


## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [ ] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
