### PR TITLE
fix: recognize announced repository maintainers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for everything
-* @agentrust-io/maintainers
+* @agentrust-io/maintainers @carloshvp @zohebk8s
 
 # Spec changes require spec-editor review
 /spec/ @agentrust-io/spec-editors
@@ -8,4 +8,4 @@
 /python/ @agentrust-io/sdk-maintainers
 
 # CI changes require maintainer review
-/.github/ @agentrust-io/maintainers
+/.github/ @agentrust-io/maintainers @carloshvp @zohebk8s

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,3 +23,12 @@ Affiliations identify a maintainer's project context; they do not give an affili
 Maintainers who step back from active review are listed here with thanks.
 
 _(none yet)_
+
+## Repository Maintainers
+
+| Name | GitHub | Appointment |
+|---|---|---|
+| Carlos Hernandez | [@carloshvp](https://github.com/carloshvp) | [Project Lead announcement](https://github.com/orgs/agentrust-io/discussions/20) |
+| Zoheb | [@zohebk8s](https://github.com/zohebk8s) | [Project Lead announcement](https://github.com/orgs/agentrust-io/discussions/31) |
+
+These appointments cover this repository. CODEOWNERS determines which paths each reviewer can approve for protected merges.


### PR DESCRIPTION
## What this changes

The announced maintainers (@carloshvp, @zohebk8s) already have active Maintain access and appear in the approval workflow, but CODEOWNERS excludes them. Add them alongside existing repository owners and record their appointments in MAINTAINERS.md. The existing spec-editor and SDK-maintainer rules remain in force for `/spec/` and `/python/`.

The change is confined to agent-manifest; it grants no organization-team membership and changes no branch rules. Existing owners remain on every rule.

## Type of change

Repository ownership and maintainer documentation; no runtime or normative specification change.

## Security impact

Adds the announced repository maintainers as eligible code-owner reviewers, including existing general-maintainer alternatives on security-sensitive paths. Preserves current owners and review counts.

## Validation

- Rechecked each appointee's active Maintain role through GitHub's permissions API.
- Checked the existing approval workflow and all ownership patterns, including overriding paths.
- `git diff --check` passed. No runtime tests were run locally because no runtime code changed.

## Checklist

- [x] DCO sign-off on the commit.
- CHANGELOG, spec sections, and breaking-change requirements: not applicable.
