### PR TITLE
feat(ci): vouch first-time contributors, and say the rule about understanding

### DIFF
--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -1,0 +1,111 @@
+name: Vouch check
+
+# Closes pull requests from contributors who have not been vouched by a
+# maintainer, and tells them how to get vouched.
+#
+# The judgement is human. This workflow decides nothing about a person: a
+# maintainer adds a name and this only reads the list. That distinction is the
+# whole design. An earlier attempt here scored contributors automatically and
+# produced false and operationally misleading signals.
+#
+# The pattern comes from another open-source project running the same kind of
+# gate. Written independently; the idea worth borrowing was keeping the list on
+# a branch of its own.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  vouch-gate:
+    if: github.repository_owner == 'agentrust-io'
+    runs-on: ubuntu-latest
+    steps:
+      # Nothing from the pull request is checked out. This runs on
+      # pull_request_target with a write-capable token, so it must never
+      # execute code from the incoming branch.
+      - name: Check the author against the vouched list
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            if (pr.user.type === 'Bot' || author.endsWith('[bot]')) {
+              core.info(`${author} is a bot. Nothing to check.`);
+              return;
+            }
+
+            // Anyone who can already push does not need vouching. Uses the
+            // permission API rather than org membership, so no extra secret
+            // is required for the check to work.
+            try {
+              const { data: perm } =
+                await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: author,
+                });
+              if (['admin', 'maintain', 'write'].includes(perm.permission)) {
+                core.info(`${author} has ${perm.permission} access. Nothing to check.`);
+                return;
+              }
+            } catch (e) {
+              core.info(`Could not read permission for ${author} (${e.status}). Continuing.`);
+            }
+
+            // Read the list from the dedicated branch, never from the pull
+            // request branch: an author can edit any file in their own fork.
+            let vouched = [];
+            try {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: '.github/VOUCHED',
+                ref: 'vouched',
+              });
+              vouched = Buffer.from(data.content, 'base64')
+                .toString('utf-8')
+                .split('\n')
+                .map(l => l.trim())
+                .filter(l => l && !l.startsWith('#'));
+            } catch (e) {
+              // Fail open. A missing or unreadable list is our problem, and
+              // silently closing every pull request would be worse than
+              // letting one through.
+              core.warning(`Could not read .github/VOUCHED on the vouched branch: ${e.message}. Allowing.`);
+              return;
+            }
+
+            if (vouched.some(name => name.toLowerCase() === author.toLowerCase())) {
+              core.info(`${author} is vouched.`);
+              return;
+            }
+
+            core.info(`${author} is not vouched. Closing.`);
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                `Thanks for this, @${author}. Closing it for now, and it is not about the change itself.`,
+                '',
+                'This repository asks first-time contributors to be vouched by a maintainer before opening a pull request. That is because agent-written contributions are easy to produce and expensive to review, and we would rather talk to you first than review something neither of us can explain.',
+                '',
+                '**To get vouched:** open an issue saying what you want to change and why, in your own words. A maintainer will reply, and add you with `/vouch`. After that, reopen this pull request or open a new one.',
+                '',
+                'See [CONTRIBUTING.md](https://github.com/agentrust-io/agent-manifest/blob/main/CONTRIBUTING.md#being-vouched) for the detail.',
+              ].join('\n'),
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });

