### PR TITLE
fix(cert-chain): enforce pathLenConstraint (RFC 5280 §4.2.1.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- **[SDK]** `verify_cert_chain()` now enforces `BasicConstraints.path_length`
+  (RFC 5280 §4.2.1.9). An issuer that declares `path_length=N` but has more
+  than `N` CA certificates between it and the leaf previously verified
+  successfully every other individual check on it (validity period, `ca`
+  flag, key usage) passed on its own, so nothing else caught it. Self-issued
+  certificates (CA key rollover) are not exempted from the count; this is the
+  fail-closed direction relative to the full RFC algorithm.
+
 ### Deprecated
 
 - **[SPEC] Issuing v0.1 manifests ends 2026-11-30** (issue #315, phase 5). From that

--- a/python/src/agent_manifest/_cert_chain.py
+++ b/python/src/agent_manifest/_cert_chain.py
@@ -94,7 +94,9 @@ def verify_cert_chain(
         CertChainError: on an empty chain, no trusted roots, a link that is not
             validly issued by the next, an expired or not-yet-valid certificate,
             an issuer that is not a CA, an issuer whose key usage forbids
-            certificate signing, an unpinned root, or missing ``cryptography``.
+            certificate signing, an issuer whose ``pathLenConstraint`` is
+            violated by the CA certificates below it, an unpinned root, or
+            missing ``cryptography``.
     """
     try:
         from cryptography import x509
@@ -129,6 +131,23 @@ def verify_cert_chain(
             ) from exc
         if not constraints.ca:
             raise CertChainError(f"issuer certificate at position {i} is not a CA")
+        # RFC 5280 4.2.1.9: pathLenConstraint bounds how many CA certificates
+        # may follow this one on the way to the leaf. Position 0 is the leaf
+        # itself, so positions 1..i-1 are the CA certificates between this
+        # issuer and the leaf - `i - 1` of them.
+        #
+        # Simplification: RFC 5280 excludes self-issued certificates (subject
+        # == issuer, used for CA key rollover) from this count. None of the
+        # three attestation call sites in this codebase (SEV-SNP, TDX, TPM)
+        # ever produce a self-issued intermediate, and treating every CA as
+        # counting is the fail-closed direction - it can only reject a chain
+        # the full RFC algorithm would accept, never the reverse.
+        if constraints.path_length is not None and (i - 1) > constraints.path_length:
+            raise CertChainError(
+                f"issuer certificate at position {i} has path_length="
+                f"{constraints.path_length}, but {i - 1} CA certificate(s) "
+                "follow it toward the leaf"
+            )
         try:
             key_usage = issuer.extensions.get_extension_for_class(x509.KeyUsage).value
         except x509.ExtensionNotFound:

--- a/python/tests/test_cert_chain.py
+++ b/python/tests/test_cert_chain.py
@@ -46,6 +46,7 @@ def _cert(
     pss=False,
     ca=False,
     key_cert_sign=None,
+    path_length=None,
     not_before=_T0,
     not_after=_T0 + timedelta(days=3650),
 ):
@@ -57,7 +58,7 @@ def _cert(
         .serial_number(x509.random_serial_number())
         .not_valid_before(not_before)
         .not_valid_after(not_after)
-        .add_extension(x509.BasicConstraints(ca=ca, path_length=None), critical=True)
+        .add_extension(x509.BasicConstraints(ca=ca, path_length=path_length), critical=True)
     )
     if key_cert_sign is not None:
         b = b.add_extension(
@@ -197,6 +198,67 @@ def test_issuer_key_usage_must_allow_certificate_signing():
     leaf = _cert("leaf", "root", lk.public_key(), rk)
     with pytest.raises(CertChainError, match="cannot sign certificates"):
         verify_cert_chain([leaf, root], [root])
+
+
+# --- pathLenConstraint (RFC 5280 4.2.1.9) -----------------------------------
+
+
+def test_path_length_zero_forbids_a_ca_below_it():
+    """root --(path_length=0)--> mid_ca --(ca=True)--> leaf is invalid.
+
+    ``path_length=0`` on ``root`` means no CA certificate may follow it on
+    the way to the leaf. ``mid_ca`` is a CA certificate that does exactly
+    that, so the chain must be rejected even though every signature and
+    every individual BasicConstraints/KeyUsage check on its own passes.
+    """
+    rk, mk, lk = _ec(), _ec(), _ec()
+    root = _cert("root", "root", rk.public_key(), rk, ca=True, path_length=0)
+    mid_ca = _cert("mid", "root", mk.public_key(), rk, ca=True)
+    leaf = _cert("leaf", "mid", lk.public_key(), mk)
+    with pytest.raises(CertChainError, match="path_length"):
+        verify_cert_chain([leaf, mid_ca, root], [root])
+
+
+def test_path_length_zero_allows_a_direct_leaf():
+    """root --(path_length=0)--> leaf is fine: zero CAs follow root."""
+    rk, lk = _ec(), _ec()
+    root = _cert("root", "root", rk.public_key(), rk, ca=True, path_length=0)
+    leaf = _cert("leaf", "root", lk.public_key(), rk)
+    assert verify_cert_chain([leaf, root], [root]) is True
+
+
+def test_path_length_one_allows_exactly_one_ca_below():
+    rk, mk, lk = _ec(), _ec(), _ec()
+    root = _cert("root", "root", rk.public_key(), rk, ca=True, path_length=1)
+    mid_ca = _cert("mid", "root", mk.public_key(), rk, ca=True)
+    leaf = _cert("leaf", "mid", lk.public_key(), mk)
+    assert verify_cert_chain([leaf, mid_ca, root], [root]) is True
+
+
+def test_path_length_violation_is_caught_at_any_position_not_just_root():
+    """The constraint is enforced on whichever issuer declares it - not
+    hard-coded to the root position. root -> ca_A(path_length=0) -> ca_B
+    (a CA) -> leaf: ca_A is not the root and not the leaf's direct issuer,
+    and its path_length=0 is still violated by ca_B."""
+    rk, ak, bk, lk = _ec(), _ec(), _ec(), _ec()
+    root = _cert("root", "root", rk.public_key(), rk, ca=True)
+    ca_a = _cert("ca_a", "root", ak.public_key(), rk, ca=True, path_length=0)
+    ca_b = _cert("ca_b", "ca_a", bk.public_key(), ak, ca=True)
+    leaf = _cert("leaf", "ca_b", lk.public_key(), bk)
+    with pytest.raises(CertChainError, match="path_length"):
+        verify_cert_chain([leaf, ca_b, ca_a, root], [root])
+
+
+def test_unconstrained_deep_chain_still_verifies():
+    """Same shape as above but every CA is unconstrained: must still pass,
+    confirming the new check has no false positives on a chain deeper than
+    the existing 3-certificate fixtures exercise."""
+    rk, ak, bk, lk = _ec(), _ec(), _ec(), _ec()
+    root = _cert("root", "root", rk.public_key(), rk, ca=True)
+    ca_a = _cert("ca_a", "root", ak.public_key(), rk, ca=True)
+    ca_b = _cert("ca_b", "ca_a", bk.public_key(), ak, ca=True)
+    leaf = _cert("leaf", "ca_b", lk.public_key(), bk)
+    assert verify_cert_chain([leaf, ca_b, ca_a, root], [root]) is True
 
 
 # --- parse_tdx_quote strict vs lenient -------------------------------------


### PR DESCRIPTION
## What

Enforce `pathLenConstraint` (RFC 5280 §4.2.1.9) in `verify_cert_chain`, which previously accepted chains that violate it.


## Why

`_cert_chain.py` is the shared X.509 chain verifier used by the SEV-SNP, TDX, and TPM attestation verifiers. It checks certificate validity, `BasicConstraints.ca`, and key usage on every issuer, but never read `BasicConstraints.path_length`. So a CA cert declaring "no CA may follow me" (`path_length=0`) could still have another CA below it in the chain, and the chain would verify anyway every other check on it passes individually. 

## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [x] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
