### PR TITLE
docs: make first manifest checks reproducible and clarify evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "python/**"
+      - "docs/**"
       - "spec/**"
       - "examples/**"
       - "scripts/**"
@@ -13,6 +14,7 @@ on:
     branches: [main]
     paths:
       - "python/**"
+      - "docs/**"
       - "spec/**"
       - "examples/**"
       - "scripts/**"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,59 +1,38 @@
 ---
-description: Create, sign, and verify your first Agent Manifest in under 15 minutes, covering Level 0 software-only signing and Level 1 TPM attestation.
+description: Sign a demo Agent Manifest, compare it with approved inputs, and detect an edited record or a changed prompt hash.
 ---
 
-# Getting Started
+# Create and check your first manifest
 
-This guide walks through creating, signing, and verifying an Agent Manifest in under 15 minutes. It covers Level 0 (software-only signing) and Level 1 (TPM-attested).
-
-!!! tip "TL;DR"
-    Install with `pip install "agent-manifest[cli]"`, run `manifest keygen`, `manifest create`, `manifest sign`, then `manifest verify`. Level 0 needs no hardware. For Level 1, run `manifest attest` on a TPM 2.0, AMD SEV-SNP, or Intel TDX host.
+Sign a small agent configuration, verify its declared inputs, then see two failures: an edited signed record and a different prompt hash. This software example runs locally after installation. It does not run a model or produce hardware attestation.
 
 ## Prerequisites
 
-- Python 3.11 or later
-- For Level 1: a Linux host with TPM 2.0 (`tpm2-tools` installed), an AMD SEV-SNP VM, or an Intel TDX VM
+Use Python 3.11+, Git, and Bash on Linux, macOS, or Windows with WSL. This guide uses the current source checkout so its verification behavior matches these docs.
 
 ## Installation
 
 ```bash
-# Core SDK
-pip install agent-manifest
-
-# With CLI
-pip install "agent-manifest[cli]"
-
-# With post-quantum profile
-pip install "agent-manifest[pq]"
+git clone https://github.com/agentrust-io/agent-manifest.git manifest-quickstart
+cd manifest-quickstart
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e "./python[cli]"
 ```
 
 ## Level 0  -  Software-only signing
 
-Level 0 is suitable for development, staging, and non-regulated environments. No hardware required.
-
-### Step 1: Generate a signing key
-
-```bash
-manifest keygen -d ./keys/
-# Creates keys/private.hex and keys/public.hex
-```
-
-Or in Python:
+Save this complete block as `first_manifest.py`, then run `python first_manifest.py` from the same directory. It uses the supported v0.1 JSON form to make the signed fields readable. The current v0.2 envelope uses COSE; see the [signature envelope decision](adr/0011-signature-envelope.md).
 
 ```python
-from agent_manifest import generate_ed25519
+import copy
+import json
+from pathlib import Path
 
-keypair = generate_ed25519()
-# Store keypair.private_hex and keypair.public_hex securely
-```
-
-### Step 2: Build the manifest
-
-```python
 from agent_manifest import (
     Manifest, ArtifactBindings,
     SystemPromptBinding, PolicyBundleBinding,
-    ToolManifestBinding, ModelIdentityBinding,
+    ModelIdentityBinding,
     CryptoProfile, DeploymentType, EnforcementMode, ModelAttestationType,
     PolicyLanguage,
 )
@@ -92,194 +71,89 @@ manifest = Manifest(
             bound_at=now,
         ),
         model_identity=ModelIdentityBinding(
-            provider="anthropic",
-            model_id="claude-haiku-4-5-20251001",
-            version="20251001",
+            provider="example",
+            model_id="demo-model",
+            version="demo-v1",
             deployment_type=DeploymentType.api,
             model_attestation_type=ModelAttestationType.provider_asserted,
             bound_at=now,
         ),
     ),
 )
-```
 
