### PR TITLE
fix(tdx): bind verification to signed quote header

### DIFF
--- a/python/src/agent_manifest/_tdx_verify.py
+++ b/python/src/agent_manifest/_tdx_verify.py
@@ -195,13 +195,12 @@ def parse_tdx_quote(quote: bytes, *, strict: bool = True) -> TdxQuote:
 
     Args:
         quote: the raw DCAP quote bytes.
-        strict: when ``True`` (default), enforce the production layout —
-            ``version == 4`` and ``tee_type == 0x81`` — raising on anything
-            else. Pass ``strict=False`` to parse the header/body of an
-            otherwise well-formed quote whose version/tee_type differ (e.g.
-            synthetic test vectors), extracting the fields without asserting the
-            production TDX identity. Signature verification
-            (:func:`verify_tdx_quote`) is unaffected and always strict.
+        strict: when ``True`` (default), enforce the production header —
+            ``version == 4``, ``att_key_type == 2`` (ECDSA-P256), and
+            ``tee_type == 0x81`` — raising on anything else. Pass
+            ``strict=False`` only for diagnostic field extraction from an
+            otherwise well-formed quote; that mode does not authorize any
+            cryptographic interpretation of the declared profile.
     """
     if len(quote) < _QUOTE_HEADER_LEN + _TD_REPORT_LEN:
         raise TdxVerificationError(
@@ -212,6 +211,10 @@ def parse_tdx_quote(quote: bytes, *, strict: bool = True) -> TdxQuote:
     if strict:
         if version != _TDX_QUOTE_VERSION:
             raise TdxVerificationError(f"unsupported TDX quote version {version} (expected 4)")
+        if att_key_type != _ATT_KEY_TYPE_ECDSA_P256:
+            raise TdxVerificationError(
+                f"unsupported TDX attestation key type {att_key_type} (expected 2)"
+            )
         if tee_type != _TEE_TYPE_TDX:
             raise TdxVerificationError(f"not a TDX quote: tee_type {tee_type:#x}")
     body = quote[_QUOTE_HEADER_LEN:_QUOTE_HEADER_LEN + _TD_REPORT_LEN]
@@ -248,11 +251,12 @@ def verify_tdx_quote(
 ) -> bool:
     """Fully verify an Intel TDX v4 DCAP quote (all four steps, fail-closed).
 
-    Returns True only when the attestation-key signature, the QE binding, the
+    Returns True only when the signed quote header declares the production
+    TDX-v4/ECDSA-P256 profile, the attestation-key signature, the QE binding, the
     PCK signature over the QE report, and the PCK chain up to the pinned Intel
     SGX Root CA all check out. Raises :class:`TdxVerificationError` on a
-    malformed quote / broken chain or if ``cryptography`` is unavailable; returns
-    False on a well-formed-but-invalid signature.
+    malformed/unsupported quote or broken chain, or if ``cryptography`` is
+    unavailable; returns False on a well-formed-but-invalid signature.
 
     Every certificate in the PCK chain must be within its validity period (see
     :func:`._cert_chain.check_validity_period`); an expired PCK leaf,
