### PR TITLE
fix(cli): verify CRL revocation records against a trusted signer key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 ### Fixed
 
+- **[SECURITY][CLI]** `manifest verify` gained `--crl-trusted-key PATH` to
+  authenticate `--crl-path` revocation records against the revoking
+  authority's public key. Previously the CLI always constructed `FileCRL`
+  without `trusted_signer_key`, so every CLI-driven CRL load ran in
+  `FileCRL`'s unauthenticated mode regardless of intent: a party who could
+  write to or intercept the CRL file could fabricate a revocation record
+  for a legitimate manifest, and `manifest verify` would accept it without
+  complaint. `--crl-trusted-key` is now required to authenticate the CRL;
+  omitting it still works (unchanged default) but now prints a loud
+  warning, and passing it without `--crl-path` fails cleanly instead of
+  being silently ignored. Same pattern as the `--approver-key` gap fixed
+  in 0.11.1.
+
+- **[SECURITY][CRL]** `FileCRL._load()` now fails closed in authenticated
+  mode: a malformed, unsigned, tampered, or wrong-key record used to be
+  silently skipped, which meant a party able to corrupt one line of an
+  authenticated CRL file could make that manifest register as *not*
+  revoked — the exact outcome `--crl-trusted-key` exists to prevent. Any
+  such record now raises `CRLIntegrityError` (surfaced by the CLI as a
+  clean, non-zero-exit error) instead of silently disappearing from the
+  in-memory set before `is_revoked()` runs.
+
+- **[DOCS]** Corrected an overclaim in the `--crl-trusted-key` help text
+  and `manifest verify` docs: authenticating records that are present in
+  a CRL file is not the same as proving the file is complete. Per-record
+  signatures cannot detect that a valid line — or the entire file — was
+  deleted, so `--crl-trusted-key` does not by itself prevent un-revocation
+  by deletion. Closing that gap needs a signed, versioned CRL
+  snapshot/digest mechanism, which is not yet implemented.
+
 - **[SDK]** `_check_manifest_binding()` no longer masks a malformed
   `artifacts` or `artifacts.policy_bundle` as merely absent. Truthy
   non-objects (`"str"`, `[1]`, `True`) already correctly reported

--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -110,7 +110,20 @@ Usage: manifest verify [OPTIONS] MANIFEST_FILE
   Prints the VerificationResult as JSON. Exits with code 0 on VALID, 1 on any other
   result.
 
-  Use --crl-path to load a revocation list and check for revoked manifests.
+  Use --crl-path to load a revocation list and check for revoked manifests. Pass --crl-
+  trusted-key with it to authenticate each record present in the CRL against the
+  revoking authority's public key (spec Section 3.7 / REVOC-003): a record with a
+  missing, malformed, or invalid signature causes verification to fail closed with an
+  error, rather than being silently treated as "not revoked".
+
+  --crl-trusted-key does NOT prove the CRL file is complete. Per-record signatures
+  authenticate the records that are present but cannot detect that a line — or the
+  entire file — was deleted. A party who can write or intercept the CRL file can still
+  suppress a real revocation by removing its record entirely; only a signed, versioned
+  CRL snapshot (not yet implemented) can close that gap. Without --crl-trusted-key at
+  all, every line in the CRL file is additionally trusted unauthenticated: a party who
+  can write or intercept that file can also fabricate a revocation for a legitimate
+  manifest.
 
   HITL approvals attach outside the manifest signature, so supply the
   approver keys you trust with --approver-key. Without them an approval is
@@ -128,6 +141,11 @@ Options:
                                   manifest hash
   --crl-path TEXT                 Path to a FileCRL JSON-Lines file for revocation
                                   checks
+  --crl-trusted-key TEXT          Path to the CRL-signing authority's raw Ed25519 public
+                                  key hex file. Required to cryptographically verify
+                                  --crl-path records (REVOC-003); without it every
+                                  record in the file is trusted unauthenticated. See the
+                                  command description above for the completeness caveat.
   --public-key TEXT               Path to a trusted raw Ed25519 public key hex file
   --approver-key APPROVER_ID=PATH
                                   Trusted HITL approver key as approver_id=path to a raw

