### PR TITLE
fix(verify): stop a nested omission masking the full-binding requirement

### DIFF
--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -444,6 +444,42 @@ def _signature_key_issuer_mismatch(
     return None
 
 
+# The full-binding requirement, checked on the raw document.
+#
+# models.Manifest enforces this in _validate_manifest_profile, which is a
+# mode="after" model validator: Pydantic runs it only once every field has
+# validated. So an unrelated omission deeper in the document stops it running,
+# and _strict_schema_violations then filters the nested "missing" error away for
+# legacy compatibility. Nothing survives, and a manifest that is missing a
+# required binding *and* a nested field verified while one missing only the
+# required binding was MISMATCH. Removing more made the verdict better.
+#
+# Checking the invariant here as well makes it independent of whether the model
+# validator got a chance to run. It is deliberately a duplicate of the rule in
+# models.py rather than a refactor of it: the model has to keep enforcing it for
+# producers, and this path has to keep enforcing it for verifiers even when the
+# model never completes.
+_FULL_BINDING_REQUIRED = ("system_prompt", "policy_bundle", "model_identity")
+
+
+def _full_binding_violation(manifest: dict[str, Any]) -> Optional[tuple[str, str]]:
+    """Return a violation when a full-binding manifest omits a required artifact."""
+    if manifest.get("profile") is not None:
+        return None  # composition-only declares its own unbound set
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return None  # a missing or malformed artifacts block is its own violation
+    missing = [
+        name for name in _FULL_BINDING_REQUIRED if artifacts.get(name) is None
+    ]
+    if not missing:
+        return None
+    return (
+        "artifacts",
+        "full-binding manifest is missing required artifacts: " + ", ".join(missing),
+    )
+
+
 def _strict_schema_violations(manifest: dict[str, Any]) -> list[tuple[str, str]]:
     """Run the manifest through the Pydantic schema and return fail-closed errors.
 
@@ -476,6 +512,13 @@ def _strict_schema_violations(manifest: dict[str, Any]) -> list[tuple[str, str]]
                 continue
             loc = ".".join(str(p) for p in loc_parts)
             violations.append((loc, err.get("msg", "schema error")))
+        # A filtered nested omission may have kept the profile validator from
+        # running at all, so re-check that invariant directly.
+        extra = _full_binding_violation(manifest)
+        if extra is not None and not any(
+            msg.startswith("full-binding manifest is missing") for _loc, msg in violations
+        ):
+            violations.append(extra)
         return violations
     return []
 

--- a/python/tests/test_audit_continuity.py
+++ b/python/tests/test_audit_continuity.py
@@ -265,6 +265,14 @@ def _manifest_with_trace(root, entry_count, trace_type="hash-chained"):
         "expires_at": (now + timedelta(days=90)).isoformat().replace("+00:00", "Z"),
         "crypto_profile": "standard",
         "artifacts": {
+            # A full-binding manifest (no profile) requires system_prompt,
+            # policy_bundle and model_identity. These were absent and the
+            # manifest still verified, which was the masking reported in
+            # GHSA-6hjj-gh3c-r6wv; the subject of these tests is the
+            # decision_trace continuity below.
+            "system_prompt": {"hash": "sha256:" + "a" * 64},
+            "policy_bundle": {"hash": "sha256:" + "b" * 64},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
             "decision_trace": {
                 "trace_type": trace_type,
                 "audit_chain_root": root,

--- a/python/tests/test_cli_cose.py
+++ b/python/tests/test_cli_cose.py
@@ -19,6 +19,7 @@ KP = ed25519_from_private_bytes(SEED)
 NOW = datetime.now(timezone.utc)
 FUTURE = (NOW + timedelta(days=90)).isoformat().replace("+00:00", "Z")
 SHA = "sha256:" + "a" * 64
+SHA_B = "sha256:" + "b" * 64
 
 
 def manifest(version="0.2", **overrides):
@@ -30,7 +31,13 @@ def manifest(version="0.2", **overrides):
         "expires_at": FUTURE,
         "issuer": "spiffe://trust.example/signing-authority",
         "crypto_profile": "standard",
-        "artifacts": {"system_prompt": {"hash": SHA}},
+        # Full-binding manifests require system_prompt, policy_bundle and
+        # model_identity (GHSA-6hjj-gh3c-r6wv).
+        "artifacts": {
+            "system_prompt": {"hash": SHA},
+            "policy_bundle": {"hash": SHA_B},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
+        },
     }
     m.update(overrides)
     return m

--- a/python/tests/test_cose_endpoint.py
+++ b/python/tests/test_cose_endpoint.py
@@ -56,6 +56,10 @@ def manifest(**overrides):
         "artifacts": {
             "system_prompt": {"hash": SHA},
             "policy_bundle": {"hash": SHA_B},
+            # A full-binding manifest (no profile) requires all three. This
+            # fixture used to omit it and still verify, which was the masking
+            # reported in GHSA-6hjj-gh3c-r6wv.
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
         },
     }
     m.update(overrides)
@@ -66,6 +70,7 @@ def trust_store(**overrides):
     ctx = VerificationContext(
         system_prompt_hash=SHA,
         policy_bundle_hash=SHA_B,
+        model_version="claude-3",
         trusted_keys={KP.key_id: KP.public_b64url()},
     )
     for k, v in overrides.items():

--- a/python/tests/test_verify.py
+++ b/python/tests/test_verify.py
@@ -1011,3 +1011,60 @@ def test_audit_key_sealed_absent_is_rejected_under_enforcement():
     result = verify_manifest(m, _appraised_ctx(m), store())
 
     assert result.result == OverallResult.ATTESTATION_UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# GHSA-6hjj-gh3c-r6wv: an extra omission must not improve the verdict.
+#
+# models._validate_manifest_profile enforces the full-binding requirement, but
+# it is a mode="after" model validator, so Pydantic runs it only once every
+# field has validated. Deleting a nested required field stopped it running, and
+# _strict_schema_violations then filtered that nested "missing" error away for
+# legacy compatibility. Nothing survived: the manifest missing a required
+# binding AND a nested field returned VALID, while the one missing only the
+# required binding returned MISMATCH.
+# ---------------------------------------------------------------------------
+
+def _without_model_identity():
+    m = base_manifest()
+    m["artifacts"] = {k: v for k, v in m["artifacts"].items() if k != "model_identity"}
+    return m
+
+
+def test_full_binding_manifest_without_model_identity_is_a_mismatch():
+    """The B1 baseline: the independent failure on its own."""
+    result = verify_manifest(sign(_without_model_identity()), base_context(), store())
+
+    assert result.result == OverallResult.MISMATCH
+
+
+def test_a_further_nested_omission_does_not_rescue_the_verdict():
+    """The B3 case: removing more must never verify better."""
+    m = _without_model_identity()
+    m["artifacts"]["system_prompt"] = {
+        k: v for k, v in m["artifacts"]["system_prompt"].items() if k != "hash"
+    }
+
+    result = verify_manifest(sign(m), base_context(), store())
+
+    assert result.result == OverallResult.MISMATCH
+    assert any(
+        "full-binding manifest is missing required artifacts" in d.actual_hash
+        for d in result.mismatch_details
+    )
+
+
+def test_nested_omissions_alone_are_still_tolerated():
+    """The legacy compatibility this filter exists for is unchanged.
+
+    An incomplete artifact binding is appraised as NOT_BOUND, not rejected.
+    Only the top-level full-binding requirement stopped being maskable.
+    """
+    m = base_manifest()
+    m["artifacts"]["system_prompt"] = {
+        k: v for k, v in m["artifacts"]["system_prompt"].items() if k != "hash"
+    }
+
+    result = verify_manifest(sign(m), base_context(), store())
+
+    assert result.result != OverallResult.MISMATCH


### PR DESCRIPTION
Closes GHSA-6hjj-gh3c-r6wv, the last of the open advisories on this repo. Reproduced against current `main` before changing anything.

## Removing more made the verdict better

`models._validate_manifest_profile` enforces that a full-binding manifest carries `system_prompt`, `policy_bundle` and `model_identity`. It is a `mode="after"` model validator, so Pydantic runs it only once every field has validated.

Delete a required field nested inside an artifact binding and it never runs. `_strict_schema_violations` then filters that nested `missing` error away, deliberately: the verifier appraises incomplete artifact bindings as `NOT_BOUND` rather than rejecting them, and the docstring says so.

The two behaviours compose badly. Nothing survives:

| manifest | verdict |
|---|---|
| `artifacts.model_identity` removed | `MISMATCH` |
| `model_identity` **and** `artifacts.system_prompt.hash` removed | `VALID` |

An additional omission masked a separate structural failure and improved the trust result.

## The fix

The full-binding requirement is now checked directly on the document, independently of whether the model validator got a chance to run.

It is deliberately a duplicate of the rule in `models.py` rather than a refactor of it. The model has to keep enforcing it for producers; this path has to keep enforcing it for verifiers **even when the model never completes**. Sharing one implementation would put the check back behind the same precondition that failed.

The nested-omission tolerance is untouched. An incomplete artifact binding is still appraised rather than rejected, and there is a test pinning that, because that compatibility is the reason the filter exists.

## Worth knowing: the masking was wider than reported

The advisory's B1 baseline says removing `model_identity` alone yields `MISMATCH`. On this repo's own fixtures it did not. `test_full_binding_manifest_without_model_identity_is_a_mismatch` fails on current `main` too, because the base manifest's artifact bindings are minimal (`{"hash": ...}`) and their nested omissions were already suppressing the profile validator.

So the full-binding requirement was effectively unenforced for any manifest with minimal bindings, not only for the two-deletion case. That is why three fixture families move in this PR.

## Fixtures

`test_cose_endpoint.py`, `test_cli_cose.py` and `test_audit_continuity.py` all built full-binding manifests with no `model_identity` (and in two cases no `policy_bundle`) and expected `VALID`. They were relying on the masking. They now declare what a full-binding manifest requires, and `test_cose_endpoint.py`'s context gained the matching `model_version` so the newly bound artifact is actually verified rather than leaving the result `INCOMPLETE`.

None of those three files is about artifact completeness; their subjects are the COSE envelope, the CLI round trip, and audit-chain continuity. The added bindings are scaffolding, and the comments say so.

## Tests

Three in `test_verify.py`: the B1 baseline, the B3 masking case, and the legacy tolerance that must not regress. Reverting `_verify.py` turns the first two red and leaves the third green.

Full suite: **1435 passed**, 6 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
