### PR TITLE
fix(delegation): non-empty Cedar constraints must be UNVERIFIABLE, not VALID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Fixed
 
+- **[SDK]** `verify_delegation_chain()` no longer verifies a delegation chain
+  as `VALID` when a hop's `scope_grant.constraints` is non-empty. Constraints
+  are Cedar statements (spec 3.4.1); this package has no Cedar parser or
+  evaluator, so per spec such a chain MUST be reported `UNVERIFIABLE`, never
+  `VALID`. `_check_scope_narrowing()` only ever did a string-set comparison
+  between parent and child constraints, so two hops carrying the identical,
+  unparseable constraint string (nothing "dropped") verified as `VALID`
+  end-to-end. A new `DelegationUnverifiable` exception now signals this case
+  distinctly from an affirmatively broken chain (`ValueError` → `INVALID`);
+  `verify_manifest()` maps it to `DelegationResult.UNVERIFIABLE`.
+
 - **[SDK]** `_check_manifest_binding()` no longer masks a malformed
   `artifacts` or `artifacts.policy_bundle` as merely absent. Truthy
   non-objects (`"str"`, `[1]`, `True`) already correctly reported

--- a/python/src/agent_manifest/__init__.py
+++ b/python/src/agent_manifest/__init__.py
@@ -93,6 +93,7 @@ from ._delegation import (
     delegation_depth_exceeded,
     DelegationHopSigner,
     HitlApprovalSigner,
+    DelegationUnverifiable,
 )
 from ._plugins import (
     PluginBundleError,
@@ -177,6 +178,7 @@ __all__ = [
     "TraceStatus", "TraceVerificationResult", "EvidencePackVerificationResult",
     "TRACE_REQUIRED_FIELDS", "TRACE_VERIFICATION_RESULTS", "INADMISSIBLE_RESULTS",
     "verify_delegation_chain", "verify_hitl_approval", "delegation_depth_exceeded",
+    "DelegationUnverifiable",
     "DelegationHopSigner", "HitlApprovalSigner",
     "PluginBundleError", "PluginSkill", "DeclaredMcpServer", "PluginBundle",
     "PluginManifestReference", "PluginReferenceResult", "PluginReferenceStatus",

--- a/python/src/agent_manifest/_delegation.py
+++ b/python/src/agent_manifest/_delegation.py
@@ -24,6 +24,26 @@ from ._signing import Ed25519KeyPair, Ed25519Verifier
 # ---------------------------------------------------------------------------
 
 
+class DelegationUnverifiable(Exception):
+    """Raised when a chain is structurally and cryptographically sound but
+    contains an element this verifier cannot evaluate with certainty.
+
+    Spec 3.4.1 / 5.2: ``scope_grant.constraints`` entries are Cedar ``permit``
+    or ``forbid`` statements. A verifying party that supports Cedar MUST
+    parse and evaluate them; a verifying party that does not MUST treat a
+    non-empty ``constraints`` array as ``UNVERIFIABLE`` rather than ``VALID``.
+    This package does not implement a Cedar parser/evaluator, so it always
+    falls into the second case.
+
+    This is deliberately not a ``ValueError``: ``ValueError`` here means the
+    chain is affirmatively broken (bad scope narrowing, malformed structure),
+    which callers map to ``INVALID``. This exception means the opposite -
+    every check this verifier is able to perform passed - but a condition
+    this verifier cannot resolve makes an outright ``VALID`` unsafe to
+    report, so callers must map it to ``UNVERIFIABLE`` instead.
+    """
+
+
 # Spec 3.4.1: when max_delegation_depth is omitted from a scope_grant,
 # verifying parties MUST apply a default value of 3.
 DEFAULT_MAX_DELEGATION_DEPTH = 3
@@ -231,6 +251,13 @@ def verify_delegation_chain(
       - Scope at each hop is not broader than the previous hop's grant
         (tools, data_classifications, constraints, ttl_seconds, depth).
       - Chain depth does not exceed root hop's max_delegation_depth.
+      - No hop carries a non-empty ``constraints`` array, since this verifier
+        does not implement Cedar and cannot evaluate what such constraints
+        actually permit (spec 3.4.1 / 5.2). Structural scope-narrowing on the
+        constraint *strings* (see ``_check_scope_narrowing``) is still
+        enforced first and can independently fail the chain with
+        ``ValueError``; only a chain that is otherwise fully valid raises
+        ``DelegationUnverifiable`` for the unresolved constraints.
 
     Args:
         delegation_chain: List of hop dicts from the manifest.
@@ -245,6 +272,10 @@ def verify_delegation_chain(
     Raises:
         InvalidSignature: If any hop signature is invalid.
         ValueError: If scope laundering is detected or chain is malformed.
+        DelegationUnverifiable: If every other check passes but one or more
+            hops carry a non-empty ``constraints`` array that this verifier
+            cannot parse/evaluate as Cedar. Callers MUST map this to
+            ``UNVERIFIABLE``, never ``VALID`` (spec 3.4.1 / 5.2).
     """
     if not isinstance(delegation_chain, list):
         raise ValueError(
@@ -285,9 +316,55 @@ def verify_delegation_chain(
             f"Delegation chain depth {len(delegation_chain) - 1} exceeds "
             f"root max_delegation_depth {root_max_depth}"
         )
+    # Verify every hop's signature and scope narrowing, in order. This is a
+    # plain function call, not inlined here, so that what happens once it
+    # returns is unambiguous even from a diff: _verify_hops raises
+    # InvalidSignature/ValueError the moment ANY hop fails (a later hop's
+    # cryptographic or structural failure is checked and raised regardless
+    # of what an earlier hop's scope_grant contained), and only *returns* a
+    # value - never raises - to report hops with unresolved Cedar
+    # constraints. The line below is reached, and DelegationUnverifiable can
+    # only be raised, once the entire chain has already passed every other
+    # check.
+    unverifiable_constraint_hops = _verify_hops(
+        delegation_chain, public_keys, manifest_id
+    )
+
+    if unverifiable_constraint_hops:
+        raise DelegationUnverifiable(
+            "Delegation chain has non-empty Cedar scope_grant.constraints at "
+            f"hop(s) {unverifiable_constraint_hops}, and this verifier does "
+            "not implement Cedar parsing/evaluation. Per spec 3.4.1 / 5.2 "
+            "this chain MUST be reported as UNVERIFIABLE, not VALID."
+        )
+
+
+def _verify_hops(
+    delegation_chain: list[dict[str, Any]],
+    public_keys: dict[str, bytes],
+    manifest_id: str,
+) -> list[int]:
+    """Check every hop's signature and scope narrowing; report unresolved Cedar.
+
+    Raises ``InvalidSignature`` or ``ValueError`` immediately - and always
+    propagates out of this function without returning - the moment any hop
+    fails a check, regardless of position in the chain and regardless of
+    what any other hop's ``scope_grant.constraints`` contains. A hop with
+    non-empty constraints never causes a later hop's failure to be skipped:
+    every hop up to and including the failing one is still fully checked in
+    order first.
+
+    Returns (rather than raises) the list of hop indices whose scope_grant
+    carried a non-empty ``constraints`` array - Cedar statements this
+    verifier does not parse or evaluate (spec 3.4.1 / 5.2) - and only does
+    so once every hop in the chain has been checked without a failure.
+    ``verify_delegation_chain`` decides whether to raise
+    ``DelegationUnverifiable`` from that list.
+    """
 
     prev_scope: dict[str, Any] | None = None
     prev_delegated_at: str | None = None
+    unverifiable_constraint_hops: list[int] = []
 
     for i, hop in enumerate(delegation_chain):
         if i:
@@ -330,8 +407,20 @@ def verify_delegation_chain(
                 child_delegated_at=delegated_at,
             )
 
+        # Cedar constraints present at this hop. The narrowing check above
+        # only compares the constraint *strings* structurally (child must
+        # keep every parent string); it never parses or evaluates what the
+        # Cedar statement actually permits. Recording this here, rather than
+        # raising immediately, lets later hops still fail closed with the
+        # more specific ValueError/InvalidSignature they'd otherwise raise -
+        # this function only returns this list; it never raises for it.
+        if scope.get("constraints"):
+            unverifiable_constraint_hops.append(i)
+
         prev_scope = scope
         prev_delegated_at = delegated_at
+
+    return unverifiable_constraint_hops
 
 
 def _parse_delegated_at(value: str) -> datetime:

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -709,6 +709,10 @@ def verify_manifest(
     - A delegation chain that cannot be verified (no
       ``delegation_public_keys``) is marked ``UNVERIFIABLE`` and the overall
       result is ``UNVERIFIABLE`` (spec 3.4.1 / 5.2).
+    - A delegation chain that verifies signatures and scope narrowing but
+      carries a non-empty ``scope_grant.constraints`` (a Cedar statement this
+      verifier does not parse or evaluate) is also marked ``UNVERIFIABLE``,
+      not ``VALID`` (spec 3.4.1 / 5.2).
     - ``enforce_hitl=True`` with no ``hitl_record`` in the manifest is a
       failure (``HitlResult.MISSING`` and a non-VALID overall result).
     - An approval is never ``APPROVED`` unless its own signature verifies with
@@ -1140,7 +1144,7 @@ def verify_manifest(
     if chain:
         if context.delegation_public_keys:
             try:
-                from ._delegation import verify_delegation_chain
+                from ._delegation import DelegationUnverifiable, verify_delegation_chain
                 from ._signing import _b64url_decode
                 pub_keys = {
                     pid: _b64url_decode(b64)
@@ -1153,6 +1157,12 @@ def verify_manifest(
                     chain, pub_keys, manifest_id, manifest_issuer=manifest_issuer
                 )
                 fields.delegation_chain = DelegationResult.VALID
+            except DelegationUnverifiable:
+                # Spec 3.4.1 / 5.2: the chain is structurally and
+                # cryptographically sound, but carries non-empty Cedar
+                # scope_grant.constraints this verifier cannot parse or
+                # evaluate. This MUST NOT be reported as VALID.
+                fields.delegation_chain = DelegationResult.UNVERIFIABLE
             except (InvalidSignature, ValueError) as e:
                 fields.delegation_chain = DelegationResult.INVALID
                 mismatches.append(MismatchDetail(

--- a/python/tests/test_delegation_hitl.py
+++ b/python/tests/test_delegation_hitl.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from agent_manifest._delegation import (
     DelegationHopSigner,
+    DelegationUnverifiable,
     HitlApprovalSigner,
     _approval_pre_image,
     _hop_pre_image,
@@ -218,12 +219,144 @@ def test_child_dropping_parent_constraint_is_rejected():
 
 
 def test_child_adding_constraint_is_allowed():
+    # Structural narrowing (child keeps every parent constraint string, only
+    # adds more) is satisfied here - it must not raise ValueError. But the
+    # constraints are still non-empty Cedar statements this verifier cannot
+    # parse/evaluate, so the chain as a whole is DelegationUnverifiable, not
+    # silently valid (spec 3.4.1 / 5.2).
     root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
             "constraints": ["region==eu"]}
     child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
              "constraints": ["region==eu", "amount<100"]}  # added, superset
     chain, keys = _two_hop_chain(root, child)
-    verify_delegation_chain(chain, keys, MID)  # must not raise
+    with pytest.raises(DelegationUnverifiable):
+        verify_delegation_chain(chain, keys, MID)
+
+
+# ---------------------------------------------------------------------------
+# Cedar constraints are UNVERIFIABLE, not VALID (this verifier has no Cedar
+# parser/evaluator - see DelegationUnverifiable's docstring and spec 3.4.1/5.2)
+# ---------------------------------------------------------------------------
+
+
+def test_matching_malformed_constraints_are_unverifiable_not_valid():
+    """The reported bug, reproduced directly against verify_delegation_chain:
+    parent and child both carry the identical, non-Cedar, unparseable
+    constraint string. Nothing is "dropped" so the structural narrowing
+    check is satisfied, and both signatures are valid - but the chain must
+    still not verify as VALID (i.e. return normally), because the
+    constraint itself was never evaluated.
+    """
+    malformed = ["this is not Cedar at all"]
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
+            "constraints": malformed}
+    child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
+             "constraints": list(malformed)}  # identical, nothing dropped
+    chain, keys = _two_hop_chain(root, child)
+    with pytest.raises(DelegationUnverifiable):
+        verify_delegation_chain(chain, keys, MID)
+
+
+def test_single_hop_chain_with_constraints_is_unverifiable():
+    """A root-only chain (no narrowing to check at all) still must not
+    verify when its own constraints are non-empty and unevaluated."""
+    kp = generate_ed25519()
+    scope = {"tools": [], "constraints": ["permit(principal, action, resource)"]}
+    sig = DelegationHopSigner(kp).sign_hop(
+        hop=0, principal_id="spiffe://x/root", principal_type="human",
+        delegated_at=NOW, scope_grant=scope, manifest_id=MID,
+    )
+    chain = [{"hop": 0, "principal_id": "spiffe://x/root", "principal_type": "human",
+              "delegated_at": NOW, "scope_grant": scope, "delegation_signature": sig}]
+    with pytest.raises(DelegationUnverifiable):
+        verify_delegation_chain(chain, {"spiffe://x/root": kp.public_bytes}, MID)
+
+
+def test_scope_laundering_takes_priority_over_unverifiable_constraints():
+    """A chain that is both scope-laundered AND carries unresolved Cedar
+    constraints must raise the more specific ValueError (INVALID), not the
+    weaker DelegationUnverifiable - an affirmatively broken chain must never
+    be softened to merely "can't tell"."""
+    root = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
+            "constraints": ["region==eu", "amount<1000"]}
+    child = {"tools": ["t"], "max_delegation_depth": 3, "ttl_seconds": 3600,
+             "constraints": ["region==eu"]}  # dropped amount<1000 (laundering)
+    chain, keys = _two_hop_chain(root, child)
+    with pytest.raises(ValueError, match="drops parent constraints"):
+        verify_delegation_chain(chain, keys, MID)
+
+
+def _two_hop_chain_distinct_signers(root_scope, child_scope, *, corrupt_child_key=False):
+    """Like ``_two_hop_chain``, but returns keys that let a caller register
+    the *wrong* public key for the child principal, to simulate a hop with
+    an invalid signature."""
+    kp_root, kp_child = generate_ed25519(), generate_ed25519()
+    sig0 = DelegationHopSigner(kp_root).sign_hop(
+        hop=0, principal_id="spiffe://x/root", principal_type="human",
+        delegated_at=NOW, scope_grant=root_scope, manifest_id=MID,
+    )
+    sig1 = DelegationHopSigner(kp_child).sign_hop(
+        hop=1, principal_id="spiffe://x/child", principal_type="agent",
+        delegated_at=NOW, scope_grant=child_scope, manifest_id=MID,
+    )
+    chain = [
+        {"hop": 0, "principal_id": "spiffe://x/root", "principal_type": "human",
+         "delegated_at": NOW, "scope_grant": root_scope, "delegation_signature": sig0},
+        {"hop": 1, "principal_id": "spiffe://x/child", "principal_type": "agent",
+         "delegated_at": NOW, "scope_grant": child_scope, "delegation_signature": sig1},
+    ]
+    child_key = generate_ed25519().public_bytes if corrupt_child_key else kp_child.public_bytes
+    keys = {"spiffe://x/root": kp_root.public_bytes, "spiffe://x/child": child_key}
+    return chain, keys
+
+
+def test_later_invalid_signature_is_not_masked_by_earlier_constrained_hop():
+    """Root hop 0 is fully valid and carries a non-empty (unresolved) Cedar
+    constraint. Hop 1's signature does not verify against the key registered
+    for its principal. The chain must fail with InvalidSignature - the
+    hop-0 constraint must never cause hop 1's own failure to be swallowed
+    into DelegationUnverifiable."""
+    root = {"tools": ["t"], "constraints": ["permit(principal, action, resource)"]}
+    child = {"tools": ["t"], "constraints": ["permit(principal, action, resource)"]}
+    chain, keys = _two_hop_chain_distinct_signers(root, child, corrupt_child_key=True)
+    with pytest.raises(InvalidSignature):
+        verify_delegation_chain(chain, keys, MID)
+
+
+def test_later_malformed_hop_is_not_masked_by_earlier_constrained_hop():
+    """Root hop 0 is fully valid and carries a non-empty (unresolved) Cedar
+    constraint. Hop 1 is structurally malformed (missing a required field).
+    The chain must fail with ValueError naming the missing field - not
+    DelegationUnverifiable."""
+    root = {"tools": ["t"], "constraints": ["permit(principal, action, resource)"]}
+    kp_root = generate_ed25519()
+    sig0 = DelegationHopSigner(kp_root).sign_hop(
+        hop=0, principal_id="spiffe://x/root", principal_type="human",
+        delegated_at=NOW, scope_grant=root, manifest_id=MID,
+    )
+    chain = [
+        {"hop": 0, "principal_id": "spiffe://x/root", "principal_type": "human",
+         "delegated_at": NOW, "scope_grant": root, "delegation_signature": sig0},
+        # Hop 1 is missing "delegation_signature" entirely.
+        {"hop": 1, "principal_id": "spiffe://x/child", "principal_type": "agent",
+         "delegated_at": NOW, "scope_grant": {"tools": ["t"]}},
+    ]
+    keys = {"spiffe://x/root": kp_root.public_bytes,
+            "spiffe://x/child": generate_ed25519().public_bytes}
+    with pytest.raises(ValueError, match="missing required fields"):
+        verify_delegation_chain(chain, keys, MID)
+
+
+def test_later_scope_laundering_is_not_masked_by_earlier_constrained_hop():
+    """Root hop 0 is fully valid and carries a non-empty (unresolved) Cedar
+    constraint. Hop 1 launders scope (claims a tool the parent didn't grant).
+    The chain must fail with ValueError naming the laundering - not
+    DelegationUnverifiable."""
+    root = {"tools": ["t"], "constraints": ["permit(principal, action, resource)"]}
+    child = {"tools": ["t", "extra-tool"], "constraints": ["permit(principal, action, resource)"]}
+    chain, keys = _two_hop_chain_distinct_signers(root, child)
+    with pytest.raises(ValueError, match="Scope laundering at hop 1"):
+        verify_delegation_chain(chain, keys, MID)
 
 
 def test_child_raising_ttl_is_rejected():

--- a/python/tests/test_verify_delegation.py
+++ b/python/tests/test_verify_delegation.py
@@ -213,6 +213,157 @@ def test_chain_without_keys_is_unverifiable():
     assert result.result == OverallResult.UNVERIFIABLE
 
 
+def test_chain_with_cedar_constraints_is_unverifiable_not_valid():
+    """Spec 3.4.1 / 5.2: a non-empty scope_grant.constraints array is a Cedar
+    statement. A verifier without Cedar support MUST report UNVERIFIABLE,
+    never VALID - even when signatures verify and every other check
+    (structural narrowing on the constraint strings, tools, ttl, depth)
+    passes. This is a single-hop chain, so it isolates the constraints
+    themselves as the only unresolved element.
+    """
+    kp = generate_ed25519()
+    pid = AGENT_ID
+    scope = {**SCOPE, "constraints": ["permit(principal, action, resource)"]}
+    sig = DelegationHopSigner(kp).sign_hop(
+        hop=0, principal_id=pid, principal_type="agent",
+        delegated_at=NOW, scope_grant=scope, manifest_id=MID,
+    )
+    chain = [{
+        "hop": 0, "principal_id": pid, "principal_type": "agent",
+        "delegated_at": NOW, "scope_grant": scope, "delegation_signature": sig,
+    }]
+    m = base_manifest(delegation_chain=chain)
+    ctx = base_context(delegation_public_keys={pid: kp.public_b64url()})
+    result = verify_manifest(m, ctx, store())
+    assert result.fields_verified.delegation_chain == DelegationResult.UNVERIFIABLE
+    assert result.result == OverallResult.UNVERIFIABLE
+    # And specifically not the two other buckets a naive fix might collapse
+    # this into:
+    assert result.fields_verified.delegation_chain != DelegationResult.VALID
+    assert result.fields_verified.delegation_chain != DelegationResult.INVALID
+
+
+def test_chain_with_malformed_non_cedar_constraints_is_unverifiable_not_valid():
+    """The exact reported bug: parent and child carry the *same*, nonsensical,
+    non-Cedar string in ``constraints``. Structural narrowing sees no dropped
+    constraint (parent set == child set) and the signatures are valid, so the
+    old implementation returned VALID. It must return UNVERIFIABLE instead,
+    since this verifier can neither parse nor evaluate the statement.
+    """
+    root_kp = generate_ed25519()
+    child_kp = generate_ed25519()
+    root_pid = AGENT_ID
+    child_pid = "spiffe://trust.example/sub"
+    malformed_scope = {**SCOPE, "constraints": ["this is not Cedar at all"]}
+
+    root_sig = DelegationHopSigner(root_kp).sign_hop(
+        hop=0, principal_id=root_pid, principal_type="human",
+        delegated_at=NOW, scope_grant=malformed_scope, manifest_id=MID,
+    )
+    child_sig = DelegationHopSigner(child_kp).sign_hop(
+        hop=1, principal_id=child_pid, principal_type="agent",
+        delegated_at=NOW, scope_grant=malformed_scope, manifest_id=MID,
+    )
+    chain = [
+        {"hop": 0, "principal_id": root_pid, "principal_type": "human",
+         "delegated_at": NOW, "scope_grant": malformed_scope,
+         "delegation_signature": root_sig},
+        {"hop": 1, "principal_id": child_pid, "principal_type": "agent",
+         "delegated_at": NOW, "scope_grant": malformed_scope,
+         "delegation_signature": child_sig},
+    ]
+    m = base_manifest(delegation_chain=chain)
+    ctx = base_context(delegation_public_keys={
+        root_pid: root_kp.public_b64url(),
+        child_pid: child_kp.public_b64url(),
+    })
+    result = verify_manifest(m, ctx, store())
+    assert result.fields_verified.delegation_chain == DelegationResult.UNVERIFIABLE
+    assert result.result == OverallResult.UNVERIFIABLE
+
+
+def test_chain_empty_constraints_still_valid():
+    """Sanity check: the fix must not regress the common case. An empty (or
+    absent) constraints array carries nothing to evaluate, so it stays VALID
+    exactly as before.
+    """
+    kp = generate_ed25519()
+    pid = AGENT_ID
+    chain = _make_chain(kp, principal_id=pid)  # SCOPE has "constraints": []
+    m = base_manifest(delegation_chain=chain)
+    ctx = base_context(delegation_public_keys={pid: kp.public_b64url()})
+    result = verify_manifest(m, ctx, store())
+    assert result.fields_verified.delegation_chain == DelegationResult.VALID
+    assert result.result == OverallResult.VALID
+
+def test_invalid_signature_with_constraints_is_invalid_not_unverifiable():
+    """A chain that is both cryptographically broken AND carries unresolved
+    Cedar constraints must report the more specific INVALID (bad signature),
+    not UNVERIFIABLE. Constraint-unverifiability must never mask an
+    outright-broken chain.
+    """
+    kp = generate_ed25519()
+    wrong_kp = generate_ed25519()  # signature will be checked against this key
+    pid = AGENT_ID
+    scope = {**SCOPE, "constraints": ["permit(principal, action, resource)"]}
+    sig = DelegationHopSigner(kp).sign_hop(
+        hop=0, principal_id=pid, principal_type="agent",
+        delegated_at=NOW, scope_grant=scope, manifest_id=MID,
+    )
+    chain = [{
+        "hop": 0, "principal_id": pid, "principal_type": "agent",
+        "delegated_at": NOW, "scope_grant": scope, "delegation_signature": sig,
+    }]
+    m = base_manifest(delegation_chain=chain)
+    ctx = base_context(delegation_public_keys={pid: wrong_kp.public_b64url()})
+    result = verify_manifest(m, ctx, store())
+    assert result.fields_verified.delegation_chain == DelegationResult.INVALID
+    assert result.result != OverallResult.VALID
+
+
+def test_later_hop_invalid_signature_after_valid_constrained_root_is_invalid():
+    """End-to-end regression for the reviewer's exact scenario: a valid,
+    constrained root hop (hop 0) followed by a hop (hop 1) whose signature
+    does not verify. The root's unresolved Cedar constraint must not mask
+    hop 1's own signature failure - the overall result must be INVALID
+    (from the bad signature), never UNVERIFIABLE.
+    """
+    root_kp = generate_ed25519()
+    child_kp = generate_ed25519()
+    wrong_child_kp = generate_ed25519()  # registered instead of child_kp
+    root_pid = AGENT_ID
+    child_pid = "spiffe://trust.example/sub"
+    constrained_scope = {**SCOPE, "constraints": ["permit(principal, action, resource)"]}
+
+    root_sig = DelegationHopSigner(root_kp).sign_hop(
+        hop=0, principal_id=root_pid, principal_type="human",
+        delegated_at=NOW, scope_grant=constrained_scope, manifest_id=MID,
+    )
+    child_sig = DelegationHopSigner(child_kp).sign_hop(
+        hop=1, principal_id=child_pid, principal_type="agent",
+        delegated_at=NOW, scope_grant=constrained_scope, manifest_id=MID,
+    )
+    chain = [
+        {"hop": 0, "principal_id": root_pid, "principal_type": "human",
+         "delegated_at": NOW, "scope_grant": constrained_scope,
+         "delegation_signature": root_sig},
+        {"hop": 1, "principal_id": child_pid, "principal_type": "agent",
+         "delegated_at": NOW, "scope_grant": constrained_scope,
+         "delegation_signature": child_sig},
+    ]
+    m = base_manifest(delegation_chain=chain)
+    ctx = base_context(delegation_public_keys={
+        root_pid: root_kp.public_b64url(),
+        # Wrong key registered for the child principal -> hop 1 signature
+        # verification must fail.
+        child_pid: wrong_child_kp.public_b64url(),
+    })
+    result = verify_manifest(m, ctx, store())
+    assert result.fields_verified.delegation_chain == DelegationResult.INVALID
+    assert result.result != OverallResult.UNVERIFIABLE
+    assert result.result != OverallResult.VALID
+
+
 # ---------------------------------------------------------------------------
 # INVALID - bad signature surfaces as MISMATCH
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`verify_delegation_chain()` no longer returns `VALID` when a hop has non-empty `scope_grant.constraints` it now raises `DelegationUnverifiable`, which `verify_manifest()` maps to UNVERIFIABLE.

## Why

Constraints are Cedar statements (spec 3.4.1), and this package has no Cedar parser/evaluator. `_check_scope_narrowing()` only did a string-set diff between parent and child constraints, so two hops carrying the exact same unparseable garbage string (nothing "dropped") verified as `VALID` end to end. Spec 3.4.1 / 5.2 explicitly require `UNVERIFIABLE` in this case, never `VALID`.

## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [ ] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
