### PR TITLE
fix(trace): manifest binding can raise on malformed nested manifest shapes

### DIFF
--- a/python/src/agent_manifest/_trace.py
+++ b/python/src/agent_manifest/_trace.py
@@ -567,7 +567,15 @@ def _check_manifest_binding(
         return warnings
 
     artifacts = manifest.get("artifacts") or {}
+    if not isinstance(artifacts, dict):
+        warnings.append("manifest_artifacts_not_an_object")
+        return warnings
+
     policy_bundle = artifacts.get("policy_bundle") or {}
+    if not isinstance(policy_bundle, dict):
+        warnings.append("manifest_policy_bundle_not_an_object")
+        return warnings
+
     expected_policy_hash = policy_bundle.get("hash")
 
     if expected_policy_hash is None:

--- a/python/tests/test_trace_verify.py
+++ b/python/tests/test_trace_verify.py
@@ -380,6 +380,55 @@ def test_manifest_without_policy_hash_warns(kp, trusted):
 
 
 # ---------------------------------------------------------------------------
+# Malformed nested manifest shapes must warn, never raise - issue #362
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_artifacts", ["not-an-object", ["a", "list"], True])
+def test_non_object_manifest_artifacts_warns_not_raises(kp, trusted, bad_artifacts):
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope,
+        trusted_keys=trusted,
+        manifest={"manifest_id": MANIFEST_ID, "artifacts": bad_artifacts},
+    )
+    # The TRACE signature already verified; a malformed optional binding must
+    # not retroactively make the envelope unappraisable.
+    assert result.status is TraceStatus.VERIFIED
+    assert "manifest_artifacts_not_an_object" in result.warnings
+
+
+@pytest.mark.parametrize("bad_policy_bundle", ["not-an-object", ["a", "list"], True])
+def test_non_object_policy_bundle_warns_not_raises(kp, trusted, bad_policy_bundle):
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope,
+        trusted_keys=trusted,
+        manifest={
+            "manifest_id": MANIFEST_ID,
+            "artifacts": {"policy_bundle": bad_policy_bundle},
+        },
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert "manifest_policy_bundle_not_an_object" in result.warnings
+
+
+def test_pack_with_malformed_manifest_artifacts_warns_not_raises(kp, trusted):
+    """The evidence-pack path is independently reachable (#362): it feeds its
+    manifest to every contained envelope without checking artifacts/
+    policy_bundle shape first."""
+    envelope = _sign_envelope(_envelope(), kp)
+    malformed_manifest = {"manifest_id": MANIFEST_ID, "artifacts": "not-an-object"}
+    pack = _sign_pack(_pack([envelope], manifest=malformed_manifest), kp)
+    result = verify_evidence_pack(
+        pack, trusted_keys=trusted, trace_key_id=kp.key_id
+    )
+    assert len(result.envelopes) == 1
+    assert result.envelopes[0].status is TraceStatus.VERIFIED
+    assert "manifest_artifacts_not_an_object" in result.envelopes[0].warnings
+
+
+# ---------------------------------------------------------------------------
 # Evidence pack
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`_check_manifest_binding()` now checks that `artifacts` and `artifacts.policy_bundle` are objects before reading them, warning instead of raising `AttributeError`.

## Why

Closes #362. `artifacts = manifest.get("artifacts") or {}` and `policy_bundle = artifacts.get("policy_bundle") or {}` only guard falsy values; a truthy non-object at either level reaches `.get()` unguarded, after the TRACE signature has already verified.

Both `verify_trace_envelope()` (direct `manifest=` callers) and `verify_evidence_pack()` route through this one function — confirmed by the single call site, so this fix covers both reported paths without duplicating logic. `verify_evidence_pack()` already establishes the manifest is a dict with a non-empty `manifest_id` before this point; `artifacts`/`policy_bundle` were the still-unguarded nested fields.

A malformed *optional* manifest binding shouldn't retroactively make an already-verified envelope unappraisable, so this follows the same severity the function already uses for "no policy bundle hash available" — a warning, not a failure. Missing and malformed now report distinct warnings (`manifest_artifacts_not_an_object`, `manifest_policy_bundle_not_an_object`) so a caller can tell "advisory info absent" from "advisory info unreadable".

## Spec impact

None. SDK-only. Does not change the F-21 hash-conflict rule, the pack's separate `verification_result` trust model, or the manifest-id binding check — purely nested structural prerequisite enforcement at an exported verifier boundary, per the issue's own scoping.

## Test plan

- [x] `pytest -v` passes (1409 passed, 6 skipped, 1 xfailed — no regressions)
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] `bandit -r src/agent_manifest` passes
- [x] New tests: non-object `artifacts` (string/list/bool) and non-object `policy_bundle` (string/list/bool) both warn rather than raise, envelope stays `VERIFIED`; a pack-level test confirms the same for the independently-reachable `verify_evidence_pack()` path. Existing F-21 conflict, `manifest_id_mismatch`, and no-policy-hash-warning tests confirmed unaffected. 120/120 in `test_trace_verify.py`.
- [x] N/A — SDK-only, no spec change

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