-### Step 3: Sign the manifest
-
-```python
 from agent_manifest import Ed25519Signer, generate_ed25519
-
-keypair = generate_ed25519()
-signer = Ed25519Signer(keypair)
-manifest_dict = manifest.model_dump(mode="json", by_alias=True)
-sig_block = signer.sign(manifest_dict)
-
-manifest_dict["signature"] = sig_block
-print(sig_block["algorithm"])  # Ed25519
-```
-
-Or with the CLI:
-
-```bash
-manifest create my-agent-config.json -o draft.json
-manifest sign draft.json --key keys/private.hex -o signed.json
-```
-
-### Step 4: Verify
-
-```python
 from agent_manifest._verify import verify_manifest, VerificationContext, RevocationStore
 
-# Fail-closed: VALID requires the issuer's key in trusted_keys. Without
-# trusted keys the result is UNVERIFIABLE - never VALID.
-result = verify_manifest(
-    manifest_dict,
-    VerificationContext(
-        system_prompt_hash=prompt_hash,
-        policy_bundle_hash="sha256:" + "b" * 64,
-        trusted_keys={keypair.key_id: keypair.public_b64url()},
-    ),
-    RevocationStore(),
+keypair = generate_ed25519()
+record = manifest.model_dump(mode="json", by_alias=True, exclude_none=True)
+record["signature"] = Ed25519Signer(keypair).sign(record)
+# Verifier inputs come from this demo's approved configuration, not the record.
+context = VerificationContext(
+    system_prompt_hash=prompt_hash,
+    policy_bundle_hash="sha256:" + "b" * 64,
+    enforcement_mode="enforce",
+    model_version="demo-v1",
+    trusted_keys={keypair.key_id: keypair.public_b64url()},
 )
-print(result.result.value)   # VALID
+result = verify_manifest(record, context, RevocationStore())
+assert result.result.value == "VALID", result.model_dump_json()
+print("PASS: approved demo inputs match (VALID)")
+
+changed = copy.deepcopy(record)
+changed["artifacts"]["model_identity"]["version"] = "changed"
+result = verify_manifest(changed, context, RevocationStore())
+assert result.result.value == "MISMATCH" and not result.signature_verified
+print("PASS: edited signed record rejected (MISMATCH)")
+
+drift = context.model_copy(update={"system_prompt_hash": "sha256:" + "0" * 64})
+result = verify_manifest(record, drift, RevocationStore())
+assert result.result.value == "MISMATCH" and result.signature_verified
+print("PASS: different prompt hash rejected (MISMATCH)")
+
+Path("signed.json").write_text(json.dumps(record, indent=2))
+Path("public.hex").write_text(keypair.public_bytes.hex())
+print("Saved signed.json and public.hex; private key was not saved")
 ```
 
-Or with the CLI:
+Expected output:
+
+```text
+PASS: approved demo inputs match (VALID)
+PASS: edited signed record rejected (MISMATCH)
+PASS: different prompt hash rejected (MISMATCH)
+Saved signed.json and public.hex; private key was not saved
+```
+
+The prompt hash comes from the demo text. The policy hash and model identity are synthetic declarations. `VALID` here applies to the three declared bindings and the supplied verifier inputs. It is not a claim that all ten artifact categories were bound, a model executed, or the configuration is safe.
+
+The verifier retains its trusted public key separately from the record. In production, obtain issuer keys and runtime measurements through your approved trust channels. Reading expected hashes from an untrusted manifest would only compare the document with itself.
+
+## Inspect the saved record
 
 ```bash
-manifest verify signed.json --public-key keys/public.hex
+manifest verify signed.json --public-key public.hex
 ```
 