--- a/python/src/agent_manifest/_revocation.py
+++ b/python/src/agent_manifest/_revocation.py
@@ -26,6 +26,21 @@ _MAX_CRL_BYTES = 50 * 1024 * 1024  # 50 MB
 _MAX_CRL_RECORDS = 1_000_000
 
 
+class CRLIntegrityError(Exception):
+    """Raised when an authenticated CRL file cannot be trusted as loaded.
+
+    In authenticated mode (``trusted_signer_key`` provided), a malformed,
+    unsigned, tampered, or wrong-key record does not mean "not revoked"
+    which means the CRL's integrity cannot be established. Silently skipping
+    such records would let anyone who can write or intercept the CRL file
+    un-revoke a manifest by corrupting its record (CRL-CLI-002).
+    Deleting a complete record remains undetectable without an authenticated
+    inventory of the records that should be present.
+    Callers must treat this as a hard verification failure, not as
+    evidence of non-revocation.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Signed revocation record
 # ---------------------------------------------------------------------------
@@ -134,12 +149,24 @@ class FileCRL:
     For production, replace with a database-backed store and serve
     the CRL at /.well-known/agent-manifest/revocation.
 
+    Note: a CRL path that does not exist at construction time is treated
+    as an empty CRL and never reaches signature verification, even in
+    authenticated mode - the same outcome as a file that existed and was
+    later emptied or had its records deleted. Authenticated mode's
+    fail-closed guarantee only covers records that are *present but
+    invalid*; it does not, and cannot by itself, detect a missing or
+    truncated file. See the CRL completeness caveat on ``manifest verify``.
+
     Args:
         path: Path to the CRL file. Resolved and confined at construction.
         trusted_signer_key: Raw Ed25519 public key bytes of the authority
-            whose signatures are accepted on load. When provided, records
-            with invalid or absent signatures are skipped (REVOC-003).
-            When None, signatures are not verified (development mode only).
+            whose signatures are accepted on load. When provided
+            (authenticated mode), a malformed, unsigned, tampered, or
+            wrong-key record raises ``CRLIntegrityError`` and invalidates
+            the entire load (REVOC-003, CRL-CLI-002), see
+            ``CRLIntegrityError`` for why records are not simply skipped.
+            When None, signatures are not verified and malformed lines are
+            best-effort skipped (development mode only).
     """
 
     def __init__(
@@ -161,11 +188,23 @@ class FileCRL:
                 f"CRL file is {file_size} bytes, exceeding the {_MAX_CRL_BYTES}-byte limit. "
                 "Use a database-backed store for large CRLs."
             )
+        # CRL-CLI-002: in authenticated mode, load into a fresh dict first and
+        # only publish it to self._cache if every line is parseable and every
+        # record verifies. A single malformed/unsigned/tampered/wrong-key
+        # record makes the whole file's integrity unknown and we cannot tell
+        # whether it is an honest data error or a corrupted
+        # revocation, so we must not selectively keep the records that
+        # happened to still verify. Invalid present records raise instead of
+        # silently yielding fewer revocations. Deleting a complete line is
+        # indistinguishable from a record that never existed and is not detected.
+        authenticated = self._trusted_signer_key is not None
+        loaded: dict[str, SignedRevocationRecord] = {}
+
 
         count = 0
         with open(self._path) as f:
-            for line in f:
-                line = line.strip()
+            for lineno, raw_line in enumerate(f, start=1):
+                line = raw_line.strip()
                 if not line:
                     continue
                 if count >= _MAX_CRL_RECORDS:
@@ -174,18 +213,33 @@ class FileCRL:
                     )
                 try:
                     rec = SignedRevocationRecord.model_validate_json(line)
-                except Exception:  # nosec B112 — intentional skip of malformed lines
+                except Exception as exc:
+                    if authenticated:
+                        raise CRLIntegrityError(
+                            f"{self._path}:{lineno}: malformed revocation "
+                            f"record in authenticated CRL ({exc}). Refusing "
+                            "to load a CRL whose integrity cannot be "
+                            "established."
+                        ) from exc
+                    # nosec B112 - dev-mode (no trusted key): best-effort skip
                     continue
 
                 # REVOC-003: verify signature if trusted key is provided
