### PR TITLE
fix(hitl): bind approval_method into the approval signature pre-image

### DIFF
--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Optional
 
 from ._canonicalize import canonicalize
 from ._signing import Ed25519KeyPair, Ed25519Verifier
@@ -465,14 +465,33 @@ def _approval_pre_image(
     approved_at: str,
     approved_scope: dict[str, Any],
     approver_id: str,
+    approval_method: Optional[str] = None,
 ) -> bytes:
-    """RFC 8785 canonical bytes for HITL approval signing."""
+    """RFC 8785 canonical bytes for HITL approval signing.
+
+    ``approval_method`` is included when the approval carries one. It is
+    verdict-relevant at conformance Level 2, where the integrated verifier
+    treats "software-key" as insufficient and requires "hardware-key" for
+    high and critical risk tiers. Leaving it outside the pre-image meant an
+    approval signed as software-key could be relabelled hardware-key after
+    the fact, keeping its valid signature and changing the Level-2 outcome
+    from APPROVAL_INSUFFICIENT to APPROVED. An authenticated approval did
+    not establish authenticated approval strength.
+
+    Omitting the key entirely when the field is absent keeps the pre-image
+    byte-identical for approvals that never carried a method, so those
+    signatures still verify. Adding, removing or editing the field on a
+    signed approval all change the pre-image and break the signature, which
+    is the whole point.
+    """
     obj = {
         "manifest_id": manifest_id,
         "approved_at": approved_at,
         "approved_scope": approved_scope,
         "approver_id": approver_id,
     }
+    if approval_method is not None:
+        obj["approval_method"] = approval_method
     return canonicalize(obj)
 
 
@@ -494,10 +513,17 @@ class HitlApprovalSigner:
         approved_at: str,
         approved_scope: dict[str, Any],
         approver_id: str,
+        approval_method: Optional[str] = None,
     ) -> str:
-        """Return base64url-encoded approval signature."""
+        """Return base64url-encoded approval signature.
+
+        Pass ``approval_method`` whenever the approval record will carry one,
+        so the signature covers the strength claim the verifier reads.
+        """
         import base64
-        pre = _approval_pre_image(manifest_id, approved_at, approved_scope, approver_id)
+        pre = _approval_pre_image(
+            manifest_id, approved_at, approved_scope, approver_id, approval_method
+        )
         sig_bytes = self.keypair.private_key.sign(pre)
         return base64.urlsafe_b64encode(sig_bytes).rstrip(b"=").decode()
 
@@ -540,6 +566,7 @@ def verify_hitl_approval(
         approved_at=approval["approved_at"],
         approved_scope=approval["approved_scope"],
         approver_id=approval["approver_id"],
+        approval_method=approval.get("approval_method"),
     )
     sig = approval["approval_signature"]
     pad = 4 - len(sig) % 4

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -299,6 +299,7 @@ def _hitl_approval(approver_keypair, *, manifest_id, signature=None):
         approved_at=approved_at,
         approved_scope=scope,
         approver_id=APPROVER_ID,
+        approval_method=approval["approval_method"],
     )
     return approval
 

--- a/python/tests/test_cose.py
+++ b/python/tests/test_cose.py
@@ -159,6 +159,7 @@ def approval(**overrides):
             approved_at=a["approved_at"],
             approved_scope=a["approved_scope"],
             approver_id=a["approver_id"],
+            approval_method=a.get("approval_method"),
         )
     a.pop("manifest_id", None)
     return a

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -481,3 +481,88 @@ def test_hitl_approval_accepts_did_approver_id():
     from agent_manifest.models import HitlApproval
     a = HitlApproval(**_approval_kwargs("did:web:acme.example:alice"))
     assert a.approver_id == "did:web:acme.example:alice"