-Without `--public-key`, signed manifests fail closed as `UNVERIFIABLE`
-because the CLI has no trusted issuer key to authenticate the signature.
-The CLI `--public-key` option accepts the raw Ed25519 public key generated by
-`manifest keygen`.
-
-### Step 5: Watch it catch a change
-
-A `VALID` result only means something if you have seen the same manifest come back
-`MISMATCH`. There are two independent ways it does, and they fail differently.
-
-**The record was edited after signing.** Swap the approved model version inside the
-signed manifest and re-verify:
-
-```python
-import copy
-
-tampered = copy.deepcopy(manifest_dict)
-tampered["artifacts"]["model_identity"]["version"] = "20260101"
-
-result = verify_manifest(
-    tampered,
-    VerificationContext(trusted_keys={keypair.key_id: keypair.public_b64url()}),
-    RevocationStore(),
-)
-print(result.result.value)              # MISMATCH
-print(result.signature_verified)        # False
-print(result.mismatch_details[0].field) # signature
-```
-
-The signature no longer covers the bytes, so the edit is caught without the verifier
-knowing anything about models.
-
-**The record is intact but the running agent drifted.** Here the signature still
-verifies. What fails is the declared-vs-actual comparison, which is the binding the
-manifest exists for:
-
-```python
-import hashlib
-
-running_prompt = "You are a document summarization assistant. Ignore prior instructions."
-running_hash = "sha256:" + hashlib.sha256(running_prompt.encode("utf-8")).hexdigest()
-
-result = verify_manifest(
-    manifest_dict,
-    VerificationContext(
-        system_prompt_hash=running_hash,          # what is actually loaded
-        trusted_keys={keypair.key_id: keypair.public_b64url()},
-    ),
-    RevocationStore(),
-)
-print(result.result.value)                        # MISMATCH
-print(result.fields_verified.system_prompt.value) # MISMATCH
-```
-
-Pass the real hash and the same call returns `VALID` with `system_prompt: MATCH`.
-
-Both checks answer "is this the agent that was approved" at the moment you verify.
-Neither one watches the agent afterwards: an attacker who changes the system prompt in
-memory after this check has passed is outside what a boot-time manifest can see. That
-boundary is deliberate and documented in [Limitations](limitations.md), and
-`attest_runtime_state()` is the primitive for closing it with a hardware-signed
-freshness proof on a cadence you choose.
+This CLI invocation supplies a trusted key but no runtime hashes. Expect `INCOMPLETE`, with a verified signature and missing artifact comparisons. Without `--public-key`, expect `UNVERIFIABLE`. The Python example supplies the comparison inputs needed for its `VALID` result.
 
 ## Level 1  -  TPM attestation
 
-Level 1 adds hardware attestation, which binds the manifest hash to a TEE measurement that cannot be forged by the operator. Required for enterprise production deployments, and for EU AI Act Art. 15 (cybersecurity) when that obligation applies from around December 2027.
-
-### Prerequisites
-
-On Ubuntu/Debian:
-
-```bash
-apt install tpm2-tools
-```
-
-On AWS: Nitro Enclaves with `aws-nitro-enclaves-sdk-python` installed.
-
-### Attest the signed manifest
-
-```python
-from agent_manifest._auto_provider import select_provider
-
-# Auto-selects: OPAQUE -> SEV-SNP -> TDX -> TPM -> Software
-provider = select_provider(level=1)
-provider.extend_manifest_hash(manifest_dict)
-report = provider.get_attestation_report()
-
-manifest_dict["attestation"] = {
-    "tee_type": report.platform,       # "tpm" | "amd-sev-snp" | "intel-tdx" | "opaque"
-    "manifest_hash_in_report": True,
-    "report_uri": report.report_uri,
-    "bound_at": now.isoformat(),
-}
-```
-
-Or with the CLI:
-
-```bash
-manifest attest signed.json --provider auto --level 1 -o attested.json
-manifest verify attested.json --public-key keys/public.hex
-```
-
-The verification result for a Level 1 manifest includes `attestation_verified: true` when the TEE measurement matches the manifest hash.
+Hardware provenance is a separate step. Follow the [hardware attestation tutorial](tutorials/hardware-attestation.md) and [limitations](limitations.md) for provider-specific evidence and appraisal. A TPM supplies measured-state evidence; it does not by itself isolate process memory. A declared hardware platform or a successful signing command does not establish a conformance level.
 
 ## Revocation
 
