### PR TITLE
fix(verify): make the verifier fail closed on attestation, timestamps and AK chains

### DIFF
--- a/python/src/agent_manifest/_tpm_verify.py
+++ b/python/src/agent_manifest/_tpm_verify.py
@@ -329,47 +329,37 @@ def _verify_ak_chain(
 ) -> object:
     """Verify a leaf-first AK chain up to a pinned trusted root; return the leaf.
 
-    Every certificate in the chain must be within its validity period (see
-    :func:`._cert_chain.check_validity_period`); an expired AK certificate or
-    an expired link above it is rejected even if every signature in the chain
-    is otherwise valid.
+    Delegates to :func:`._cert_chain.verify_cert_chain`, which is the same
+    appraisal the SEV-SNP and TDX paths use. Checking only "each certificate is
+    signed by the next, and the last one is pinned" is not enough: it accepts an
+    expired or not-yet-valid AK, a non-CA intermediate, and an intermediate whose
+    KeyUsage explicitly forbids certificate signing. Any of those is a chain a
+    relying party should never have treated as rooted in its pinned vendor CA.
 
-    Raises :class:`TpmVerificationError` on any failure.
+    Raises :class:`TpmVerificationError` on any failure, including malformed PEM.
+    The attestation dispatcher above only catches TpmVerificationError, so a raw
+    ValueError out of the certificate parser would escape it.
     """
     from cryptography import x509
-    from cryptography.exceptions import InvalidSignature
-    from cryptography.hazmat.primitives.hashes import SHA256
 
-    from ._cert_chain import CertChainError, check_validity_period
+    from ._cert_chain import CertChainError, verify_cert_chain
 
-    chain = x509.load_pem_x509_certificates(ak_chain_pem)
-    roots = x509.load_pem_x509_certificates(trusted_roots_pem)
+    try:
+        chain = x509.load_pem_x509_certificates(ak_chain_pem)
+        roots = x509.load_pem_x509_certificates(trusted_roots_pem)
+    except (ValueError, TypeError) as exc:
+        raise TpmVerificationError(f"AK certificate material is malformed: {exc}") from exc
+
     if not chain:
         raise TpmVerificationError("empty AK certificate chain")
     if not roots:
         raise TpmVerificationError("no trusted TPM roots supplied")
 
-    for i, cert in enumerate(chain):
-        try:
-            check_validity_period(
-                cert, label=f"AK chain certificate at position {i}", verification_time=verification_time
-            )
-        except CertChainError as e:
-            raise TpmVerificationError(str(e)) from e
+    try:
+        verify_cert_chain(chain, roots, verification_time=verification_time)
+    except CertChainError as exc:
+        raise TpmVerificationError(f"AK chain is not trusted: {exc}") from exc
 
