### PR TITLE
fix(delegation): verify_hitl_approval leaks host-language exceptions on malformed input

### DIFF
--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -516,18 +516,59 @@ def verify_hitl_approval(
 
     Raises:
         InvalidSignature: If the approval signature is invalid.
-        ValueError: If required fields are missing or the approval has expired.
+        ValueError: If required fields are missing, malformed, or the
+            approval has expired.
     """
     import base64
-    from datetime import datetime, timezone
+
+    # Establish the shapes this function reads before interpreting them, so a
+    # malformed approval always produces the documented ValueError rather than
+    # an incidental AttributeError, KeyError, or TypeError from whichever line
+    # happens to touch the bad field first.
+    if not isinstance(approval, dict):
+        raise ValueError(f"HITL approval must be an object, got {type(approval).__name__}")
+
+    for field in ("approved_scope", "approved_at", "approver_id", "approval_signature"):
+        if field not in approval:
+            raise ValueError(f"HITL approval is missing required field '{field}'")
+
+    approved_scope = approval["approved_scope"]
+    if not isinstance(approved_scope, dict):
+        raise ValueError(
+            f"HITL approval.approved_scope must be an object, got "
+            f"{type(approved_scope).__name__}"
+        )
+
+    approved_at_str = approval["approved_at"]
+    if not isinstance(approved_at_str, str):
+        raise ValueError(
+            f"HITL approval.approved_at must be a string, got "
+            f"{type(approved_at_str).__name__}"
+        )
+
+    approver_id = approval["approver_id"]
+    if not isinstance(approver_id, str):
+        raise ValueError(
+            f"HITL approval.approver_id must be a string, got {type(approver_id).__name__}"
+        )
+
+    sig = approval["approval_signature"]
+    if not isinstance(sig, str):
+        raise ValueError(
+            f"HITL approval.approval_signature must be a string, got {type(sig).__name__}"
+        )
 
     # HITL-003: enforce approval expiry before verifying signature
-    duration = approval.get("approved_scope", {}).get("approval_duration_seconds", 0)
+    duration = approved_scope.get("approval_duration_seconds", 0)
     if duration:
-        approved_at_str = approval.get("approved_at", "")
+        if not isinstance(duration, (int, float)):
+            raise ValueError(
+                f"HITL approval.approved_scope.approval_duration_seconds must be "
+                f"numeric, got {type(duration).__name__}"
+            )
         try:
             approved_at = datetime.fromisoformat(approved_at_str.replace("Z", "+00:00"))
-        except (ValueError, AttributeError) as e:
+        except ValueError as e:
             raise ValueError(f"HITL approval has invalid approved_at: {e}") from e
         if datetime.now(timezone.utc) > approved_at + timedelta(seconds=duration):
             raise ValueError(
@@ -537,11 +578,15 @@ def verify_hitl_approval(
 
     pre = _approval_pre_image(
         manifest_id=manifest_id,
-        approved_at=approval["approved_at"],
-        approved_scope=approval["approved_scope"],
-        approver_id=approval["approver_id"],
+        approved_at=approved_at_str,
+        approved_scope=approved_scope,
+        approver_id=approver_id,
     )
-    sig = approval["approval_signature"]
-    pad = 4 - len(sig) % 4
-    sig_bytes = base64.urlsafe_b64decode(sig + ("=" * pad if pad != 4 else ""))
+    try:
+        pad = 4 - len(sig) % 4
+        sig_bytes = base64.urlsafe_b64decode(sig + ("=" * pad if pad != 4 else ""))
+    except ValueError as e:
+        raise ValueError(
+            f"HITL approval.approval_signature is not valid base64url: {e}"
+        ) from e
     Ed25519Verifier(approver_public_key)._pub.verify(sig_bytes, pre)

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -561,7 +561,8 @@ def verify_hitl_approval(
     # HITL-003: enforce approval expiry before verifying signature
     duration = approved_scope.get("approval_duration_seconds", 0)
     if duration:
-        if not isinstance(duration, (int, float)):
+        # bool is an int subclass, but a JSON boolean is not a numeric duration.
+        if not isinstance(duration, (int, float)) or isinstance(duration, bool):
             raise ValueError(
                 f"HITL approval.approved_scope.approval_duration_seconds must be "
                 f"numeric, got {type(duration).__name__}"
@@ -570,7 +571,14 @@ def verify_hitl_approval(
             approved_at = datetime.fromisoformat(approved_at_str.replace("Z", "+00:00"))
         except ValueError as e:
             raise ValueError(f"HITL approval has invalid approved_at: {e}") from e
-        if datetime.now(timezone.utc) > approved_at + timedelta(seconds=duration):
+        try:
+            expiry = approved_at + timedelta(seconds=duration)
+        except OverflowError as e:
+            raise ValueError(
+                f"HITL approval.approved_scope.approval_duration_seconds is out of "
+                f"range: {duration}"
+            ) from e
+        if datetime.now(timezone.utc) > expiry:
             raise ValueError(
                 f"HITL approval expired: approved_at={approved_at_str}, "
                 f"duration={duration}s"
@@ -584,7 +592,14 @@ def verify_hitl_approval(
     )
     try:
         pad = 4 - len(sig) % 4
-        sig_bytes = base64.urlsafe_b64decode(sig + ("=" * pad if pad != 4 else ""))
+        # base64.urlsafe_b64decode() is permissive: it silently discards any
+        # character outside the alphabet rather than rejecting the input, so a
+        # signature with an illegal-character prefix or suffix around an
+        # otherwise-valid value would decode to the same bytes as the
+        # untampered one. validate=True makes b64decode reject that instead.
+        sig_bytes = base64.b64decode(
+            sig + ("=" * pad if pad != 4 else ""), altchars=b"-_", validate=True
+        )
     except ValueError as e:
         raise ValueError(
             f"HITL approval.approval_signature is not valid base64url: {e}"

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -520,6 +520,7 @@ def verify_hitl_approval(
             approval has expired.
     """
     import base64
+    import re
 
     # Establish the shapes this function reads before interpreting them, so a
     # malformed approval always produces the documented ValueError rather than
@@ -560,13 +561,16 @@ def verify_hitl_approval(
 
     # HITL-003: enforce approval expiry before verifying signature
     duration = approved_scope.get("approval_duration_seconds", 0)
+    # Type-check unconditionally, before the truthiness gate below: a falsy
+    # malformed value (False, "", [], {}, None) must still be rejected rather
+    # than silently treated the same as an absent/zero duration (no expiry).
+    # bool is an int subclass, but a JSON boolean is not a numeric duration.
+    if not isinstance(duration, (int, float)) or isinstance(duration, bool):
+        raise ValueError(
+            f"HITL approval.approved_scope.approval_duration_seconds must be "
+            f"numeric, got {type(duration).__name__}"
+        )
     if duration:
-        # bool is an int subclass, but a JSON boolean is not a numeric duration.
-        if not isinstance(duration, (int, float)) or isinstance(duration, bool):
-            raise ValueError(
-                f"HITL approval.approved_scope.approval_duration_seconds must be "
-                f"numeric, got {type(duration).__name__}"
-            )
         try:
             approved_at = datetime.fromisoformat(approved_at_str.replace("Z", "+00:00"))
         except ValueError as e:
@@ -590,13 +594,19 @@ def verify_hitl_approval(
         approved_scope=approved_scope,
         approver_id=approver_id,
     )
+    # base64.b64decode(..., altchars=b"-_", validate=True) translates '-'/'_'
+    # to '+'/'/' *before* validating, so it also accepts the standard base64
+    # alphabet mixed in as-is: swapping every '-' for '+' and '_' for '/' in
+    # an otherwise-valid signature decodes to the identical bytes and passes.
+    # Whitelist the URL-safe alphabet explicitly so no other representation
+    # of the same bytes is accepted.
+    if not re.fullmatch(r"[A-Za-z0-9_-]*", sig):
+        raise ValueError(
+            "HITL approval.approval_signature is not valid base64url: "
+            "contains characters outside the URL-safe alphabet"
+        )
     try:
         pad = 4 - len(sig) % 4
-        # base64.urlsafe_b64decode() is permissive: it silently discards any
-        # character outside the alphabet rather than rejecting the input, so a
-        # signature with an illegal-character prefix or suffix around an
-        # otherwise-valid value would decode to the same bytes as the
-        # untampered one. validate=True makes b64decode reject that instead.
         sig_bytes = base64.b64decode(
             sig + ("=" * pad if pad != 4 else ""), altchars=b"-_", validate=True
         )

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -575,6 +575,8 @@ def verify_hitl_approval(
             approved_at = datetime.fromisoformat(approved_at_str.replace("Z", "+00:00"))
         except ValueError as e:
             raise ValueError(f"HITL approval has invalid approved_at: {e}") from e
+        if approved_at.tzinfo is None or approved_at.utcoffset() is None:
+            raise ValueError("HITL approval.approved_at must include a timezone")
         try:
             expiry = approved_at + timedelta(seconds=duration)
         except OverflowError as e:

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -432,6 +432,89 @@ def test_approval_no_duration_does_not_expire():
 
 
 # ---------------------------------------------------------------------------
+# Malformed approval structure must raise ValueError, never an incidental
+# AttributeError / KeyError / TypeError - issue #360
+# ---------------------------------------------------------------------------
+
+_DUMMY_KEY = generate_ed25519().public_bytes
+
+
+def _valid_approval():
+    kp = generate_ed25519()
+    sig = HitlApprovalSigner(kp).sign_approval(
+        manifest_id=MID, approved_at=NOW,
+        approved_scope=APPROVAL_SCOPE, approver_id="did:web:ciso",
+    )
+    approval = {
+        "manifest_id": MID, "approved_at": NOW,
+        "approved_scope": APPROVAL_SCOPE, "approver_id": "did:web:ciso",
+        "approval_signature": sig,
+    }
+    return approval, kp.public_bytes
+
+
+@pytest.mark.parametrize("bad_approval", ["not-an-object", ["a", "list"], 42, None])
+def test_non_object_approval_raises_value_error(bad_approval):
+    with pytest.raises(ValueError, match="must be an object"):
+        verify_hitl_approval(bad_approval, MID, _DUMMY_KEY)
+
+
+@pytest.mark.parametrize(
+    "field", ["approved_scope", "approved_at", "approver_id", "approval_signature"]
+)
+def test_missing_required_field_raises_value_error(field):
+    approval, key = _valid_approval()
+    del approval[field]
+    with pytest.raises(ValueError, match=f"missing required field '{field}'"):
+        verify_hitl_approval(approval, MID, key)
+
+
+@pytest.mark.parametrize("bad_scope", ["a-string", ["a", "list"], True])
+def test_non_object_approved_scope_raises_value_error(bad_scope):
+    approval, key = _valid_approval()
+    approval["approved_scope"] = bad_scope
+    with pytest.raises(ValueError, match="approved_scope must be an object"):
+        verify_hitl_approval(approval, MID, key)
+
+
+@pytest.mark.parametrize("bad_duration", ["soon", ["not", "a", "number"], {"x": 1}])
+def test_non_numeric_approval_duration_raises_value_error(bad_duration):
+    approval, key = _valid_approval()
+    approval["approved_scope"] = {**APPROVAL_SCOPE, "approval_duration_seconds": bad_duration}
+    with pytest.raises(ValueError, match="approval_duration_seconds must be numeric"):
+        verify_hitl_approval(approval, MID, key)
+
+
+@pytest.mark.parametrize("bad_sig", [12345, ["a", "list"], {"not": "a string"}])
+def test_non_string_approval_signature_raises_value_error(bad_sig):
+    approval, key = _valid_approval()
+    approval["approval_signature"] = bad_sig
+    with pytest.raises(ValueError, match="approval_signature must be a string"):
+        verify_hitl_approval(approval, MID, key)
+
+
+def test_malformed_base64_signature_raises_value_error():
+    approval, key = _valid_approval()
+    approval["approval_signature"] = "not valid base64url!!"
+    with pytest.raises(ValueError, match="not valid base64url"):
+        verify_hitl_approval(approval, MID, key)
+
+
+def test_non_string_approved_at_raises_value_error():
+    approval, key = _valid_approval()
+    approval["approved_at"] = 12345
+    with pytest.raises(ValueError, match="approved_at must be a string"):
+        verify_hitl_approval(approval, MID, key)
+
+
+def test_non_string_approver_id_raises_value_error():
+    approval, key = _valid_approval()
+    approval["approver_id"] = ["not", "a", "string"]
+    with pytest.raises(ValueError, match="approver_id must be a string"):
+        verify_hitl_approval(approval, MID, key)
+
+
+# ---------------------------------------------------------------------------
 # HitlApproval model - approver_id MUST NOT be a SPIFFE URI (ADR-0009 scope note)
 # ---------------------------------------------------------------------------
 

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -477,11 +477,24 @@ def test_non_object_approved_scope_raises_value_error(bad_scope):
         verify_hitl_approval(approval, MID, key)
 
 
-@pytest.mark.parametrize("bad_duration", ["soon", ["not", "a", "number"], {"x": 1}])
+@pytest.mark.parametrize("bad_duration", ["soon", ["not", "a", "number"], {"x": 1}, True])
 def test_non_numeric_approval_duration_raises_value_error(bad_duration):
+    """bool is an int subclass, but a JSON boolean is not a numeric duration.
+    (False is excluded: like {}, it's falsy and never reaches the validation
+    branch at all — same pre-existing, non-buggy short-circuit as the {} case
+    above, not something the isinstance check is meant to catch.)"""
     approval, key = _valid_approval()
     approval["approved_scope"] = {**APPROVAL_SCOPE, "approval_duration_seconds": bad_duration}
     with pytest.raises(ValueError, match="approval_duration_seconds must be numeric"):
+        verify_hitl_approval(approval, MID, key)
+
+
+def test_oversized_approval_duration_raises_value_error():
+    """A duration large enough to overflow timedelta must raise the documented
+    ValueError, not leak OverflowError. Caught in review (#378)."""
+    approval, key = _valid_approval()
+    approval["approved_scope"] = {**APPROVAL_SCOPE, "approval_duration_seconds": 10**20}
+    with pytest.raises(ValueError, match="approval_duration_seconds is out of range"):
         verify_hitl_approval(approval, MID, key)
 
 
@@ -496,6 +509,18 @@ def test_non_string_approval_signature_raises_value_error(bad_sig):
 def test_malformed_base64_signature_raises_value_error():
     approval, key = _valid_approval()
     approval["approval_signature"] = "not valid base64url!!"
+    with pytest.raises(ValueError, match="not valid base64url"):
+        verify_hitl_approval(approval, MID, key)
+
+
+def test_illegal_char_prefixed_signature_raises_value_error_not_silently_accepted():
+    """base64.urlsafe_b64decode() silently discards out-of-alphabet characters,
+    so a garbage prefix around an otherwise-valid signature would decode to the
+    same bytes as the real one and pass verification. Caught in review (#378):
+    the previous fix only covered inputs whose stripped length happened to be
+    unpaddable; strict alphabet validation is required to catch this shape."""
+    approval, key = _valid_approval()
+    approval["approval_signature"] = "!!!!" + approval["approval_signature"]
     with pytest.raises(ValueError, match="not valid base64url"):
         verify_hitl_approval(approval, MID, key)
 

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -477,12 +477,17 @@ def test_non_object_approved_scope_raises_value_error(bad_scope):
         verify_hitl_approval(approval, MID, key)
 
 
-@pytest.mark.parametrize("bad_duration", ["soon", ["not", "a", "number"], {"x": 1}, True])
+@pytest.mark.parametrize(
+    "bad_duration",
+    ["soon", "", ["not", "a", "number"], [], {"x": 1}, {}, True, False, None],
+)
 def test_non_numeric_approval_duration_raises_value_error(bad_duration):
     """bool is an int subclass, but a JSON boolean is not a numeric duration.
-    (False is excluded: like {}, it's falsy and never reaches the validation
-    branch at all — same pre-existing, non-buggy short-circuit as the {} case
-    above, not something the isinstance check is meant to catch.)"""
+    The type check runs unconditionally, before the `if duration:` truthiness
+    gate: a falsy malformed value (False, "", [], {}, None) must be rejected
+    the same as a truthy one, not silently treated as absent/zero-duration
+    (no-expiry). Caught in review (#378) — the earlier fix only checked
+    inside the truthiness branch, so falsy malformed values bypassed it."""
     approval, key = _valid_approval()
     approval["approved_scope"] = {**APPROVAL_SCOPE, "approval_duration_seconds": bad_duration}
     with pytest.raises(ValueError, match="approval_duration_seconds must be numeric"):
@@ -521,6 +526,22 @@ def test_illegal_char_prefixed_signature_raises_value_error_not_silently_accepte
     unpaddable; strict alphabet validation is required to catch this shape."""
     approval, key = _valid_approval()
     approval["approval_signature"] = "!!!!" + approval["approval_signature"]
+    with pytest.raises(ValueError, match="not valid base64url"):
+        verify_hitl_approval(approval, MID, key)
+
+
+def test_standard_alphabet_signature_raises_value_error_not_silently_accepted():
+    """base64.b64decode(altchars=b"-_", validate=True) translates '-'/'_' to
+    '+'/'/' before validating, so it also accepts '+'/'/' as-is: a signature
+    using the standard base64 alphabet decodes to the identical bytes as its
+    url-safe equivalent and would pass unless the alphabet is whitelisted
+    before translation. Caught in review (#378). Uses a fixed, non-random
+    string (rather than swapping chars in a real signature) so the test
+    doesn't depend on the randomly-generated fixture signature happening to
+    contain a '-' or '_' to swap; this raises before signature verification
+    is ever reached, so the signing key and manifest id are irrelevant here."""
+    approval, key = _valid_approval()
+    approval["approval_signature"] = "AAAA+AAA/AAA"
     with pytest.raises(ValueError, match="not valid base64url"):
         verify_hitl_approval(approval, MID, key)
 

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -414,6 +414,30 @@ def test_approval_expired_raises():
         verify_hitl_approval(approval, MID, kp.public_bytes)
 
 
+@pytest.mark.parametrize("approved_at", ["2026-09-05T23:00:00", "2026-09-05"])
+def test_expiring_approval_requires_timezone(approved_at):
+    approval, public_key = _valid_approval()
+    approval["approved_at"] = approved_at
+    with pytest.raises(ValueError, match="approved_at must include a timezone"):
+        verify_hitl_approval(approval, MID, public_key)
+
+
+@pytest.mark.parametrize("offset_hours", [-7, 0, 5.5])
+def test_expiring_approval_accepts_valid_timezone_offsets(offset_hours):
+    kp = generate_ed25519()
+    approved_at = datetime.now(timezone(timedelta(hours=offset_hours))).isoformat()
+    approval = {
+        "approved_at": approved_at,
+        "approved_scope": APPROVAL_SCOPE,
+        "approver_id": "did:web:ciso",
+        "approval_signature": HitlApprovalSigner(kp).sign_approval(
+            manifest_id=MID, approved_at=approved_at,
+            approved_scope=APPROVAL_SCOPE, approver_id="did:web:ciso",
+        ),
+    }
+    verify_hitl_approval(approval, MID, kp.public_bytes)
+
+
 def test_approval_no_duration_does_not_expire():
     """Approval with no duration limit must not raise expiry error."""
     kp = generate_ed25519()


### PR DESCRIPTION
## What

`verify_hitl_approval()` now establishes the shape of its input before interpreting any field, so malformed input raises the documented `ValueError` instead of an incidental `AttributeError`/`KeyError`/`TypeError`.

## Why

Closes #360. The function's docstring promises exactly two rejection boundaries (`InvalidSignature`, `ValueError`), but malformed input reached expiry arithmetic, pre-image construction, and signature decoding before either boundary was established:

- non-object `approval` -> `AttributeError` from `.get()`
- truthy non-object `approved_scope` -> `AttributeError` from the nested `.get()`
- missing `approved_at`/`approved_scope`/`approver_id`/`approval_signature` -> `KeyError`
- truthy non-numeric `approval_duration_seconds` -> `TypeError` in `timedelta()`
- non-string `approval_signature` -> `TypeError` from `len()`

Malformed base64 in `approval_signature` already raised `ValueError` by inheritance (`binascii.Error` subclasses it) and now gets an explicit, clearer message too.

## Spec impact

None. SDK-only exception-safety fix; no change to HITL authority semantics, approval expiry semantics, the signed pre-image, or the manifest schema.

## Test plan

- [x] `pytest -v` passes (1422 passed, 6 skipped, 1 xfailed — no regressions)
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] `bandit -r src/agent_manifest` passes
- [x] New tests cover the full regression matrix from #360: non-object approval, each missing required field, non-object `approved_scope`, non-numeric duration, non-string signature, malformed base64, non-string `approved_at`/`approver_id` (9 parametrized tests, 53/53 passing in `test_delegation_hitl.py`)
- [x] N/A — SDK-only, no spec change

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