-When an artifact changes (new model version, policy update, system prompt revision), revoke the old manifest and issue a new one:
+An artifact update needs a newly approved manifest. Production verification also needs current revocation information; this demo uses an empty in-memory store. See [revocation and key rotation](tutorials/revocation-and-key-rotation.md).
 
-```bash
-manifest revoke <manifest-id> \
-  --reason "policy bundle updated to v1.1.0" \
-  --revoked-by security@acme.co
-```
+## Troubleshooting
 
-In Python:
-
-```python
-from agent_manifest._verify import RevocationStore
-
-store = RevocationStore()
-store.revoke(
-    manifest_id="019236ab-cdef-7000-8000-000000000001",
-    reason="policy bundle updated to v1.1.0",
-    revoked_by="security@acme.co",
-)
-```
+- **Module not found:** activate `.venv` in the terminal running the example.
+- **File not found:** run `first_manifest.py` before inspecting `signed.json`.
+- **INCOMPLETE:** inspect which runtime comparisons are missing. Supply independent inputs instead of disabling strict verification.
+- **MISMATCH:** check the signature and named artifact mismatch. Both deliberate changes in this demo should fail.
+- **Expired record:** rerun the example to create a fresh demo record.
 
 ## Next steps
 
-- Read the [full specification](spec/agent-manifest-v0.2.md)
-- Browse the [examples](../examples/) for complete manifest JSON for each conformance level
-- For hardware attestation setup on Azure, AWS, or GCP, see the platform-specific notes in Section 3.3.1 of the spec
-- For EU AI Act HITL compliance, see Section 9.1 and the Level 2 example in `examples/`
-- For post-quantum signing, install `agent-manifest[pq]` and set `crypto_profile=CryptoProfile.post_quantum`
+- [Specification](spec/agent-manifest-v0.2.md): artifact and verification contracts.
+- [cMCP session binding](tutorials/cmcp-session-binding.md): connect deployment identity to tool-call evidence.
+- [Verification API](api-reference/index.md): caller inputs and result fields.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,96 +1,70 @@
 ---
-title: Verifiable identity and permissions for AI agents
-description: Agent Manifest is an open standard that cryptographically anchors the 10 artifacts defining an AI agent, so a third party can verify the agent running in production is the one that was approved.
+title: Check an agent configuration against approved inputs
+description: Sign an agent configuration, verify its artifact bindings against independent inputs, and detect changes. Start locally with software signing.
 ---
 
-# Agent Manifest
+# Check the agent configuration you approved
 
-Agent Manifest is an open standard for the cryptographic identity and provenance of AI agents. It anchors all 10 artifacts that define an agent at deployment, so a verifier who does not trust the operator can prove the agent running in production is the exact agent that was approved.
+Agent Manifest records an agent's deployment configuration in a signed document: prompt, policy, tools, model identity, and related artifacts. A verifier authenticates the issuer and compares the bindings with independently supplied inputs.
 
-**Cryptographically anchor all 10 artifacts defining an AI agent at deployment.**
+[Create and check your first manifest](getting-started.md){ .md-button .md-button--primary }
+[Read the verification limits](limitations.md){ .md-button }
 
-!!! tip "TL;DR"
-    - A signed JWT proves who called an API. An Agent Manifest proves who the agent *was*, what it was *allowed to do*, how it was *built*, what it *decided*, and who *approved* it.
-    - Level 0 is software-only Ed25519 signing and runs anywhere with Python 3.11 or later. Hardware attestation (TPM 2.0, AMD SEV-SNP, Intel TDX, OPAQUE) is optional from Level 1 up.
-    - Install with `pip install "agent-manifest[cli]"` and verify your first manifest in under 15 minutes.
-
-A signed JWT proves who called an API. An Agent Manifest proves who the agent **was**, what it was **allowed to do**, how it was **built**, what it **decided**, who **approved** it, and whether any of that changed between approval and execution.
-
-```bash
-pip install "agent-manifest[cli]"
-```
-
-```bash
-manifest keygen -d ./keys/
-manifest create config.json -o draft.json
-manifest sign draft.json --key keys/private.hex -o signed.json
-manifest verify signed.json --public-key keys/public.hex   # VALID
-```
+Start locally with Python 3.11+ and no hardware or cloud account. The example signs a demo configuration, checks it, then detects an edited record and a different prompt hash.
 
 ## The agent attestation gap
 
