### PR TITLE
fix(trace): don't mask falsy non-dict artifacts/policy_bundle as missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+
+- **[SDK]** `_check_manifest_binding()` no longer masks a malformed
+  `artifacts` or `artifacts.policy_bundle` as merely absent. Truthy
+  non-objects (`"str"`, `[1]`, `True`) already correctly reported
+  `manifest_artifacts_not_an_object` / `manifest_policy_bundle_not_an_object`,
+  but `manifest.get(...) or {}` folded any *falsy* non-object (`""`, `[]`,
+  `False`, `0`) into `{}` before the `isinstance` check ever ran, so those
+  were reported as `manifest_has_no_policy_bundle_hash` "no hash
+  available" instead of the structural warning. A value is now only
+  treated as missing when the key is absent or explicitly `None`; any other
+  non-dict value reports the structural warning regardless of truthiness.
+
 ## [0.12.0] — 2026-09-05
 
 ### Security

--- a/python/src/agent_manifest/_trace.py
+++ b/python/src/agent_manifest/_trace.py
@@ -566,13 +566,22 @@ def _check_manifest_binding(
         )
         return warnings
 
-    artifacts = manifest.get("artifacts") or {}
-    if not isinstance(artifacts, dict):
+    # `or {}` would fold falsy non-dicts ("", [], False, 0) into {} before the
+    # isinstance check ever saw them, so they were reported as merely
+    # "missing" instead of "malformed". Missing is only "absent key"
+    # or an explicit `None`; anything else that isn't a dict is a structural
+    # problem regardless of truthiness.
+    artifacts = manifest.get("artifacts")
+    if artifacts is None:
+        artifacts = {}
+    elif not isinstance(artifacts, dict):
         warnings.append("manifest_artifacts_not_an_object")
         return warnings
 
-    policy_bundle = artifacts.get("policy_bundle") or {}
-    if not isinstance(policy_bundle, dict):
+    policy_bundle = artifacts.get("policy_bundle")
+    if policy_bundle is None:
+        policy_bundle = {}
+    elif not isinstance(policy_bundle, dict):
         warnings.append("manifest_policy_bundle_not_an_object")
         return warnings
 

--- a/python/tests/test_trace_verify.py
+++ b/python/tests/test_trace_verify.py
@@ -413,6 +413,87 @@ def test_non_object_policy_bundle_warns_not_raises(kp, trusted, bad_policy_bundl
     assert "manifest_policy_bundle_not_an_object" in result.warnings
 
 
+@pytest.mark.parametrize("bad_artifacts", ["", [], False, 0])
+def test_falsy_non_object_manifest_artifacts_warns_structurally(
+    kp, trusted, bad_artifacts
+):
+    """`manifest.get("artifacts") or {}` folded falsy non-dicts
+    ("", [], False, 0) into `{}` before the isinstance check ever ran, so
+    they were reported as merely absent (`manifest_has_no_policy_bundle_hash`)
+    instead of malformed. Only a genuinely missing `artifacts` (absent key or
+    `None`) may fall back to `{}`; any other non-dict, falsy or not, must
+    report the structural warning.
+    """
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope,
+        trusted_keys=trusted,
+        manifest={"manifest_id": MANIFEST_ID, "artifacts": bad_artifacts},
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert "manifest_artifacts_not_an_object" in result.warnings
+    assert "manifest_has_no_policy_bundle_hash" not in result.warnings
+
+
+@pytest.mark.parametrize("bad_policy_bundle", ["", [], False, 0])
+def test_falsy_non_object_policy_bundle_warns_structurally(
+    kp, trusted, bad_policy_bundle
+):
+    """Same bug as above, one level down: `artifacts.get("policy_bundle") or
+    {}` swallowed falsy non-dict policy bundles into the no-hash warning."""
+    envelope = _sign_envelope(_envelope(), kp)
+    result = verify_trace_envelope(
+        envelope,
+        trusted_keys=trusted,
+        manifest={
+            "manifest_id": MANIFEST_ID,
+            "artifacts": {"policy_bundle": bad_policy_bundle},
+        },
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert "manifest_policy_bundle_not_an_object" in result.warnings
+    assert "manifest_has_no_policy_bundle_hash" not in result.warnings
+
+
+@pytest.mark.parametrize(
+    "manifest_extra",
+    [
+        {},  # artifacts key absent entirely
+        {"artifacts": None},  # explicit None
+        {"artifacts": {}},  # well-typed but empty
+        {"artifacts": {"policy_bundle": None}},  # policy_bundle explicit None
+        {"artifacts": {"policy_bundle": {}}},  # well-typed but empty
+    ],
+)
+def test_true_missing_cases_still_use_no_hash_warning(kp, trusted, manifest_extra):
+    """None, an absent key, and `{}` are genuinely missing data, not
+    malformed structure, and must keep reporting
+    `manifest_has_no_policy_bundle_hash` rather than a structural warning."""
+    envelope = _sign_envelope(_envelope(), kp)
+    manifest = {"manifest_id": MANIFEST_ID, **manifest_extra}
+    result = verify_trace_envelope(
+        envelope, trusted_keys=trusted, manifest=manifest
+    )
+    assert result.status is TraceStatus.VERIFIED
+    assert "manifest_has_no_policy_bundle_hash" in result.warnings
+    assert "manifest_artifacts_not_an_object" not in result.warnings
+    assert "manifest_policy_bundle_not_an_object" not in result.warnings
+
+
+def test_pack_with_falsy_non_object_artifacts_warns_structurally(kp, trusted):
+    """Same as the falsy-artifacts test above, but through the independently
+    reachable evidence-pack path (the two paths are known to be separate
+    separate call sites feeding the same function)."""
+    envelope = _sign_envelope(_envelope(), kp)
+    malformed_manifest = {"manifest_id": MANIFEST_ID, "artifacts": ""}
+    pack = _sign_pack(_pack([envelope], manifest=malformed_manifest), kp)
+    result = verify_evidence_pack(pack, trusted_keys=trusted, trace_key_id=kp.key_id)
+    assert len(result.envelopes) == 1
+    assert result.envelopes[0].status is TraceStatus.VERIFIED
+    assert "manifest_artifacts_not_an_object" in result.envelopes[0].warnings
+    assert "manifest_has_no_policy_bundle_hash" not in result.envelopes[0].warnings
+
+
 def test_pack_with_malformed_manifest_artifacts_warns_not_raises(kp, trusted):
     """The evidence-pack path is independently reachable (#362): it feeds its
     manifest to every contained envelope without checking artifacts/


### PR DESCRIPTION
## What

Fixes ` _check_manifest_binding()` so a falsy non-dict `artifacts` or `policy_bundle` (`""`, `[]`, `False`, `0`) reports the correct structural warning instead of being silently treated as "no hash available."

## Why

`manifest.get("artifacts") or {}` folds any falsy value into `{}` before the `isinstance` check runs, so those cases were reported as `manifest_has_no_policy_bundle_hash` (missing) instead of `manifest_artifacts_not_an_object` / `manifest_policy_bundle_not_an_object` (malformed). Callers couldn't tell "hash absent" from "shape unreadable" for these inputs.

## Spec impact

none

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [ ] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
