### PR TITLE
fix(deps): raise docs tooling past known advisories

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,7 @@
 mkdocs>=1.6
-mkdocs-material>=9.5
+mkdocs-material>=9.7.7
 mkdocs-minify-plugin>=0.8
-pymdown-extensions>=10.7
+pymdown-extensions>=11.0.2
 mkdocstrings[python]>=0.25
 griffe>=0.47
 mkdocs-llmstxt>=0.2


### PR DESCRIPTION
Closes the five advisories OpenSSF Scorecard reports against this repo. Dependabot reports nothing here because these are open version ranges in `requirements-docs.txt` rather than a lockfile it tracks, so they never surfaced as alerts.

| Advisory | Package | Fixed in |
|---|---|---|
| GHSA-xvg9-69gf-fjrf | mkdocs-material | 9.7.7 |
| PYSEC-2026-3609 | pymdown-extensions | 11.0.0 |
| PYSEC-2026-3654 | pymdown-extensions | 11.0.1 |
| PYSEC-2026-2999 | pymdown-extensions | 10.21.3 |
| PYSEC-2026-1825 | pymdown-extensions | 10.16.1 |

The mkdocs-material one is worth calling out: it is a **DOM XSS in search suggestions reachable through a query parameter**, so it lands on the published docs site rather than only the build. The pymdown-extensions set is a path traversal in the b64 extension letting an `<img src>` read outside `base_path`, a sibling-prefix traversal regression that defeats `restrict_base_path`, and exponential-backtracking ReDoS in several inline processors.

Floors go to `mkdocs-material>=9.7.7` and `pymdown-extensions>=11.0.2`, which are the current releases and the floors `ca2a`, `trace-spec` and `trace-tests` already use. This repo and `cmcp` were the two left behind.

Docs tooling only. Nothing here reaches the shipped package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t