-Every entity in a modern enterprise has a verifiable identity. Users have X.509 certificates. Services have SPIFFE SVIDs. Containers have image digests. AI agents have none of these.
-
-An agent calling a tool today presents no unforgeable proof of which system prompt defined its behavior, which model is running, which policy was approved, or whether a human reviewed any of it. This is not an authentication gap  -  agents can authenticate with tokens. It is an **attestation gap**: the inability to prove, to a third party who does not trust the operator, that the agent running right now is the agent that was approved.
-
-Software-signed manifests do not close this gap. A privileged operator can replace a system prompt in memory after signing, swap a model version between approval and runtime, or forge a human-in-the-loop approval record. Hardware-attested manifests make these attacks impossible  -  the measurement happens in silicon before any user code runs and the signing key never leaves the TEE.
+An authenticated caller can still run a changed prompt, policy, or tool configuration. A manifest gives a verifier specific artifact bindings to compare. Software signing authenticates declarations; hardware provenance requires valid attestation, approved measurements, and a binding between the evidence and this manifest.
 
 ## How it works
 
-```
-Developer                 TEE                    Verifier
-─────────                 ───                    ────────
-Hash 10 artifacts   →   Measure in hardware  →  Verify against
-Sign manifest       →   Seal signing key     →  attestation report
-Publish to log      →   Return TRACE claim   →  VALID / MISMATCH
+```mermaid
+flowchart TB
+    config[Approved deployment artifacts] -->|hash and identify| issuer[Manifest issuer]
+    issuer -->|sign| record[Signed manifest]
+    record --> verifier[Verifier]
+    keys[Trusted issuer keys] --> verifier
+    actual[Independent runtime inputs] --> verifier
+    evidence[Optional appraised hardware evidence] --> verifier
+    verifier --> result[Result and per-field checks]
 ```
 
-A verifying party who holds an Agent Manifest and its accompanying attestation report can prove  -  without trusting the operator  -  that a specific agent started with specific code, policy, tools, audit-chain baseline, and human oversight. Runtime evidence shows what happened after that point and is verified separately.
+The verifier needs its own trusted inputs. A signed manifest does not continuously observe the agent, and attestation does not make every later modification impossible. Runtime activity is recorded separately in [TRACE](https://trace.agentrust-io.com/).
 
 ## The 10 attested artifacts
 
-| # | Artifact | What it proves |
-|---|----------|----------------|
-| 1 | System Prompt | The exact prompt defining the agent's persona and safety constraints |
-| 2 | Policy Bundle | The Cedar/Rego/YAML governance rules in force |
-| 3 | Tool Manifest | Every tool schema and description the agent was authorized to call |
-| 4 | Model Identity | Which model and version ran (binary hash for local, version for API) |
-| 5 | RAG Corpus | The knowledge base the agent was grounded on (Merkle root) |
-| 6 | Memory Baseline | Approved agent memory state with TTL-based re-approval |
-| 7 | Decision-log baseline | Audit-chain root current when the manifest is issued; later decisions are separate linked evidence |
-| 8 | A2A Delegation | Signed delegation chain from human principal to current agent |
-| 9 | Supply Chain | Container digest, SLSA provenance, SBOM, MCP server supply chain |
-| 10 | HITL Approvals | Hardware-signed human oversight records (EU AI Act Art. 14) |
+The format covers these ten categories. Their presence and verification requirements depend on the profile; a category listed here is not evidence that it was measured or checked.
+
+| Artifact | What the binding identifies |
+|---|---|
+| System prompt | Prompt hash, version, and classification |
+| Policy bundle | Policy hash, language, and declared enforcement mode |
+| Tool manifest | Tool catalog hash |
+| Model identity | Provider, model, version, and attestation type |
+| RAG corpus | Corpus commitment |
+| Memory baseline | Approved memory snapshot |
+| Decision-log baseline | Audit-chain root at issuance |
+| A2A delegation | Delegation credentials and scope |
+| Supply chain | Image digest and build provenance |
+| Human approvals | Approval records and signer evidence |
 
 ## Hardware providers
 
-| Provider | Platform | Assurance |
-|----------|----------|-----------|
-| TPM 2.0 | Any Azure/AWS/GCP VM with Trusted Launch | Medium |
-| AMD SEV-SNP | Azure DCasv5, AWS C6a Nitro, GCP N2D | High |
-| Intel TDX | Azure DCedsv5, GCP C3 | High |
-| OPAQUE | OPAQUE Managed Runtime | Managed (chain-verified) |
-
-Provider auto-selects based on available hardware: `OPAQUE → SEV-SNP → TDX → TPM → software`.
+Provider support includes TPM, AMD SEV-SNP, Intel TDX, and OPAQUE. Evidence collection, verification, and memory isolation differ by provider. Use the [hardware guide](tutorials/hardware-attestation.md) and [limitations](limitations.md) to choose a deployment; the provider name alone is not an assurance verdict.
 
 ## Conformance levels
 
-| Level | Requirements | Use case |
-|-------|-------------|---------|
-| Level 0 | Software signing, all artifact bindings | Development, staging |
-| Level 1 | + TEE attestation, `audit_key_sealed: true` | Enterprise production; EU AI Act Art. 15 from ~Dec 2027 |
-| Level 2 | + All 10 artifacts, HITL approvals, Phase 2 cMCP | Regulated industries, DORA |
-| Level 3 | + ML-DSA-65, ML-KEM-768, SHAKE-256 | Sovereign, classified, long-horizon financial |
+Begin with software signing. Higher profiles add hardware, approval, transparency, or cryptographic requirements. Check the [specification](spec/agent-manifest-v0.2.md) before claiming a level; a successful signature check is only one part of verification.
 
 ## Frequently asked questions
 
 ### What is an Agent Manifest?
 
-An Agent Manifest is a cryptographically signed record that anchors the 10 artifacts defining an AI agent at deployment: system prompt, policy bundle, tool manifest, model identity, RAG corpus, memory baseline, decision-log baseline, A2A delegation, supply chain, and HITL approvals. It lets a third party verify that the agent running now is the agent that was approved. It does not claim that later runtime decisions existed at deployment time: those are separate TRACE or OCSF records joined back to the manifest.
+A signed record of deployment artifact bindings. Its usefulness depends on authenticating the issuer, comparing independent runtime inputs, and checking the evidence your trust policy requires.
 
 ### How is an Agent Manifest different from a signed JWT?
 
-A signed JWT proves who called an API. An Agent Manifest proves who the agent was, what it was allowed to do, how it was built, which audit-chain baseline it started from, who approved it, and whether the deployment configuration changed before execution.
+JWT describes an envelope for claims. Agent Manifest defines artifact bindings and their verification contract. Envelope choice alone does not establish runtime provenance.
 
 ### Why not specify it as a JWT or JOSE profile?
 
@@ -100,82 +74,17 @@ Every multi-artifact provenance standard with a transparency log went the other 
 
 An Agent Manifest is that second kind of object: ten artifacts, several independent signers, hardware-report binding, a 90-day life, and a log receipt attached after signing. So the layering is EAT and JWT for the attestation-token input, and a signed document for the manifest. The two compose. See [ADR-0011](adr/0011-signature-envelope.md) for the full argument. The envelope moves to COSE_Sign1 in spec v0.2 to align with SCITT; v0.1 manifests keep verifying unchanged.
 
-### What is the agent attestation gap?
-
-Users have X.509 certificates, services have SPIFFE SVIDs, and containers have image digests, but AI agents have no unforgeable proof of which prompt, model, or policy defined their behavior. The attestation gap is the inability to prove, to a third party who does not trust the operator, that the running agent matches the approved one.
-
 ### Does Agent Manifest require special hardware?
 
-No. Level 0 uses software-only Ed25519 signing and runs anywhere with Python 3.11 or later. Hardware attestation (Level 1 and above) is optional and supports TPM 2.0, AMD SEV-SNP, Intel TDX, and OPAQUE, auto-selected by available hardware.
-
-### What are the conformance levels?
-
-Level 0 is software signing with all artifact bindings. Level 1 adds TEE attestation with a sealed audit key. Level 2 adds all 10 artifacts, HITL approvals, and Phase 2 cMCP. Level 3 adds the post-quantum profile (ML-DSA-65, ML-KEM-768, SHAKE-256).
+No. The [first example](getting-started.md) uses software signing. Hardware provenance requires additional evidence and verification.
 
 ### Is Agent Manifest free and open source?
 
-Yes. It is published on PyPI (`pip install agent-manifest`) and developed in the open at [github.com/agentrust-io/agent-manifest](https://github.com/agentrust-io/agent-manifest).
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What is an Agent Manifest?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "An Agent Manifest is a cryptographically signed record that anchors the deployment configuration and decision-log baseline for an AI agent. Runtime decisions are separate TRACE or OCSF records joined back to the manifest."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How is an Agent Manifest different from a signed JWT?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "A signed JWT proves who called an API. An Agent Manifest proves who the agent was, what it was allowed to do, how it was built, which audit-chain baseline it started from, who approved it, and whether the deployment configuration changed before execution."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the agent attestation gap?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Users have X.509 certificates, services have SPIFFE SVIDs, and containers have image digests, but AI agents have no unforgeable proof of which prompt, model, or policy defined their behavior. The attestation gap is the inability to prove, to a third party who does not trust the operator, that the running agent matches the approved one."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does Agent Manifest require special hardware?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "No. Level 0 uses software-only Ed25519 signing and runs anywhere with Python 3.11 or later. Hardware attestation (Level 1 and above) is optional and supports TPM 2.0, AMD SEV-SNP, Intel TDX, and OPAQUE, auto-selected by available hardware."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What are the conformance levels?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Level 0 is software signing with all artifact bindings. Level 1 adds TEE attestation with a sealed audit key. Level 2 adds all 10 artifacts, HITL approvals, and Phase 2 cMCP. Level 3 adds the post-quantum profile (ML-DSA-65, ML-KEM-768, SHAKE-256)."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Is Agent Manifest free and open source?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. It is published on PyPI (pip install agent-manifest) and developed in the open at github.com/agentrust-io/agent-manifest."
-      }
-    }
-  ]
-}
-</script>
+Yes. The source and license are available on [GitHub](https://github.com/agentrust-io/agent-manifest).
 
 ## Next steps
 
-- [Getting started](getting-started.md)  -  Level 0 in 15 minutes
-- [Examples](https://github.com/agentrust-io/examples)  -  complete manifest JSON for Level 0 and Level 1
-- [Specification](spec/agent-manifest-v0.2.md)  -  197 conformance tests across 5 modules
-- [Architecture decisions](adr/index.md)  -  rationale behind cryptographic design choices
+- [Getting started](getting-started.md): sign, compare, and detect changes.
+- [Tutorials](tutorials/index.md): integration and operational tasks.
+- [Specification](spec/agent-manifest-v0.2.md): normative requirements.
+- [Architecture decisions](adr/index.md): design rationale.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,10 @@ An authenticated caller can still run a changed prompt, policy, or tool configur
 
 ## How it works
 
+Scroll the diagram horizontally on smaller screens.
+
+<div class="at-diagram" role="region" aria-label="Manifest verification diagram; scroll horizontally" tabindex="0" markdown>
+
 ```mermaid
 flowchart TB
     config[Approved deployment artifacts] -->|hash and identify| issuer[Manifest issuer]