-                if self._trusted_signer_key is not None:
+                if authenticated:
                     try:
-                        verify_revocation_signature(rec, self._trusted_signer_key)
-                    except Exception:  # nosec B112 — intentional skip of unsigned/tampered records
-                        continue
+                        verify_revocation_signature(rec, self._trusted_signer_key)  # type: ignore[arg-type]
+                    except Exception as exc:
+                        raise CRLIntegrityError(
+                            f"{self._path}:{lineno}: revocation record for "
+                            f"manifest {rec.manifest_id!r} failed signature "
+                            "verification against the trusted CRL signer "
+                            f"key ({exc}). Refusing to load a CRL whose "
+                            "integrity cannot be established."
+                        ) from exc
 
-                self._cache[rec.manifest_id] = rec
+                loaded[rec.manifest_id] = rec
                 count += 1
+        self._cache = loaded
 
     def revoke(self, record: SignedRevocationRecord) -> None:
         """Append a revocation record to the CRL file."""

--- a/python/src/agent_manifest/cli.py
+++ b/python/src/agent_manifest/cli.py
@@ -30,7 +30,7 @@ except ImportError:
 from ._auto_provider import select_provider
 from ._cose import COSE_MANIFEST_VERSION
 from ._providers import AttestationUnavailableError
-from ._revocation import FileCRL
+from ._revocation import CRLIntegrityError, FileCRL
 from ._signing import Ed25519Signer, ed25519_from_private_bytes, generate_ed25519
 from ._types import ManifestId
 from ._verify import (
@@ -352,6 +352,14 @@ def attest(manifest_file: str, provider: str, level: int, output: Optional[str])
 @click.option("--enforce-attestation", is_flag=True, default=False,
               help="Fail unless the attestation report matches the manifest hash")
 @click.option("--crl-path", default=None, help="Path to a FileCRL JSON-Lines file for revocation checks")
+@click.option(
+    "--crl-trusted-key",
+    default=None,
+    help="Path to the CRL-signing authority's raw Ed25519 public key hex file. "
+         "Required to cryptographically verify --crl-path records (REVOC-003); "
+         "without it every record in the file is trusted unauthenticated. See "
+         "the command description above for the completeness caveat.",
+)
 @click.option("--public-key", default=None, help="Path to a trusted raw Ed25519 public key hex file")
 @click.option("--approver-key", multiple=True, metavar="APPROVER_ID=PATH",
               help="Trusted HITL approver key as approver_id=path to a raw Ed25519 "
@@ -376,6 +384,7 @@ def verify(
     enforce_hitl: bool,
     enforce_attestation: bool,
     crl_path: Optional[str],
+    crl_trusted_key: Optional[str],
     public_key: Optional[str],
     approver_key: tuple[str, ...],
     require_transparency: bool,
@@ -391,6 +400,22 @@ def verify(
     1 on any other result.
 
     Use --crl-path to load a revocation list and check for revoked manifests.
+    Pass --crl-trusted-key with it to authenticate each record present in the
+    CRL against the revoking authority's public key (spec Section 3.7 /
+    REVOC-003): a record with a missing, malformed, or invalid signature
+    causes verification to fail closed with an error, rather than being
+    silently treated as "not revoked".
+
+    --crl-trusted-key does NOT prove the CRL file is complete. Per-record
+    signatures authenticate the records that are present but cannot detect
+    that a line — or the entire file — was deleted. A party who can write or
+    intercept the CRL file can still suppress a real revocation by removing
+    its record entirely; only a signed, versioned CRL snapshot (not yet
+    implemented) can close that gap. Without --crl-trusted-key at all, every
+    line in the CRL file is additionally trusted unauthenticated: a party who
+    can write or intercept that file can also fabricate a revocation for a
+    legitimate manifest.
+
 
     
     HITL approvals attach outside the manifest signature, so supply the
@@ -403,6 +428,9 @@ def verify(
       manifest verify signed.json --public-key pub.hex --enforce-hitl
         --approver-key mailto:alice@example.com=alice.hex
     """
+    if crl_trusted_key and not crl_path:
+        raise click.ClickException("--crl-trusted-key requires --crl-path.")
+
     subject = _load_manifest_or_envelope(manifest_file)
     trusted_keys = _trusted_key_from_public_hex(public_key) if public_key else {}
     ctx = VerificationContext(
@@ -420,7 +448,42 @@ def verify(
     # REVOC-001: load CRL if provided, otherwise use empty in-memory store
     store: RevocationStore
     if crl_path:
-        store = _CRLRevocationStore(FileCRL(Path(crl_path)))
+        trusted_signer_key: Optional[bytes]
+        if crl_trusted_key:
+            trusted_signer_key = _public_bytes_from_hex_file(
+                crl_trusted_key, "CRL trusted key"
+            )
+        else:
+            trusted_signer_key = None
+            # CRL-CLI-001: FileCRL trusts every record unauthenticated when no
+            # signer key is supplied (development mode). Warn loudly, because
+            # unlike --public-key (whose absence forces UNVERIFIABLE) a CRL
+            # with no --crl-trusted-key silently *succeeds*: a tampered or
+            # incomplete CRL file un-revokes a compromised manifest instead of
+            # failing closed.
+            click.echo(
+                "WARNING: --crl-path given without --crl-trusted-key. "
+                "Revocation records are NOT cryptographically verified; any "
+                "party who can write or intercept this file can suppress a "
+                "real revocation or fabricate one. Pass --crl-trusted-key to "
+                "authenticate records present in the CRL — note that even "
+                "with --crl-trusted-key, deleting a record (or the whole "
+                "file) still suppresses a revocation, since per-record "
+                "signatures cannot prove the CRL is complete.",
+                err=True,
+            )
+        try:
+            store = _CRLRevocationStore(
+                FileCRL(Path(crl_path), trusted_signer_key=trusted_signer_key)
+            )
+        except CRLIntegrityError as exc:
+            # CRL-CLI-002: an authenticated CRL that fails to load must not
+            # be treated as "nothing revoked". Fail the whole verify command
+            # closed instead of silently proceeding as if the CRL were
+            # empty (see FileCRL._load's authenticated-mode contract).
+            raise click.ClickException(
+                f"CRL failed integrity verification: {exc}"
+            )
     else:
         store = RevocationStore()
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 
 from agent_manifest.cli import cli
 from agent_manifest._delegation import HitlApprovalSigner
+from agent_manifest._revocation import FileCRL, sign_revocation
 from agent_manifest._signing import Ed25519Signer, generate_ed25519
 
 APPROVER_ID = "mailto:alice@example.com"
@@ -145,6 +146,241 @@ def test_cli_verify_with_missing_public_key_file_fails_cleanly(tmp_path):
 
     assert result.exit_code != 0
     assert "Public key file not found or is not a regular file" in result.output
+    assert "Traceback" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# CRL-CLI-001: --crl-path must be able to authenticate revocation records.
+#
+# FileCRL(trusted_signer_key=...) already verifies each record's signature
+# (REVOC-003), but the CLI's `verify --crl-path` never plumbed that argument
+# through, so every CLI-driven CRL load ran in FileCRL's unauthenticated
+# "development mode" regardless of intent. A party who can write to or
+# intercept the CRL file could inject a fabricated revocation record and the
+# CLI would accept it. --crl-trusted-key authenticates present records; it
+# cannot detect deletion of a complete record.
+# ---------------------------------------------------------------------------
+
+
+def _write_crl_with_revocation(tmp_path, manifest_id, authority_kp, name="crl.jsonl"):
+    crl_path = tmp_path / name
+    crl = FileCRL(crl_path, trusted_signer_key=authority_kp.public_bytes)
+    crl.revoke(sign_revocation(manifest_id, "key compromise", "admin", authority_kp))
+    return crl_path
+
+
+def _write_authority_key(tmp_path, keypair, name="authority.hex") -> Path:
+    path = tmp_path / name
+    path.write_text(keypair.public_bytes.hex())
+    return path
+
+
+def test_cli_verify_crl_trusted_key_detects_revocation(tmp_path):
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+    authority_kp = generate_ed25519()
+    manifest = json.loads(signed_path.read_text())
+    crl_path = _write_crl_with_revocation(tmp_path, manifest["manifest_id"], authority_kp)
+    authority_path = _write_authority_key(tmp_path, authority_kp)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path),
+            "--public-key", str(public_path),
+            "--signature-only",
+            "--crl-path", str(crl_path),
+            "--crl-trusted-key", str(authority_path),
+        ],
+    )
+
+    payload = _json_stdout(result)
+    assert result.exit_code == 1
+    assert payload["result"] == "REVOKED"
+    assert "WARNING" not in result.output
+
+
+def test_cli_verify_crl_without_trusted_key_still_works_but_warns(tmp_path):
+    # Backward-compatible: omitting --crl-trusted-key must not break existing
+    # scripts, but it must loudly say the CRL is unauthenticated.
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+    authority_kp = generate_ed25519()
+    manifest = json.loads(signed_path.read_text())
+    crl_path = _write_crl_with_revocation(tmp_path, manifest["manifest_id"], authority_kp)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path),
+            "--public-key", str(public_path),
+            "--signature-only",
+            "--crl-path", str(crl_path),
+        ],
+    )
+
+    payload = _json_stdout(result)
+    assert result.exit_code == 1
+    assert payload["result"] == "REVOKED"
+    combined = (result.output or "") + (result.stderr or "")
+    assert "WARNING: --crl-path given without --crl-trusted-key" in combined
+
+
+def test_cli_verify_crl_with_wrong_trusted_key_fails_closed(tmp_path):
+    # A CRL signed by an authority the caller does NOT trust must NOT be
+    # treated as evidence of non-revocation. The record fails REVOC-003
+    # verification on load, which must surface as a hard, non-zero-exit
+    # error — not as a silent "not revoked" / VALID result. Reporting VALID
+    # here would let anyone who can tamper with (or swap the signer of) a
+    # record achieve the same un-revocation outcome --crl-trusted-key exists
+    # to prevent (CRL-CLI-002).
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+    real_authority = generate_ed25519()
+    untrusted_authority = generate_ed25519()
+    manifest = json.loads(signed_path.read_text())
+    crl_path = _write_crl_with_revocation(
+        tmp_path, manifest["manifest_id"], untrusted_authority
+    )
+    trusted_path = _write_authority_key(tmp_path, real_authority)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path),
+            "--public-key", str(public_path),
+            "--signature-only",
+            "--crl-path", str(crl_path),
+            "--crl-trusted-key", str(trusted_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "CRL failed integrity verification" in result.output
+    assert "Traceback" not in result.output
+    # Must NOT be reachable as a VALID/REVOKED verdict in stdout — the
+    # command must fail before verify_manifest() ever runs.
+    assert '"result"' not in result.output
+
+
+def test_cli_verify_crl_with_tampered_record_fails_closed(tmp_path):
+    # Directly reproduces the reviewer's repro: flip a byte in a genuinely
+    # signed record's signature and confirm the CLI errors out instead of
+    # reporting the manifest as not revoked.
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+    authority_kp = generate_ed25519()
+    manifest = json.loads(signed_path.read_text())
+    crl_path = _write_crl_with_revocation(
+        tmp_path, manifest["manifest_id"], authority_kp
+    )
+    authority_path = _write_authority_key(tmp_path, authority_kp)
+
+    line = json.loads(crl_path.read_text().splitlines()[0])
+    sig = list(line["revocation_signature"])
+    mid_idx = len(sig) // 2
+    sig[mid_idx] = "A" if sig[mid_idx] != "A" else "B"
+    line["revocation_signature"] = "".join(sig)
+    crl_path.write_text(json.dumps(line) + "\n")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path),
+            "--public-key", str(public_path),
+            "--signature-only",
+            "--crl-path", str(crl_path),
+            "--crl-trusted-key", str(authority_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "CRL failed integrity verification" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_verify_crl_cannot_detect_deleted_record(tmp_path):
+    # Deleting a signed record entirely is currently indistinguishable from
+    # "it never existed" (documented limitation see CHANGELOG/docs: this
+    # is NOT fixed by fail-closed verification of present records, and
+    # requires a signed CRL snapshot/digest to close). This test pins down
+    # today's actual behavior so a future regression doesn't silently
+    # loosen it further without anyone noticing.
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+    authority_kp = generate_ed25519()
+    manifest = json.loads(signed_path.read_text())
+    crl_path = _write_crl_with_revocation(
+        tmp_path, manifest["manifest_id"], authority_kp
+    )
+    authority_path = _write_authority_key(tmp_path, authority_kp)
+
+    crl_path.write_text("")  # simulate deletion of the (only) record
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path),
+            "--public-key", str(public_path),
+            "--signature-only",
+            "--crl-path", str(crl_path),
+            "--crl-trusted-key", str(authority_path),
+        ],
+    )
+    payload = _json_stdout(result)
+    assert result.exit_code == 0
+    assert payload["result"] == "VALID"
+
+
+def test_cli_verify_crl_trusted_key_without_crl_path_fails_cleanly(tmp_path):
+    # --crl-trusted-key with no --crl-path has nothing to authenticate and
+    # would otherwise be silently ignored, giving a false sense that
+    # revocation checking is enabled when it is not running at all.
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+    authority_kp = generate_ed25519()
+    authority_path = _write_authority_key(tmp_path, authority_kp)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path),
+            "--public-key", str(public_path),
+            "--crl-trusted-key", str(authority_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--crl-trusted-key requires --crl-path." in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_verify_crl_trusted_key_malformed_fails_cleanly(tmp_path):
+    keypair = generate_ed25519()
+    signed_path = _write_signed_manifest(tmp_path, keypair)
+    public_path = _write_public_key(tmp_path, keypair)
+    crl_path = tmp_path / "crl.jsonl"
+    crl_path.write_text("")
+    bad_authority_path = tmp_path / "bad-authority.hex"
+    bad_authority_path.write_text("not-hex")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "verify", str(signed_path),
+            "--public-key", str(public_path),
+            "--crl-path", str(crl_path),
+            "--crl-trusted-key", str(bad_authority_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "CRL trusted key file does not contain valid hex data." in result.output
     assert "Traceback" not in result.output
 
 

--- a/python/tests/test_revocation.py
+++ b/python/tests/test_revocation.py
@@ -8,6 +8,7 @@ Strategy:
     list (empty and populated), get-found, get-404, signature fields present.
   No hardware or network required.
 """
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -15,6 +16,7 @@ import pytest
 from cryptography.exceptions import InvalidSignature
 
 from agent_manifest._revocation import (
+    CRLIntegrityError,
     FileCRL,
     SignedRevocationRecord,
     create_crl_router,
@@ -223,6 +225,112 @@ def test_revocation_rejects_mismatched_signer_key_id(tmp_path):
     with pytest.raises(InvalidSignature):
         crl.revoke(record)
 
+    assert not crl.is_revoked(MID)
+
+
+def test_file_crl_authenticated_load_fails_closed_on_tampered_record(tmp_path):
+    # CRL-CLI-002 regression: a tampered record in an authenticated CRL must
+    # raise, not be silently dropped so is_revoked() reports False.
+    authority = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl = FileCRL(path, trusted_signer_key=authority.public_bytes)
+    crl.revoke(sign_revocation(MID, "key compromise", "admin", authority))
+
+    line = json.loads(path.read_text().splitlines()[0])
+    sig = list(line["revocation_signature"])
+    mid_idx = len(sig) // 2
+    sig[mid_idx] = "A" if sig[mid_idx] != "A" else "B"
+    line["revocation_signature"] = "".join(sig)
+    path.write_text(json.dumps(line) + "\n")
+
+    with pytest.raises(CRLIntegrityError):
+        FileCRL(path, trusted_signer_key=authority.public_bytes)
+
+
+def test_file_crl_authenticated_load_fails_closed_on_wrong_key(tmp_path):
+    real_authority = generate_ed25519()
+    untrusted_authority = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl = FileCRL(path, trusted_signer_key=untrusted_authority.public_bytes)
+    crl.revoke(sign_revocation(MID, "test", "admin", untrusted_authority))
+
+    with pytest.raises(CRLIntegrityError):
+        FileCRL(path, trusted_signer_key=real_authority.public_bytes)
+
+
+def test_file_crl_authenticated_load_fails_closed_on_malformed_line(tmp_path):
+    authority = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    path.write_text("not valid json at all\n")
+
+    with pytest.raises(CRLIntegrityError):
+        FileCRL(path, trusted_signer_key=authority.public_bytes)
+
+
+def test_file_crl_authenticated_load_one_bad_record_poisons_whole_file(tmp_path):
+    # A single tampered/unverifiable line must invalidate the whole load,
+    # not just be excluded otherwise attacker can tamper with the one
+    # record they want suppressed while leaving others intact and still get
+    # a (partially) trusted result.
+    authority = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl = FileCRL(path, trusted_signer_key=authority.public_bytes)
+    crl.revoke(sign_revocation(MID, "good record", "admin", authority))
+
+    with open(path, "a") as f:
+        f.write("garbage-not-json\n")
+
+    with pytest.raises(CRLIntegrityError):
+        FileCRL(path, trusted_signer_key=authority.public_bytes)
+
+
+def test_file_crl_unauthenticated_load_still_skips_malformed_lines(tmp_path):
+    # Backward-compatible dev-mode behavior (no trusted key) is unchanged:
+    # malformed lines are best-effort skipped rather than raising.
+    path = tmp_path / "crl.jsonl"
+    kp = generate_ed25519()
+    crl = FileCRL(path)
+    crl.revoke(sign_revocation(MID, "test", "admin", kp))
+    with open(path, "a") as f:
+        f.write("not valid json\n")
+
+    crl2 = FileCRL(path)  # must not raise
+    assert crl2.is_revoked(MID)
+
+
+def test_file_crl_authenticated_deleted_record_still_not_revoked(tmp_path):
+    # Documents a known, NOT-fixed limitation: per-record signatures can't
+    # detect deletion of a valid line. This pins current behavior so a
+    # future change can't silently claim more than it delivers without a
+    # test change forcing a conscious decision.
+    authority = generate_ed25519()
+    path = tmp_path / "crl.jsonl"
+    crl = FileCRL(path, trusted_signer_key=authority.public_bytes)
+    crl.revoke(sign_revocation(MID, "key compromise", "admin", authority))
+
+    path.write_text("")  # delete the record
+
+    crl2 = FileCRL(path, trusted_signer_key=authority.public_bytes)  # must not raise
+    assert not crl2.is_revoked(MID)
+
+
+def test_file_crl_authenticated_missing_file_same_as_deleted_record(tmp_path):
+    # A CRL path that never existed and a CRL file that existed and was then
+    # emptied are indistinguishable to FileCRL, even in authenticated mode:
+    # __init__ only calls _load() when the path exists, so a missing file
+    # never reaches the fail-closed signature-verification path at all and
+    # is silently treated as "zero revocations," exactly like the emptied
+    # file in test_file_crl_authenticated_deleted_record_still_not_revoked.
+    # This pins that the two cases share the same (documented) completeness
+    # limitation, so a party who can delete the whole CRL file gets the same
+    # silent un-revocation as one who can only blank its contents -
+    # CRLIntegrityError is never raised in either case.
+    authority = generate_ed25519()
+    missing_path = tmp_path / "never_existed.jsonl"
+    assert not missing_path.exists()
+
+    crl = FileCRL(missing_path, trusted_signer_key=authority.public_bytes)  # must not raise
+    assert crl.all_records() == []
     assert not crl.is_revoked(MID)
 
 


### PR DESCRIPTION
## What

This PR adds --crl-trusted-key to manifest verify so that --crl-path revocation records can actually be cryptographically verified, instead of always loading in FileCRL's unauthenticated mode.

## Why

FileCRL already supports trusted_signer_key for verifying revocation record signatures but the CLI never exposed a flag for it manifest verify --crl-path constructed FileCRL with no signer key. This means anyone who can write to it or intercept the CRL file can delete a revocation record to un-revoke a compromised manifest, or fabricate one, and the CLI accepts it silently.

## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [ ] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