--- a/.github/workflows/vouch-command.yml
+++ b/.github/workflows/vouch-command.yml
@@ -1,0 +1,89 @@
+name: Vouch command
+
+# Lets a maintainer add someone to the vouched list by commenting
+#   /vouch @username
+# on any issue or pull request. Only accounts that can already push may do it.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  vouch:
+    if: github.repository_owner == 'agentrust-io' && startsWith(github.event.comment.body, '/vouch')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add the named account to the vouched list
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const body = context.payload.comment.body.trim();
+            const issueNumber = context.payload.issue.number;
+
+            const reply = (text) => github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: text,
+            });
+
+            // Only people who can already push may vouch.
+            let permission = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: commenter,
+              });
+              permission = data.permission;
+            } catch (e) {
+              core.setFailed(`Could not read permission for ${commenter}: ${e.message}`);
+              return;
+            }
+            if (!['admin', 'maintain', 'write'].includes(permission)) {
+              core.info(`${commenter} has ${permission} access. Ignoring.`);
+              return;
+            }
+
+            const match = body.match(/^\/vouch\s+@?([A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38})\s*$/);
+            if (!match) {
+              await reply('Usage: `/vouch @username`, one account per comment.');
+              return;
+            }
+            const target = match[1];
+
+            const { data: file } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/VOUCHED',
+              ref: 'vouched',
+            });
+            const current = Buffer.from(file.content, 'base64').toString('utf-8');
+            const names = current
+              .split('\n')
+              .map(l => l.trim())
+              .filter(l => l && !l.startsWith('#'));
+
+            if (names.some(n => n.toLowerCase() === target.toLowerCase())) {
+              await reply(`@${target} is already vouched.`);
+              return;
+            }
+
+            const updated = current.replace(/\n*$/, '\n') + `${target}\n`;
+
+            await github.rest.repos.createOrUpdateFileContents({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/VOUCHED',
+              branch: 'vouched',
+              message: `chore: vouch ${target}\n\nVouched by ${commenter} in #${issueNumber}.`,
+              content: Buffer.from(updated, 'utf-8').toString('base64'),
+              sha: file.sha,
+            });
+
+            await reply(`@${target} is vouched by @${commenter}. Pull requests from that account will not be closed by the vouch check.`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,22 @@ Agent Manifest is an open specification and reference SDK. Contributions are wel
 
 The spec is in active design-partner review, and in CoSAI WS4 Phase 1 review ahead of a proposed contribution to WS4. Breaking spec changes (field renames, schema incompatibilities, conformance level changes) require an issue and discussion before a PR. Non-breaking additions and bug fixes can go straight to a PR.
 
+## Using AI to contribute
+
+Use agents. A lot of this was built with them and saying otherwise would be dishonest.
+
+The rule is that you have to understand what you submit. If you cannot explain what your change does and how it interacts with the rest of the system, with the agent closed, do not open the pull request. Reviewing a change nobody can explain costs more than writing it did, and it becomes someone else's problem the moment it merges.
+
+That is a rule about understanding, not about tooling.
+
+## Being vouched
+
+If you have not contributed here before, ask before you build. Open an issue saying what you want to change and why, in your own words. A maintainer will reply and add you with `/vouch`, and after that your pull requests go through the normal review.
+
+A pull request from an account that has not been vouched is closed automatically, with a comment pointing back here. That is not a judgement about you or about the change. It exists because agent-written contributions are cheap to produce and expensive to review, and a short conversation first is better for both sides than a review neither of us can finish.
+
+Anyone who can already push, and anyone with a merged pull request here before this rule existed, is already vouched.
+
 ## DCO sign-off
 
 All commits must be signed off with the [Developer Certificate of Origin](https://developercertificate.org/):


### PR DESCRIPTION
Mirrors what is already merged in `cmcp` (agentrust-io/cmcp#605).

## The gate

A pull request from an account not on the vouched list is closed with a comment explaining how to get vouched. The judgement stays human: a maintainer comments `/vouch @username`, `vouch-command.yml` appends to the list, and `vouch-check.yml` only ever reads it. Nothing here scores anybody.

- **Seeded**, with every account that already has a merged PR here, so nobody existing is turned away.
- **Reads the list off the `vouched` branch, never the PR branch**, because an author can edit any file in their own fork.
- **Fails open.** An unreadable list is our problem; silently closing every PR would be worse.
- **No new secret.** Uses the permission API rather than org membership, so anyone who can already push is skipped.
- **Checks out nothing from the PR.** It runs on `pull_request_target` with a write-capable token.

## It composes with the reputation check rather than replacing it

The existing contributor reputation check is advisory: it comments and labels a risk level and closes nothing. So it reads as evidence for the maintainer deciding whether to vouch, rather than as a verdict of its own. A score acting as a verdict is the thing that failed review elsewhere; a score informing a person is a different mechanism.

## And the half that costs nothing

`CONTRIBUTING.md` gains the understanding rule: use agents, a lot of this was built with them, and if you cannot explain your change with the agent closed, do not open the PR. That is going to every repository including the spec ones, gate or no gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc16CsknaQ9PTLxGj8TXXj