@@ -28,6 +32,8 @@ flowchart TB
     evidence[Optional appraised hardware evidence] --> verifier
     verifier --> result[Result and per-field checks]
 ```
+
+</div>
 
 The verifier needs its own trusted inputs. A signed manifest does not continuously observe the agent, and attestation does not make every later modification impossible. Runtime activity is recorded separately in [TRACE](https://trace.agentrust-io.com/).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,15 +56,11 @@ plugins:
   - llmstxt:
       full_output: llms-full.txt
       markdown_description: >-
-        Agent Manifest is an open standard for the cryptographic identity and
-        provenance of AI agents. It anchors the 10 artifacts that define an
-        agent at deployment (system prompt, policy bundle, tool manifest, model
-        identity, RAG corpus, memory baseline, decision-log baseline, A2A delegation,
-        supply chain, and HITL approvals) so a verifier who does not trust the
-        operator can prove the agent running in production is the one that was
-        approved. Level 0 is software-only Ed25519 signing; Levels 1 to 3 add
-        TEE attestation (TPM, AMD SEV-SNP, Intel TDX, OPAQUE) and post-quantum
-        profiles.
+        Agent Manifest defines signed deployment artifact bindings for AI agents.
+        Verifiers authenticate the issuer and compare independently supplied
+        runtime inputs. Software signing, hardware provenance, and runtime
+        activity establish different properties. Start with a local configuration
+        check and tamper detection, then select the evidence your policy needs.
       sections:
         Getting started:
           - index.md

--- a/python/tests/test_docs_first_manifest.py
+++ b/python/tests/test_docs_first_manifest.py
@@ -1,0 +1,32 @@
+"""Execute the complete onboarding example and inspect its saved artifact."""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from agent_manifest.cli import cli
+
+
+def test_first_manifest(tmp_path):
+    page = Path(__file__).resolve().parents[2] / "docs/getting-started.md"
+    if not page.is_file():
+        pytest.skip("documentation is not included in the sdist")
+    blocks = re.findall(r"^```python\n(.*?)^```", page.read_text(encoding="utf-8"), re.M | re.S)
+    assert len(blocks) == 1
+    run = subprocess.run(
+        [sys.executable, "-c", blocks[0]], cwd=tmp_path, capture_output=True, text=True
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert run.stdout.count("PASS:") == 3
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", str(tmp_path / "signed.json"),
+                                 "--public-key", str(tmp_path / "public.hex")])
+    payload = json.loads(result.stdout)
+    assert payload["result"] == "INCOMPLETE"
+    assert payload["signature_verified"] is True
+    result = runner.invoke(cli, ["verify", str(tmp_path / "signed.json")])
+    assert json.loads(result.stdout)["result"] == "UNVERIFIABLE"


### PR DESCRIPTION
The landing page asked readers to use an undefined configuration file and described hardware guarantees too broadly. It now leads to one complete local example: sign a demo configuration, compare independent inputs, reject a changed record, and reject a changed prompt hash.

The architecture diagram distinguishes issuer, signed record, independent runtime inputs, optional appraised evidence, and verifier. The quickstart explains the scope of VALID, INCOMPLETE, and UNVERIFIABLE, uses one signing key, and saves only the public key. Search-facing copy follows the same claims. Existing detailed envelope rationale remains available.

Validation: the documented Python block and saved-record CLI verification pass in an automated test. The test covers two distinct MISMATCH cases and the CLI's missing-input and missing-key results. Docs edits now trigger CI. MkDocs builds successfully; strict mode still fails on 15 pre-existing changelog cross-reference warnings. No verifier or runtime code changes.
