### PR TITLE
ci: add actionlint and a test-environment guard

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,41 @@
+name: Workflow lint
+
+# actionlint catches what a YAML parser cannot: duplicate mapping keys that
+# make GitHub refuse to load a workflow, invalid ${{ }} expressions, and shell
+# problems inside run: blocks. A duplicate env: key silently broke this repo
+# family's release workflow once; yaml.safe_load keeps the last value without
+# complaining, so local validation passed while Actions rejected the file.
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**']
+  pull_request:
+    paths: ['.github/workflows/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Fetched and checksum-verified rather than run as a third-party action,
+      # so this check adds no new action to the supply chain it exists to guard.
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "$archive" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+
+      - name: Lint workflows
+        run: actionlint -color

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,74 @@
+"""Pytest configuration for this suite.
+
+Guards a silent failure mode rather than testing anything itself.
+
+pytest puts the source tree on the path, so an in-process import always finds
+this tree. A test that shells out does not get that: a plain
+``subprocess.run([sys.executable, ...])`` resolves the distribution the normal
+way, and with a released wheel also installed it finds site-packages. The
+subprocess then exercises a published version while the suite reports a pass,
+which is how a tutorial test in this repo family graded against an old schema
+and looked green.
+
+CI installs the package editable, so the subprocess resolves back into the tree
+and this check is a no-op there. Locally it turns a wrong answer into a loud one.
+
+A package that is not importable from a subprocess at all is fine: that is the
+path-only setup, not a shadowing install, and the suite still runs.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+#: Packages this suite is meant to exercise from source.
+_PACKAGES_UNDER_TEST = ("agent_manifest",)
+
+#: Repository root, resolved from this file.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+_PROBE = textwrap.dedent(
+    """
+    import importlib, sys
+    try:
+        m = importlib.import_module(sys.argv[1])
+    except Exception:
+        print("")
+    else:
+        print(getattr(m, "__file__", "") or "")
+    """
+)
+
+
+def _subprocess_origin(package: str) -> pathlib.Path | None:
+    """Where a fresh interpreter finds ``package``, or None if it cannot."""
+    try:
+        done = subprocess.run(
+            [sys.executable, "-c", _PROBE, package],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    origin = done.stdout.strip()
+    return pathlib.Path(origin).resolve() if origin else None
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    for name in _PACKAGES_UNDER_TEST:
+        origin = _subprocess_origin(name)
+        if origin is None:
+            continue  # not importable from a subprocess; nothing can shadow
+        if _REPO_ROOT not in origin.parents:
+            raise pytest.UsageError(
+                f"{name} resolves to {origin} in a subprocess, outside "
+                f"{_REPO_ROOT}. Any test that shells out would exercise that "
+                "installed distribution instead of this working tree. Install "
+                f"editable (pip install -e .) or uninstall the shadowing {name}."
+            )

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -53,6 +53,7 @@ def _subprocess_origin(package: str) -> pathlib.Path | None:
             capture_output=True,
             text=True,
             timeout=60,
+            check=False,  # a non-zero exit just means "cannot import", handled below
         )
     except (OSError, subprocess.SubprocessError):
         return None


### PR DESCRIPTION
Two guardrails, each for a silent failure that actually happened during this security sweep.

## 1. actionlint

I introduced a duplicate `env:` key in cmcp's `release.yml` while hardening tag interpolation. GitHub Actions refuses to load a workflow with a duplicate key, reported it as a "workflow file issue" on unrelated pushes, ran nothing for the release event, and left a version unpublished for hours.

It got through because `yaml.safe_load` keeps the last value for a duplicate key without complaining. actionlint says it plainly:

```
.github/workflows/repro.yml:16:9: key "env" is duplicated in element of "steps" section.
previously defined at line:13,col:9 [syntax-check]
```

Verified against a reproduction of the exact broken file before adding it.

**On how it's installed:** fetched by pinned version with a checksum verification, not run as a third-party action. actionlint publishes no official action, and a check whose whole purpose is guarding the workflow supply chain should not add a new dependency to it.

Triggered only on changes under `.github/workflows`, so it costs nothing on ordinary PRs. **Every repo in the org is clean against it today**, so this adds no backlog.

## 2. Test-environment guard

pytest puts the source tree on the path, so an in-process import always finds this tree and looks right. A test that shells out gets no such help: `subprocess.run([sys.executable, ...])` resolves the distribution normally, and with a released wheel also installed it finds site-packages.

The subprocess then exercises a **published version** while the suite reports a pass. That is exactly how `trace-spec`'s tutorial test graded against the previous schema and still looked green, and why `cmcp`'s distribution smoke test reported a version that had nothing to do with the tree.

The guard probes a subprocess once per session and fails with an actionable message:

```
ERROR: agentrust_trace resolves to ...\site-packages\agentrust_trace\__init__.py
in a subprocess, outside C:\Users\imran\source\trace-spec. Any test that shells
out would exercise that installed distribution instead of this working tree.
Install editable (pip install -e .) or uninstall the shadowing agentrust_trace.
```

**It is a no-op in CI**, which installs editable, and verified as such against a correctly configured local venv. A package that is not importable from a subprocess at all is deliberately allowed: that is a path-only setup, not a shadowing install, so nobody gets locked out of running the suite.

Applied to the seven repos that install their own package editable in CI. `examples`, `integrations` and `demos` test against third-party distributions on purpose and get actionlint only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