-    for i in range(len(chain) - 1):
-        try:
-            chain[i].verify_directly_issued_by(chain[i + 1])
-        except (ValueError, TypeError, InvalidSignature) as exc:
-            raise TpmVerificationError(
-                f"AK chain certificate at position {i} is not validly issued by the next: {exc}"
-            ) from exc
-
-    trusted = {c.fingerprint(SHA256()) for c in roots}
-    if chain[-1].fingerprint(SHA256()) not in trusted:
-        raise TpmVerificationError(
-            "AK chain root is not among the supplied trusted TPM roots"
-        )
     return chain[0]
 
 

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, TypeAdapter
 
 from ._audit_continuity import AuditCheckpoint, verify_continuity
 from ._cose import (
@@ -28,6 +28,37 @@ from ._cose import (
     MEDIA_TYPE_MANIFEST_COSE,
     CoseVerification,
 )
+
+
+# ---------------------------------------------------------------------------
+# Timestamp parsing
+# ---------------------------------------------------------------------------
+
+# Manifest timestamps are typed `datetime` on the model, so Pydantic accepts and
+# normalizes several representations that datetime.fromisoformat() rejects:
+# decimal epoch seconds ("1769904000") and a lowercase zone designator
+# ("...T00:00:00z") among them. The schema gate reports no violation for those,
+# which meant a verifier re-parsing the raw signed string with fromisoformat()
+# saw a ValueError for a value the model considers perfectly well formed.
+#
+# Parsing here through the same TypeAdapter the model uses keeps the verifier's
+# reading of a timestamp identical to the model's. Anything it still cannot read
+# is unparseable to this verifier, and the callers below fail closed on it: a
+# validity window that cannot be evaluated is not a validity window that passed.
+_DATETIME_ADAPTER = TypeAdapter(datetime)
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    """Parse a manifest timestamp to an aware UTC datetime, or raise ValueError."""
+    try:
+        parsed = _DATETIME_ADAPTER.validate_python(value)
+    except Exception as exc:  # pydantic ValidationError and anything below it
+        raise ValueError(f"unparseable timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        # An offset-naive timestamp is ambiguous. The spec writes instants in
+        # UTC, so read it as UTC rather than as local time on the verifying host.
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +247,9 @@ class VerifyRequest(BaseModel):
     verified_transparency_entry_ids: set[str] = Field(default_factory=set)
     verified_transparency_receipt_hashes: set[str] = Field(default_factory=set)
     transparency_evidence_manifest_id: Optional[str] = None
+    # Independent hardware-attestation appraisal results; see VerificationContext.
+    verified_attestation_manifest_hashes: set[str] = Field(default_factory=set)
+    attestation_evidence_manifest_id: Optional[str] = None
     require_transparency: bool = False
     # When True, a manifest without a delegation_chain is a verification failure
     require_delegation: bool = False
@@ -299,6 +333,20 @@ class VerificationContext(BaseModel):
     # The manifest to which the independent appraisal bound those IDs/digests.
     # This prevents a verified receipt allow-list from becoming replayable.
     transparency_evidence_manifest_id: Optional[str] = None
+    # Hardware-attestation evidence, on exactly the same footing as the
+    # transparency inputs above: an appraisal the relying party performed, not
+    # an assertion the document makes about itself.
+    #
+    # Each entry is a manifest hash ("sha256:<hex>") for which an independent
+    # hardware appraisal - verify_attestation_chain(), or an equivalent external
+    # verifier - returned passed=True. The engine matches against the hash it
+    # computes locally, never against the manifest's own manifest_hash_in_report,
+    # so nothing an attacker writes into the attestation block can put a value
+    # in this set.
+    verified_attestation_manifest_hashes: set[str] = Field(default_factory=set)
+    # The manifest the appraisal was bound to, so a passing appraisal for one
+    # manifest cannot be replayed against another.
+    attestation_evidence_manifest_id: Optional[str] = None
     # Level 1+ implies this requirement even when the flag is false.
     require_transparency: bool = False
     # When True, bound artifacts without runtime hashes cause INCOMPLETE result
@@ -690,8 +738,8 @@ def verify_manifest(
     expires_at = manifest.get("expires_at")
     if issued_at and expires_at:
         try:
-            issued = datetime.fromisoformat(issued_at.replace("Z", "+00:00"))
-            exp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            issued = _parse_timestamp(issued_at)
+            exp = _parse_timestamp(expires_at)
             now = datetime.now(timezone.utc)
             if issued > now:
                 result.result = OverallResult.MISMATCH
@@ -705,7 +753,17 @@ def verify_manifest(
                 result.result = OverallResult.EXPIRED
                 return result
         except (ValueError, AttributeError):
-            pass
+            # Fail closed. These strings are inside the signing pre-image, so an
+            # unreadable one is not a transport artefact; it is a manifest whose
+            # validity window this verifier cannot evaluate. Skipping the check
+            # let a correctly signed but expired manifest reach VALID.
+            result.result = OverallResult.MISMATCH
+            result.mismatch_details = [MismatchDetail(
+                field="validity.timestamps",
+                expected_hash="<parseable issued_at and expires_at>",
+                actual_hash=f"<issued_at={issued_at!r} expires_at={expires_at!r}>",
+            )]
+            return result
 
     # --- Crypto profile downgrade check (spec 4.2: a verifier MUST reject
     # rather than silently fall back, "this prevents downgrade attacks during
@@ -1007,11 +1065,14 @@ def verify_manifest(
         baseline_expired = False
         if ttl and approved_at:
             try:
-                approved = datetime.fromisoformat(approved_at.replace("Z", "+00:00"))
+                approved = _parse_timestamp(approved_at)
                 if datetime.now(timezone.utc) > approved + timedelta(seconds=ttl):
                     baseline_expired = True
             except (ValueError, AttributeError):
-                pass
+                # Same fail-closed rule as the validity window and the HITL
+                # approval window (HITL-001): a TTL that cannot be evaluated is
+                # treated as elapsed, never as still current.
+                baseline_expired = True
         if baseline_expired:
             fields.memory_baseline = FieldResult.EXPIRED
         else:
@@ -1202,7 +1263,33 @@ def verify_manifest(
                 }
                 expected_attest_hash = "sha256:" + _hashlib.sha256(_canonicalize(subset)).hexdigest()
             if hmac.compare_digest(reported_hash, expected_attest_hash):
-                result.attestation_verified = True
+                # The hash matching proves the report is *about this manifest*.
+                # It proves nothing about hardware: for a v0.1 manifest the
+                # attestation block is outside the signing pre-image (spec 3.3
+                # excludes it), and for a v0.2 COSE envelope it rides in the
+                # unprotected header. Either way a party holding any validly
+                # signed manifest can append a self-asserted digest it computed
+                # itself. Treating that as attestation let a software-only
+                # manifest satisfy enforce_attestation=True and reach VALID.
+                #
+                # So the binding is necessary and not sufficient. The verdict
+                # also needs an independent appraisal, supplied by the caller
+                # and bound to this manifest, exactly as transparency receipts
+                # are handled below.
+                attestation_evidence_bound = (
+                    context.attestation_evidence_manifest_id == manifest_id
+                )
+                if (
+                    attestation_evidence_bound
+                    and expected_attest_hash in context.verified_attestation_manifest_hashes
+                ):
+                    result.attestation_verified = True
+                else:
+                    result.warnings.append(
+                        "attestation block binds this manifest but no independent "
+                        "hardware appraisal was supplied; attestation_verified "
+                        "reflects the binding only, not hardware provenance"
+                    )
             else:
                 # A present attestation that binds a different manifest is a
                 # mismatch whether or not the caller asked for enforcement
@@ -1285,6 +1372,18 @@ def verify_manifest(
             result.result = OverallResult.INCOMPLETE
         elif context.enforce_attestation and not result.attestation_verified:
             result.result = OverallResult.ATTESTATION_UNAVAILABLE
+        elif context.enforce_attestation and attestation_block.get("audit_key_sealed") is not True:
+            # Spec v0.2 5.3 requires audit_key_sealed=true in the attestation
+            # block under enforcement. The engine read audit_chain_root and
+            # reacted to it, but never read this flag, so a manifest declaring
+            # audit_key_sealed=false returned exactly the same VALID as one
+            # declaring true. An unsealed audit key means the audit chain can be
+            # rewritten by whoever holds it, which is the thing sealing prevents.
+            result.result = OverallResult.ATTESTATION_UNAVAILABLE
+            result.warnings.append(
+                "enforce_attestation is set but attestation.audit_key_sealed is "
+                "not true (spec 5.3)"
+            )
 
     # Surface bound-but-unchecked artifacts even in non-strict mode so callers
     # never read a VALID result as proof that artifact bindings were checked.
@@ -1564,6 +1663,8 @@ def create_router(
             verified_transparency_entry_ids=request.verified_transparency_entry_ids,
             verified_transparency_receipt_hashes=request.verified_transparency_receipt_hashes,
             transparency_evidence_manifest_id=request.transparency_evidence_manifest_id,
+            verified_attestation_manifest_hashes=request.verified_attestation_manifest_hashes,
+            attestation_evidence_manifest_id=request.attestation_evidence_manifest_id,
             require_transparency=request.require_transparency,
             require_delegation=request.require_delegation,
         )

--- a/python/tests/test_am_verify.py
+++ b/python/tests/test_am_verify.py
@@ -560,3 +560,63 @@ def test_verification_accepts_bound_delta():
     # the manifest binding round-trips and preserves the checkpoint anchor
     parsed = MemoryCheckpointBinding.model_validate(binding.model_dump())
     assert parsed.memory_root == new.memory_root and parsed.seq == new.seq
+
+
+# ---------------------------------------------------------------------------
+# GHSA-7v9r-xprj-65j7: an expired manifest must not reach VALID because the
+# verifier could not read its timestamps.
+#
+# issued_at/expires_at are typed datetime on the model, so Pydantic accepts
+# representations that datetime.fromisoformat() rejects. The schema gate passed
+# them, the verifier's re-parse raised ValueError, and the whole validity-window
+# check was skipped. The raw strings are inside the signing pre-image, so no
+# signature forgery or post-signing rewrite is involved.
+# ---------------------------------------------------------------------------
+
+_EXPIRED_EPOCH = str(int((NOW - timedelta(days=1)).timestamp()))
+_ISSUED_EPOCH = str(int((NOW - timedelta(days=30)).timestamp()))
+
+
+@pytest.mark.parametrize(
+    "issued_at,expires_at",
+    [
+        # decimal epoch seconds
+        (_ISSUED_EPOCH, _EXPIRED_EPOCH),
+        # lowercase zone designator
+        (
+            (NOW - timedelta(days=30)).isoformat().replace("+00:00", "z"),
+            (NOW - timedelta(days=1)).isoformat().replace("+00:00", "z"),
+        ),
+    ],
+)
+def test_expired_manifest_is_not_valid_under_alternate_timestamp_forms(issued_at, expires_at):
+    r = verify_manifest(manifest(issued_at=issued_at, expires_at=expires_at), ctx(), store())
+
+    assert r.result == OverallResult.EXPIRED
+
+
+def test_alternate_timestamp_forms_still_verify_when_in_window():
+    """Failing closed must not mean rejecting every representation but one."""
+    issued_at = str(int((NOW - timedelta(days=1)).timestamp()))
+    expires_at = str(int((NOW + timedelta(days=90)).timestamp()))
+
+    r = verify_manifest(manifest(issued_at=issued_at, expires_at=expires_at), ctx(), store())
+
+    assert r.result == OverallResult.VALID
+
+
+def test_unparseable_timestamps_fail_closed():
+    """A validity window that cannot be evaluated is not a window that passed.
+
+    Free-form garbage is caught earlier, by the schema gate, and reported against
+    the individual fields. Either way the verdict is MISMATCH; what must never
+    happen is the manifest continuing to VALID with the window unchecked.
+    """
+    r = verify_manifest(
+        manifest(issued_at="not-a-timestamp", expires_at="also-not-a-timestamp"),
+        ctx(),
+        store(),
+    )
+
+    assert r.result == OverallResult.MISMATCH
+    assert r.mismatch_details

--- a/python/tests/test_cose.py
+++ b/python/tests/test_cose.py
@@ -870,6 +870,13 @@ def test_a_bare_v02_dict_has_no_signature():
 
 
 def test_engine_binds_attestation_to_the_payload_hash():
+    """The binding is checked, and it is still not hardware evidence.
+
+    GHSA-85fc-3g4g-fjjc. On the COSE path the attestation block lives in the
+    unprotected header, which the envelope spec makes explicitly malleable, so
+    a matching payload hash tells you the report names these bytes and nothing
+    more. Under enforcement that has to fail closed.
+    """
     manifest = base_manifest()
     signed = sign_cose_sign1(manifest, KP)
     signed = attach_attestation(
@@ -877,9 +884,34 @@ def test_engine_binds_attestation_to_the_payload_hash():
         {
             "platform": "amd-sev-snp",
             "manifest_hash_in_report": payload_hash(cose_payload(manifest)),
+            "audit_key_sealed": True,
         },
     )
     result = verify_manifest(signed, base_context(enforce_attestation=True), store())
+    assert result.attestation_verified is False
+    assert result.result == OverallResult.ATTESTATION_UNAVAILABLE
+
+
+def test_engine_accepts_attestation_with_an_independent_appraisal():
+    manifest = base_manifest()
+    signed = sign_cose_sign1(manifest, KP)
+    bound_hash = payload_hash(cose_payload(manifest))
+    signed = attach_attestation(
+        signed,
+        {
+            "platform": "amd-sev-snp",
+            "manifest_hash_in_report": bound_hash,
+            "audit_key_sealed": True,
+        },
+    )
+    ctx = base_context(
+        enforce_attestation=True,
+        verified_attestation_manifest_hashes={bound_hash},
+        attestation_evidence_manifest_id=manifest["manifest_id"],
+    )
+
+    result = verify_manifest(signed, ctx, store())
+
     assert result.attestation_verified is True
     assert result.result == OverallResult.VALID
 

--- a/python/tests/test_cose_endpoint.py
+++ b/python/tests/test_cose_endpoint.py
@@ -113,19 +113,40 @@ def test_enforce_flags_are_honoured():
     assert response.json()["result"] == "ATTESTATION_UNAVAILABLE"
 
 
-def test_attestation_binding_is_checked_over_http():
+def test_attestation_binding_alone_does_not_pass_enforcement_over_http():
+    """GHSA-85fc-3g4g-fjjc, on the HTTP COSE surface.
+
+    This endpoint takes its flags as query parameters and has no channel for
+    the caller to hand back a hardware appraisal. It therefore cannot establish
+    hardware provenance for anything, and under enforce_attestation it now says
+    so instead of reading a self-asserted digest in the unprotected header as
+    an attested result.
+    """
     m = manifest()
     signed = attach_attestation(
         sign_cose_sign1(m, KP),
         {
             "platform": "amd-sev-snp",
             "manifest_hash_in_report": payload_hash(cose_payload(m)),
+            "audit_key_sealed": True,
         },
     )
     response = post(client(trust_store()), signed, enforce_attestation=True)
     body = response.json()
-    assert body["result"] == "VALID"
-    assert body["attestation_verified"] is True
+    assert body["result"] == "ATTESTATION_UNAVAILABLE"
+    assert body["attestation_verified"] is False
+
+
+def test_attestation_binding_is_still_checked_over_http():
+    """A report naming other bytes is a mismatch, enforcement or not."""
+    m = manifest()
+    signed = attach_attestation(
+        sign_cose_sign1(m, KP),
+        {"platform": "amd-sev-snp", "manifest_hash_in_report": "sha256:" + "c" * 64},
+    )
+    response = post(client(trust_store()), signed)
+    body = response.json()
+    assert body["result"] == "MISMATCH"
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_tpm_verify.py
+++ b/python/tests/test_tpm_verify.py
@@ -37,8 +37,30 @@ def _name(cn):
     return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
 
 
-def _cert(subject, subject_pub, issuer, issuer_key, halg=hashes.SHA256()):
+def _ca_extensions(builder):
+    """Mark a certificate as a CA that may sign certificates.
+
+    Real TPM vendor roots and intermediates carry both extensions. The AK chain
+    verifier now requires them on every issuing certificate, so a fixture that
+    omits them is not a weaker fixture, it is an unrealistic one.
+    """
     return (
+        builder
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=True, crl_sign=True,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+    )
+
+
+def _cert(subject, subject_pub, issuer, issuer_key, halg=hashes.SHA256(), ca=False):
+    builder = (
         x509.CertificateBuilder()
         .subject_name(_name(subject))
         .issuer_name(_name(issuer))
@@ -46,8 +68,10 @@ def _cert(subject, subject_pub, issuer, issuer_key, halg=hashes.SHA256()):
         .serial_number(x509.random_serial_number())
         .not_valid_before(_T0)
         .not_valid_after(_T0 + datetime.timedelta(days=3650))
-        .sign(issuer_key, halg)
     )
+    if ca:
+        builder = _ca_extensions(builder)
+    return builder.sign(issuer_key, halg)
 
 
 def _ak_chain(kind="ec"):
@@ -58,7 +82,7 @@ def _ak_chain(kind="ec"):
     else:
         root_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         ak_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    root = _cert("test-tpm-root", root_key.public_key(), "test-tpm-root", root_key)
+    root = _cert("test-tpm-root", root_key.public_key(), "test-tpm-root", root_key, ca=True)
     ak = _cert("test-ak", ak_key.public_key(), "test-tpm-root", root_key)
     chain_pem = ak.public_bytes(Encoding.PEM) + root.public_bytes(Encoding.PEM)
     return ak_key, chain_pem, root.public_bytes(Encoding.PEM)
@@ -253,8 +277,8 @@ def test_nv_certify_parsers_are_public_api():
 
 def _ak_chain_at(not_before, not_after, kind="ec"):
     """Like ``_ak_chain`` but with a caller-chosen validity window."""
-    def cert_at(subject, subject_pub, issuer, issuer_key, halg=hashes.SHA256()):
-        return (
+    def cert_at(subject, subject_pub, issuer, issuer_key, halg=hashes.SHA256(), ca=False):
+        builder = (
             x509.CertificateBuilder()
             .subject_name(_name(subject))
             .issuer_name(_name(issuer))
@@ -262,8 +286,10 @@ def _ak_chain_at(not_before, not_after, kind="ec"):
             .serial_number(x509.random_serial_number())
             .not_valid_before(not_before)
             .not_valid_after(not_after)
-            .sign(issuer_key, halg)
         )
+        if ca:
+            builder = _ca_extensions(builder)
+        return builder.sign(issuer_key, halg)
 
     if kind == "ec":
         root_key = ec.generate_private_key(ec.SECP256R1())
@@ -271,7 +297,7 @@ def _ak_chain_at(not_before, not_after, kind="ec"):
     else:
         root_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         ak_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    root = cert_at("test-tpm-root", root_key.public_key(), "test-tpm-root", root_key)
+    root = cert_at("test-tpm-root", root_key.public_key(), "test-tpm-root", root_key, ca=True)
     ak = cert_at("test-ak", ak_key.public_key(), "test-tpm-root", root_key)
     chain_pem = ak.public_bytes(Encoding.PEM) + root.public_bytes(Encoding.PEM)
     return ak_key, chain_pem, root.public_bytes(Encoding.PEM)
@@ -395,7 +421,7 @@ def test_verify_rejects_untrusted_root():
     _, _, other_roots = _ak_chain()  # a different, unrelated root
     attest = _build_attest(NONCE, PCR)
     sig = _sign(ak_key, attest)
-    with pytest.raises(TpmVerificationError, match="trusted TPM roots"):
+    with pytest.raises(TpmVerificationError, match="does not match any trusted root"):
         verify_tpm_quote(attest, sig, chain, trusted_roots_pem=other_roots)
 
 
@@ -463,3 +489,75 @@ def test_attestation_chain_dispatches_tpm():
         expected_qualifying_data=NONCE,
     )
     assert result.signature is SignatureStatus.VERIFIED
+
+
+# ---------------------------------------------------------------------------
+# GHSA-mp83-94pc-7wqh: the AK chain helper checked only "signed by the next"
+# plus a pinned root fingerprint. It did not enforce certificate validity
+# periods, BasicConstraints(ca=True), or KeyUsage.key_cert_sign, all of which
+# the shared verify_cert_chain() already enforced for the SEV-SNP and TDX
+# paths. _verify_ak_chain now delegates to that same appraisal.
+# ---------------------------------------------------------------------------
+
+def _chain_with_issuer(*, ca: bool, key_cert_sign: bool):
+    """Build root -> AK where the root's CA / KeyUsage properties are chosen."""
+    root_key = ec.generate_private_key(ec.SECP256R1())
+    ak_key = ec.generate_private_key(ec.SECP256R1())
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(_name("test-tpm-root"))
+        .issuer_name(_name("test-tpm-root"))
+        .public_key(root_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(_T0)
+        .not_valid_after(_T0 + datetime.timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=ca, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=key_cert_sign, crl_sign=False,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+    )
+    root = builder.sign(root_key, hashes.SHA256())
+    ak = _cert("test-ak", ak_key.public_key(), "test-tpm-root", root_key)
+    chain_pem = ak.public_bytes(Encoding.PEM) + root.public_bytes(Encoding.PEM)
+    return ak_key, chain_pem, root.public_bytes(Encoding.PEM)
+
+
+def test_verify_rejects_non_ca_issuer():
+    """A leaf masquerading as an issuer is not a CA, pinned or not."""
+    ak_key, chain, roots = _chain_with_issuer(ca=False, key_cert_sign=True)
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+
+    with pytest.raises(TpmVerificationError, match="is not a CA"):
+        verify_tpm_quote(attest, sig, chain, trusted_roots_pem=roots)
+
+
+def test_verify_rejects_issuer_that_may_not_sign_certificates():
+    """KeyUsage saying keyCertSign=False means the AK was never validly issued."""
+    ak_key, chain, roots = _chain_with_issuer(ca=True, key_cert_sign=False)
+    attest = _build_attest(NONCE, PCR)
+    sig = _sign(ak_key, attest)
+
+    with pytest.raises(TpmVerificationError, match="cannot sign certificates"):
+        verify_tpm_quote(attest, sig, chain, trusted_roots_pem=roots)
+
+
+def test_malformed_certificate_material_raises_tpm_error_not_value_error():
+    """The dispatcher above catches TpmVerificationError only.
+
+    A raw ValueError out of the PEM parser escaped it and surfaced as an
+    unhandled exception rather than a verification failure.
+    """
+    attest = _build_attest(NONCE, PCR)
+    _ak_key, _chain, roots = _ak_chain()
+    sig = _sign(_ak_key, attest)
+
+    with pytest.raises(TpmVerificationError, match="malformed"):
+        verify_tpm_quote(attest, sig, b"-----BEGIN CERTIFICATE-----\nnope\n", trusted_roots_pem=roots)

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -438,11 +438,63 @@ def _manifest_hash(manifest: dict) -> str:
     return "sha256:" + hashlib.sha256(canonicalize(subset)).hexdigest()
 
 
-def test_attestation_verified_true_when_hash_matches():
+# GHSA-85fc-3g4g-fjjc / GHSA-qvg2-j8c5-5x3w: a matching manifest_hash_in_report
+# proves the report is about this manifest. It is not evidence that any hardware
+# produced it. For v0.1 the attestation block is outside the signing pre-image
+# (spec 3.3), so a party holding any validly signed manifest can append a digest
+# it computed itself; for v0.2 COSE the block rides in the unprotected header.
+# attestation_verified therefore needs an independent appraisal as well.
+
+def test_attestation_hash_binding_alone_does_not_verify_attestation():
     m = base_manifest()
     m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": _manifest_hash(m)}
+
     result = verify_manifest(m, base_context(), store())
+
+    assert result.attestation_verified is False
+    assert any("no independent hardware appraisal" in w for w in result.warnings)
+
+
+def test_attestation_verified_true_with_an_independent_appraisal():
+    m = base_manifest()
+    m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": _manifest_hash(m)}
+    ctx = base_context(
+        verified_attestation_manifest_hashes={_manifest_hash(m)},
+        attestation_evidence_manifest_id=m["manifest_id"],
+    )
+
+    result = verify_manifest(m, ctx, store())
+
     assert result.attestation_verified is True
+
+
+def test_appraisal_bound_to_another_manifest_does_not_transfer():
+    """A passing appraisal is not a bearer token for every manifest."""
+    m = base_manifest()
+    m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": _manifest_hash(m)}
+    ctx = base_context(
+        verified_attestation_manifest_hashes={_manifest_hash(m)},
+        attestation_evidence_manifest_id="018f4a3b-0000-7e5f-a8b9-000000000000",
+    )
+
+    result = verify_manifest(m, ctx, store())
+
+    assert result.attestation_verified is False
+
+
+def test_software_only_manifest_cannot_satisfy_enforce_attestation():
+    """The reported impact: a self-asserted digest reaching VALID under enforcement."""
+    m = base_manifest()
+    m["attestation"] = {
+        "platform": "tpm",
+        "manifest_hash_in_report": _manifest_hash(m),
+        "audit_key_sealed": True,
+    }
+
+    result = verify_manifest(m, base_context(enforce_attestation=True), store())
+
+    assert result.attestation_verified is False
+    assert result.result == OverallResult.ATTESTATION_UNAVAILABLE
 
 
 def test_attestation_verified_false_when_no_attestation():
@@ -909,3 +961,52 @@ def test_bad_enum_value_fails_schema():
     result = verify_manifest(m, base_context(), store())
     assert result.result == OverallResult.MISMATCH
     assert any(d.field.startswith("schema") for d in result.mismatch_details)
+
+
+# GHSA-mqqg-9mpc-mpg7: spec v0.2 5.3 requires audit_key_sealed=true under
+# enforce_attestation. The engine read audit_chain_root but never this flag, so
+# true and false produced the same VALID.
+
+def _appraised_ctx(m, **overrides):
+    return base_context(
+        enforce_attestation=True,
+        verified_attestation_manifest_hashes={_manifest_hash(m)},
+        attestation_evidence_manifest_id=m["manifest_id"],
+        **overrides,
+    )
+
+
+def test_audit_key_sealed_true_is_accepted_under_enforcement():
+    m = base_manifest()
+    m["attestation"] = {
+        "platform": "tpm",
+        "manifest_hash_in_report": _manifest_hash(m),
+        "audit_key_sealed": True,
+    }
+
+    result = verify_manifest(m, _appraised_ctx(m), store())
+
+    assert result.result == OverallResult.VALID
+
+
+def test_audit_key_sealed_false_is_rejected_under_enforcement():
+    m = base_manifest()
+    m["attestation"] = {
+        "platform": "tpm",
+        "manifest_hash_in_report": _manifest_hash(m),
+        "audit_key_sealed": False,
+    }
+
+    result = verify_manifest(m, _appraised_ctx(m), store())
+
+    assert result.result == OverallResult.ATTESTATION_UNAVAILABLE
+
+
+def test_audit_key_sealed_absent_is_rejected_under_enforcement():
+    """Absent is not sealed. Spec 5.3 requires the flag to be present and true."""
+    m = base_manifest()
+    m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": _manifest_hash(m)}
+
+    result = verify_manifest(m, _appraised_ctx(m), store())
+
+    assert result.result == OverallResult.ATTESTATION_UNAVAILABLE

--- a/python/tests/vectors/AM-VEC-018d.json
+++ b/python/tests/vectors/AM-VEC-018d.json
@@ -1,6 +1,6 @@
 {
-  "id": "AM-VEC-018",
-  "description": "Attestation hash binding alone does not make attestation_verified true.",
+  "id": "AM-VEC-018d",
+  "description": "An independent hardware appraisal bound to this manifest makes attestation_verified true.",
   "spec_refs": [
     "3.3"
   ],
@@ -70,10 +70,14 @@
     "model_version": "claude-3",
     "trusted_keys": {
       "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
-    }
+    },
+    "verified_attestation_manifest_hashes": [
+      "sha256:f1cbdacb5191606917f4340ab8340c1e0eaa471004430a9811df83200324090d"
+    ],
+    "attestation_evidence_manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
   },
   "expected": {
     "result": "VALID",
-    "attestation_verified": false
+    "attestation_verified": true
   }
 }

--- a/python/tests/vectors/AM-VEC-018e.json
+++ b/python/tests/vectors/AM-VEC-018e.json
@@ -1,6 +1,6 @@
 {
-  "id": "AM-VEC-018",
-  "description": "Attestation hash binding alone does not make attestation_verified true.",
+  "id": "AM-VEC-018e",
+  "description": "A hardware appraisal bound to another manifest does not transfer.",
   "spec_refs": [
     "3.3"
   ],
@@ -70,7 +70,11 @@
     "model_version": "claude-3",
     "trusted_keys": {
       "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
-    }
+    },
+    "verified_attestation_manifest_hashes": [
+      "sha256:f1cbdacb5191606917f4340ab8340c1e0eaa471004430a9811df83200324090d"
+    ],
+    "attestation_evidence_manifest_id": "018f4a3b-0000-7e5f-a8b9-000000000000"
   },
   "expected": {
     "result": "VALID",

--- a/python/tests/vectors/generate.py
+++ b/python/tests/vectors/generate.py
@@ -829,10 +829,42 @@ def build() -> list[dict[str, Any]]:
     subset = {k: v for k, v in m.items() if k not in ("attestation", "transparency_log_entry")}
     attest_hash = "sha256:" + hashlib.sha256(canonicalize(subset)).hexdigest()
     m["attestation"] = {"platform": "tpm", "manifest_hash_in_report": attest_hash}
+    # The binding says the report is about *this* manifest. It says nothing
+    # about hardware: for v0.1 the attestation block is outside the signing
+    # pre-image (3.3 excludes it), so anyone holding a validly signed manifest
+    # can append a digest they computed themselves. attestation_verified is
+    # therefore false until an independent appraisal is supplied (018d).
     vectors.append(_vector(
-        "AM-VEC-018", "Attestation report hash matching the canonical manifest hash verifies.",
+        "AM-VEC-018",
+        "Attestation hash binding alone does not make attestation_verified true.",
         ["3.3"], m, base_context(),
+        {"result": "VALID", "attestation_verified": False},
+    ))
+
+    # 018d - the same manifest, with the hardware appraisal the relying party
+    # performed supplied as context. This is the only way the flag becomes true.
+    vectors.append(_vector(
+        "AM-VEC-018d",
+        "An independent hardware appraisal bound to this manifest makes attestation_verified true.",
+        ["3.3"], m,
+        base_context(
+            verified_attestation_manifest_hashes=[attest_hash],
+            attestation_evidence_manifest_id=MANIFEST_ID,
+        ),
         {"result": "VALID", "attestation_verified": True},
+    ))
+
+    # 018e - the same appraisal, bound to a different manifest. A passing
+    # appraisal must not be replayable onto another document.
+    vectors.append(_vector(
+        "AM-VEC-018e",
+        "A hardware appraisal bound to another manifest does not transfer.",
+        ["3.3"], m,
+        base_context(
+            verified_attestation_manifest_hashes=[attest_hash],
+            attestation_evidence_manifest_id="018f4a3b-0000-7e5f-a8b9-000000000000",
+        ),
+        {"result": "VALID", "attestation_verified": False},
     ))
 
     # 018b - the stale-attestation case from issue #265. The manifest is

--- a/python/tests/vectors/index.json
+++ b/python/tests/vectors/index.json
@@ -96,7 +96,17 @@
     {
       "id": "AM-VEC-018",
       "file": "AM-VEC-018.json",
-      "description": "Attestation report hash matching the canonical manifest hash verifies."
+      "description": "Attestation hash binding alone does not make attestation_verified true."
+    },
+    {
+      "id": "AM-VEC-018d",
+      "file": "AM-VEC-018d.json",
+      "description": "An independent hardware appraisal bound to this manifest makes attestation_verified true."
+    },
+    {
+      "id": "AM-VEC-018e",
+      "file": "AM-VEC-018e.json",
+      "description": "A hardware appraisal bound to another manifest does not transfer."
     },
     {
       "id": "AM-VEC-021",


### PR DESCRIPTION
Closes four private advisories. They are separate reports but one shape: the integrated verifier reaching a passing verdict on evidence that does not support it.

Reported by external researchers through private vulnerability reporting. Every reproduction in the advisories was re-run against current `main` before changing anything; all four were still live.

## GHSA-85fc-3g4g-fjjc and GHSA-qvg2-j8c5-5x3w (high)

`attestation_verified` was set by comparing the manifest's own `manifest_hash_in_report` against the locally computed manifest hash. That comparison establishes that the report *names this manifest*. It establishes nothing about hardware.

The reason it cannot: for a v0.1 JSON manifest the `attestation` block is excluded from the signing pre-image (spec 3.3 excludes it by name), and for a v0.2 COSE manifest it is carried in the unprotected header, which the envelope spec makes explicitly malleable. So a party holding **any** validly signed manifest could append a two-field object containing a digest they computed themselves, with no issuer private key and no attestation hardware, and move the verdict from `ATTESTATION_UNAVAILABLE` to `VALID` under `enforce_attestation=True`.

No TPM quote, SEV-SNP report, TDX quote, hardware signature, certificate chain, trusted root, launch measurement, nonce or sealed-key evidence was required at any point.

The SDK already ships the real appraisal, `verify_attestation_chain()` in `_attestation.py`, which is properly fail-closed. The integrated verifier just never consumed its result.

**The fix.** The hash binding is now necessary and not sufficient. `attestation_verified` additionally requires an independent appraisal, supplied through `VerificationContext` and bound to this `manifest_id`:

```python
verified_attestation_manifest_hashes: set[str]   # hashes an appraisal passed for
attestation_evidence_manifest_id: Optional[str]  # the manifest it was bound to
```

This is deliberately the same shape the engine already uses for transparency receipts, where the surrounding comment states the principle: *"the envelope field/header is untrusted input; only an entry ID or receipt digest supplied by an independent log appraisal can make this true."* Attestation was the one place that principle had not been applied.

The engine matches against the hash **it** computes, never against the manifest's own claim, so nothing an attacker writes into the attestation block can put a value into that set. Binding to `manifest_id` stops a passing appraisal being replayed onto a different document.

When the binding matches but no appraisal was supplied, the result carries an explicit warning rather than silently reading as attested.

## GHSA-mqqg-9mpc-mpg7

Spec v0.2 §5.3 requires `audit_key_sealed=true` in the attestation block under `enforce_attestation`. The engine read `audit_chain_root` and reacted to it, but never read this flag, so `true`, `false` and absent all produced the same `VALID`. An unsealed audit key is one that can be rewritten by whoever holds it, which is the thing sealing exists to prevent. Now gated, with absent treated as not sealed.

## GHSA-7v9r-xprj-65j7

`issued_at` and `expires_at` are typed `datetime` on the model, so Pydantic accepts and normalizes representations that `datetime.fromisoformat()` rejects: decimal epoch seconds (`"1769904000"`) and a lowercase zone designator (`"...T00:00:00z"`). The schema gate reported no violation for either.

The validity block then re-parsed the original signed strings with `fromisoformat()`, that raised `ValueError`, and it was swallowed:

```python
except (ValueError, AttributeError):
    pass
```

The entire issued/expiry check was skipped and a correctly signed but expired manifest proceeded to `VALID`. The raw strings are inside the signing pre-image, so no forgery or post-signing rewrite is involved.

**The fix.** Timestamps parse through the same `TypeAdapter(datetime)` the model uses, so the verifier's reading of a timestamp is identical to the model's and those representations are now *evaluated* rather than skipped. Anything still unreadable fails closed, because a validity window that cannot be evaluated is not a window that passed.

While in there: the memory-baseline TTL check had the identical fail-open handler and was not in the report. It is fixed the same way. The HITL approval window three lines further down already failed safe and carries the comment explaining why, so the codebase had the right answer in one of three places.

## GHSA-mp83-94pc-7wqh

`_verify_ak_chain()` checked only that each certificate is signed by the next and that the last one is fingerprint-pinned. It did not enforce `BasicConstraints(ca=True)` or `KeyUsage.key_cert_sign`. The repository's shared `verify_cert_chain()` enforces both, and the SNP and TDX paths already use it; the TPM path just did not call it. Validity periods had already been fixed separately.

Malformed certificate input also escaped as a raw `ValueError`, past a dispatcher that catches only `TpmVerificationError`.

Now delegates to the shared verifier and wraps the parser.

The TPM test fixtures built issuing certificates with no extensions at all. Rather than weaken the check to accommodate them, the fixtures now build proper CA certificates, which is what real vendor roots look like.

## Conformance vectors

`AM-VEC-018` encoded the vulnerable semantics as a portable contract: *"Attestation report hash matching the canonical manifest hash verifies"*, expecting `attestation_verified: true` from a `"platform": "tpm"` block with no hardware evidence. Corrected, and two vectors added:

- `AM-VEC-018d`: an appraisal bound to this manifest makes the flag true
- `AM-VEC-018e`: an appraisal bound to a different manifest does not transfer

Worth flagging for review: these are language-neutral vectors other SDKs test against, so this is an intentional contract change, not just a test edit.

## Behaviour change

`enforce_attestation=True` now means hardware was actually appraised. A caller who sets it and supplies no appraisal gets `ATTESTATION_UNAVAILABLE` where they previously got `VALID`. That is the point of the fix, but it is a real change for anyone who was relying on the old reading.

The COSE HTTP endpoint takes its flags as query parameters and has no channel for returning an appraisal, so under enforcement it now always fails closed. That is correct for a surface with no attestation capability, and the test says so explicitly.

## Verification

Each fix was confirmed to fail without the change. The clearest is the timestamp one, where reverting only `_verify.py` turns the new assertions into `- EXPIRED / + VALID`.

Full suite: **1429 passed**, 6 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