+
+
+# ---------------------------------------------------------------------------
+# GHSA-q8mp-875w-2w53 / GHSA-wfv4-3xwh-9f2h: approval_method decides Level-2
+# sufficiency but sat outside the approval signature pre-image, so a
+# software-key approval could be relabelled hardware-key while keeping its
+# valid signature. An authenticated approval did not establish authenticated
+# approval strength.
+# ---------------------------------------------------------------------------
+
+def test_relabelling_approval_method_breaks_the_signature():
+    kp = generate_ed25519()
+    manifest_id = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+    approved_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    scope = {"artifacts": ["system_prompt"], "risk_tier": "high"}
+
+    approval = {
+        "approver_id": "mailto:alice@example.com",
+        "approved_at": approved_at,
+        "approved_scope": scope,
+        "approval_method": "software-key",
+    }
+    approval["approval_signature"] = HitlApprovalSigner(kp).sign_approval(
+        manifest_id=manifest_id,
+        approved_at=approved_at,
+        approved_scope=scope,
+        approver_id=approval["approver_id"],
+        approval_method="software-key",
+    )
+
+    # The approval is genuine as signed.
+    verify_hitl_approval(approval, manifest_id, kp.public_bytes)
+
+    # Upgrading the strength claim without the approver is now detected.
+    approval["approval_method"] = "hardware-key"
+    with pytest.raises((InvalidSignature, ValueError)):
+        verify_hitl_approval(approval, manifest_id, kp.public_bytes)
+
+
+def test_adding_an_approval_method_to_a_signed_approval_breaks_the_signature():
+    """An approval signed without a method claim cannot gain one afterwards."""
+    kp = generate_ed25519()
+    manifest_id = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+    approved_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    scope = {"artifacts": ["system_prompt"], "risk_tier": "high"}
+
+    approval = {
+        "approver_id": "mailto:alice@example.com",
+        "approved_at": approved_at,
+        "approved_scope": scope,
+    }
+    approval["approval_signature"] = HitlApprovalSigner(kp).sign_approval(
+        manifest_id=manifest_id,
+        approved_at=approved_at,
+        approved_scope=scope,
+        approver_id=approval["approver_id"],
+    )
+
+    verify_hitl_approval(approval, manifest_id, kp.public_bytes)
+
+    approval["approval_method"] = "hardware-key"
+    with pytest.raises((InvalidSignature, ValueError)):
+        verify_hitl_approval(approval, manifest_id, kp.public_bytes)
+
+
+def test_approvals_without_a_method_still_verify_unchanged():
+    """Compatibility: omitting the key leaves those pre-image bytes identical."""
+    kp = generate_ed25519()
+    manifest_id = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+    approved_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    scope = {"artifacts": ["system_prompt"]}
+
+    approval = {
+        "approver_id": "mailto:alice@example.com",
+        "approved_at": approved_at,
+        "approved_scope": scope,
+        "approval_signature": HitlApprovalSigner(kp).sign_approval(
+            manifest_id=manifest_id,
+            approved_at=approved_at,
+            approved_scope=scope,
+            approver_id="mailto:alice@example.com",
+        ),
+    }
+
+    verify_hitl_approval(approval, manifest_id, kp.public_bytes)

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -110,6 +110,7 @@ def hitl_approval(approved_at, approved_scope, **overrides):
         approved_at=approval["approved_at"],
         approved_scope=approval["approved_scope"],
         approver_id=approval["approver_id"],
+        approval_method=approval.get("approval_method"),
     )
     return approval
 


### PR DESCRIPTION
Closes GHSA-q8mp-875w-2w53 and GHSA-wfv4-3xwh-9f2h, two private advisories reporting the same gap. Reproduced against current `main` before changing anything.

## The gap

At conformance Level 2 the integrated verifier reads `approval_method` to decide whether an otherwise valid approval is sufficient: `software-key` is insufficient, and `high`/`critical` risk tiers require `hardware-key`.

The approval signature pre-image covered:

```
manifest_id
approved_at
approved_scope
approver_id
```

`approval_method` is a sibling field, outside `approved_scope`, and was never signed.

So an approval signed as `software-key` could be relabelled `hardware-key` with `approval_signature` left completely untouched. The signed bytes do not change, standalone signature verification still passes, and the Level-2 outcome moves from `APPROVAL_INSUFFICIENT` / `MISMATCH` to `APPROVED` / `VALID`.

As the reporter put it: an authenticated approval did not establish authenticated approval strength.

## The fix

`_approval_pre_image()` now includes `approval_method` when the approval carries one, and `HitlApprovalSigner.sign_approval()` takes it as a keyword argument. `verify_hitl_approval()` reads it back off the approval being verified, so signer and verifier always derive the pre-image from the same record.

**On the compatibility choice.** The key is omitted from the canonical object entirely when the field is absent, rather than being included as `null`. That keeps the pre-image byte-identical for approvals that never carried a method, so their signatures still verify untouched.

That choice is safe in all three directions, which the tests cover:

- editing the field on a signed approval changes the pre-image, so the signature breaks
- **adding** a method to an approval signed without one also changes the pre-image, so an unsigned approval cannot acquire a `hardware-key` claim afterwards
- removing it likewise breaks the signature

There is no variant an attacker can pick that verifies and still carries an unauthenticated strength claim.

## What this breaks

Approvals that already carry `approval_method` must be re-signed. Their current signatures do not cover the field, which is the vulnerability, so there is no way to keep honouring them without keeping the hole open. Approvals with no `approval_method` are unaffected.

## Verification

Three regression tests in `test_delegation_hitl.py` covering relabelling, adding, and the unchanged no-method case. Reverting only `_delegation.py` turns the two attack tests red.

Three existing test helpers built approvals that set `approval_method` while signing without it. They now sign what they claim, which is the correct fixture shape and was itself a small demonstration of how easy the field was to leave unbound.

Full suite: **1415 passed**, 6 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