@@ -261,6 +265,10 @@ def verify_tdx_quote(
 
     ``trusted_root_pem`` overrides the embedded Intel root (for testing).
     """
+    # The signed header authorizes the only verification profile implemented
+    # here. Establish it before accepting any signature/certification semantics.
+    parse_tdx_quote(quote, strict=True)
+
     try:
         from cryptography import x509
         from cryptography.exceptions import InvalidSignature

--- a/python/tests/test_tdx_verify.py
+++ b/python/tests/test_tdx_verify.py
@@ -57,10 +57,17 @@ def _cert(subject, pub, issuer_name, issuer_key, ca=False):
     return b.sign(issuer_key, hashes.SHA256())
 
 
-def _build_quote(report_data_digest: bytes, mrtd: bytes = b"\x11" * 48):
-    """Return (quote_bytes, test_root_pem) — a self-consistent TDX v4 quote."""
-    # Header (48): version=4, att_key_type=2, tee_type=0x81, + 40 bytes padding.
-    header = struct.pack("<HHI", 4, 2, 0x81) + bytes(40)
+def _build_quote(
+    report_data_digest: bytes,
+    mrtd: bytes = b"\x11" * 48,
+    *,
+    version: int = 4,
+    att_key_type: int = 2,
+    tee_type: int = 0x81,
+):
+    """Return a self-consistent quote whose signed header is caller-controlled."""
+    # Header (48): caller-selected signed profile + 40 bytes padding.
+    header = struct.pack("<HHI", version, att_key_type, tee_type) + bytes(40)
     body = bytearray(_BODY)
     body[136:136 + 48] = mrtd
     body[520:520 + 32] = report_data_digest  # REPORTDATA[:32]
@@ -117,16 +124,52 @@ def test_parse_rejects_short():
 
 
 def test_parse_rejects_wrong_tee_type():
-    quote, _ = _build_quote(hashlib.sha256(b"x").digest())
-    bad = bytearray(quote)
-    struct.pack_into("<I", bad, 4, 0x00)  # tee_type = SGX, not TDX
+    quote, _ = _build_quote(hashlib.sha256(b"x").digest(), tee_type=0x00)
     with pytest.raises(TdxVerificationError, match="not a TDX quote"):
-        parse_tdx_quote(bytes(bad))
+        parse_tdx_quote(quote)
+
+
+def test_parse_rejects_wrong_attestation_key_type():
+    quote, _ = _build_quote(hashlib.sha256(b"keytype").digest(), att_key_type=3)
+    with pytest.raises(TdxVerificationError, match="attestation key type 3"):
+        parse_tdx_quote(quote)
+
+
+def test_parse_non_strict_is_diagnostic_only():
+    quote, _ = _build_quote(
+        hashlib.sha256(b"diagnostic").digest(),
+        version=5,
+        att_key_type=3,
+        tee_type=0x00,
+    )
+    parsed = parse_tdx_quote(quote, strict=False)
+    assert parsed.version == 5
+    assert parsed.tee_type == 0x00
 
 
 def test_verify_full_chain_ok():
     quote, root_pem = _build_quote(hashlib.sha256(b"pre").digest())
     assert verify_tdx_quote(quote, trusted_root_pem=root_pem) is True
+
+
+@pytest.mark.parametrize(
+    ("header_overrides", "message"),
+    [
+        ({"version": 5}, "unsupported TDX quote version 5"),
+        ({"att_key_type": 3}, "attestation key type 3"),
+        ({"tee_type": 0x00}, "not a TDX quote"),
+    ],
+)
+def test_verify_rejects_self_consistent_signed_unsupported_header(
+    header_overrides: dict[str, int], message: str
+):
+    """The header mutation is included in signed_body and re-signed by the same builder."""
+    quote, root_pem = _build_quote(
+        hashlib.sha256(b"profile-binding").digest(),
+        **header_overrides,
+    )
+    with pytest.raises(TdxVerificationError, match=message):
+        verify_tdx_quote(quote, trusted_root_pem=root_pem)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #364.

## What

`verify_tdx_quote()` now establishes the signed production TDX profile before accepting any signature or certification semantics:

- `version == 4`;
- `att_key_type == 2` (`ECDSA_P256`);
- `tee_type == 0x81` (`TDX`).

The full verifier calls `parse_tdx_quote(..., strict=True)` as its profile prerequisite. The strict parser now checks the previously omitted attestation-key type as well as version and TEE type.

`strict=False` remains available for diagnostic field extraction only; its documentation now states that it does not authorize cryptographic interpretation of a declared profile.

## Regression evidence

The existing synthetic full-chain builder is parameterized at the signed header. Each unsupported-header control is therefore self-consistent and re-signed by the same generated attestation key rather than byte-flipped after signing:

- production header `(4, 2, 0x81)` keeps the existing successful path;
- version `5` is refused by the full verifier;
- attestation-key type `3` is refused by the full verifier;
- TEE type `0x00` is refused by the full verifier;
- the strict parser directly refuses key type `3`;
- `strict=False` remains a diagnostic parse control.

Existing body-tamper, pinned-root, certificate-validity, QE-binding, signature-section, and chain behavior is left unchanged.

## Scope

No algorithm, wire format, certificate-chain rule, trust root, report-data binding, or signature preimage is changed. This patch only binds the implemented TDX-v4/P-256 verifier to the signed header that declares that profile.

AI-assistance disclosure: ChatGPT assisted with source triage, mutation-oriented regression design, implementation drafting, and exact-diff review. `altrudev` reviewed the bounded claim and remains responsible for the contribution.