### PR TITLE
Fix: Bound POST /verify (JSON) body size and field cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,43 @@
   and `attach_unprotected()` converts any residual `CBOREncodeError` to
   `CoseStructureError` as a second layer.
 
+- **[SECURITY][SDK]** `POST /verify` (JSON) had no body-size or field-cardinality
+  cap, unlike `POST /verify/cose` (issue #383). `verify_cose` bounds the CBOR
+  body against `Content-Length` and then against the actual byte stream
+  before parsing it ("`Content-Length` is a claim, not a guarantee"), but
+  `verify_post` took a `VerifyRequest` Pydantic model directly, so FastAPI
+  fully buffered and validated an arbitrarily large JSON body - e.g. a
+  `trusted_keys` dict with millions of entries - before `verify_manifest`
+  ever ran. `verify_post` now takes the raw request, stream-caps the body at
+  `MAX_VERIFY_BODY_BYTES` (the renamed, now endpoint-neutral
+  `MAX_COSE_ENVELOPE_BYTES`, 1 MiB, shared by both `/verify` routes) before
+  handing the bytes to `VerifyRequest.model_validate_json()`, and returns
+  `413 VERIFY_REQUEST_TOO_LARGE` over the limit, mirroring `ENVELOPE_TOO_LARGE`.
+  `VerifyRequest`'s seven dict/set fields (`trusted_keys`, `trusted_key_issuers`,
+  `delegation_public_keys`, `approver_public_keys`,
+  `verified_transparency_entry_ids`, `verified_transparency_receipt_hashes`,
+  `verified_attestation_manifest_hashes` - the last of which the original
+  report's field list omitted, but which has the identical unbounded
+  `set[str]` shape and reaches `VerificationContext` the same way)
+  now also reject more than `MAX_VERIFY_COLLECTION_ENTRIES` (10,000) entries,
+  which catches a small body hiding an oversized collection behind short
+  keys/values that a byte cap alone could miss. `GET /verify` is unaffected;
+  it takes no body. Taking a raw `Request` instead of a `VerifyRequest`
+  parameter also meant FastAPI's own automatic `Content-Type` gate no
+  longer ran for this route, so `verify_post` would parse a JSON body
+  submitted under any (or no) `Content-Type` - `text/plain`, a bogus
+  subtype, form-encoded - contradicting the `application/json`-only
+  contract the endpoint's own OpenAPI schema advertises. `verify_post` now
+  checks `Content-Type` explicitly, using the same rule FastAPI itself uses
+  for a Pydantic-model body parameter (`application/json`, a `+json`
+  vendor subtype, or no header at all; anything else is `415
+  UNSUPPORTED_MEDIA_TYPE`), before the body is read. Separately, both
+  `verify_post` and `verify_cose` checked the accumulated body against
+  `MAX_VERIFY_BODY_BYTES` *after* appending each stream chunk rather than
+  before, so the buffer could be grown past the cap by up to one chunk's
+  size before being rejected; both now check before appending, so the
+  buffer itself is never intentionally grown past the limit.
+
 - **[SECURITY][SDK]** `_strict_schema_violations()` tolerated a missing
   top-level `issuer` claim for **any** manifest version, not just v0.1. The
   exception was added for legacy v0.1 records, which predate the `issuer`

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -13,6 +13,7 @@ The FastAPI router wires the engine to HTTP.
 """
 from __future__ import annotations
 
+import email.message
 import hashlib
 import hmac
 import uuid
@@ -20,7 +21,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable, Optional, Union
 
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, Field, TypeAdapter, field_validator
 
 from ._audit_continuity import AuditCheckpoint, verify_continuity
 from ._cose import (
@@ -253,6 +254,40 @@ class VerifyRequest(BaseModel):
     require_transparency: bool = False
     # When True, a manifest without a delegation_chain is a verification failure
     require_delegation: bool = False
+
+    # These seven fields exist to hold key/id material for the hops,
+    # approvers, and keys actually referenced by *one* manifest - never more
+    # than a handful in practice. Without a ceiling, a caller can hand this
+    # endpoint a small request body containing a dict/set with millions of
+    # short entries and force it to be fully buffered and validated before
+    # verify_manifest ever runs. A byte cap on the raw request body
+    # (MAX_VERIFY_BODY_BYTES, enforced in create_router's verify_post) catches
+    # large bodies; this catches the same attack shape hiding behind short
+    # keys/values in a small body.
+    #
+    # verified_attestation_manifest_hashes is the same set[str] shape as
+    # verified_transparency_entry_ids / verified_transparency_receipt_hashes
+    # immediately above it and reaches VerificationContext via the identical
+    # path in verify_post below - it is included here even though the
+    # upstream issue report's field list omitted it, since leaving it out
+    # would just hand an attacker an uncapped field to use instead of the
+    # six named ones.
+    @field_validator(
+        "trusted_keys",
+        "trusted_key_issuers",
+        "delegation_public_keys",
+        "approver_public_keys",
+        "verified_transparency_entry_ids",
+        "verified_transparency_receipt_hashes",
+        "verified_attestation_manifest_hashes",
+    )
+    @classmethod
+    def _cap_collection_size(cls, v: Any) -> Any:
+        if len(v) > MAX_VERIFY_COLLECTION_ENTRIES:
+            raise ValueError(
+                f"exceeds {MAX_VERIFY_COLLECTION_ENTRIES}-entry limit"
+            )
+        return v
 
 
 # ---------------------------------------------------------------------------
@@ -1628,8 +1663,21 @@ class RevocationStore:
 # A manifest is a few kilobytes (envelope spec section 4, which cites size as
 # the reason payloads are inline rather than detached). The cap is generous
 # against that and small enough that a body is bounded before anything parses
-# it - the decoder is never handed an unbounded allocation.
-MAX_COSE_ENVELOPE_BYTES = 1 << 20  # 1 MiB
+# it - the decoder is never handed an unbounded allocation. Shared by both
+# POST /verify (JSON) and POST /verify/cose (CBOR) so the two routes carry the
+# same defense-in-depth posture; it was named MAX_COSE_ENVELOPE_BYTES when
+# only the COSE endpoint enforced it.
+MAX_VERIFY_BODY_BYTES = 1 << 20  # 1 MiB
+
+# Ceiling on entry count for each of VerifyRequest's dict/set fields
+# (trusted_keys, trusted_key_issuers, delegation_public_keys,
+# approver_public_keys, verified_transparency_entry_ids,
+# verified_transparency_receipt_hashes, verified_attestation_manifest_hashes).
+# Far above what any real deployment needs - these maps exist to hold keys
+# for the hops/approvers/keys actually referenced by one manifest - and
+# catches a small-request-with-huge-collection case that the byte cap alone
+# might miss if someone sends short key strings.
+MAX_VERIFY_COLLECTION_ENTRIES = 10_000
 
 
 def create_router(
@@ -1704,8 +1752,22 @@ def create_router(
         )
         return verify_manifest(manifest, ctx, revocation_store)
 
-    @router.post("/verify", response_model=VerificationResult)
-    async def verify_post(request: VerifyRequest) -> VerificationResult:
+    # `verify_post` takes a raw `Request` (not `VerifyRequest`) so the body can
+    # be stream-capped before Pydantic parses it - see below. That means
+    # FastAPI can no longer *infer* the request body schema from the
+    # parameter type the way it does for a normal Pydantic-model parameter,
+    # so the OpenAPI/Swagger docs would otherwise show no body schema at all
+    # for this route. `openapi_extra` restores it explicitly from the same
+    # `VerifyRequest` model actually used to validate the body, so the
+    # documented contract for callers and codegen tools is unchanged.
+    _verify_post_openapi_extra = {
+        "requestBody": {
+            "required": True,
+            "content": {"application/json": {"schema": VerifyRequest.model_json_schema()}},
+        }
+    }
+
+    async def verify_post(request: "Request") -> VerificationResult:
         """Verify a manifest with caller-supplied trusted keys.
 
         The request body carries ``trusted_keys`` (key_id -> base64url public
@@ -1716,24 +1778,121 @@ def create_router(
         ``approver_public_keys`` (approver_id -> base64url Ed25519 public key)
         for HITL approval verification.
         Verification is fail-closed - see :func:`verify_manifest`.
+
+        **Only JSON request bodies are accepted.** ``Content-Type`` is
+        checked against the same rule FastAPI itself uses to decide whether
+        to parse a Pydantic-model body as JSON: ``application/json``, a
+        ``+json`` vendor subtype (e.g. ``application/vnd.api+json``), or no
+        ``Content-Type`` header at all. Anything else - ``text/plain``,
+        ``application/xml``, a bogus or empty subtype - is rejected with
+        ``415`` before the body is even read. Taking a raw ``Request``
+        instead of a ``VerifyRequest`` parameter (see below) means FastAPI's
+        own automatic content-type gate no longer runs for this route, so it
+        is reproduced here explicitly; skipping this check would let a
+        caller submit a JSON payload under any (or no) media type, silently
+        widening what the documented ``application/json``-only contract
+        actually accepts.
+
+        **The body is bounded before it is parsed**, mirroring ``POST
+        /verify/cose``: the stream is capped at ``MAX_VERIFY_BODY_BYTES``
+        regardless of the declared ``Content-Length`` (a claim, not a
+        guarantee), so an oversized body is rejected before Pydantic ever
+        buffers or validates it. Each chunk is checked *before* it is
+        appended, not after, so the buffer itself is never intentionally
+        grown past the limit - the cap holds regardless of how large a
+        single ASGI receive chunk is. Independently, ``VerifyRequest`` caps
+        the entry count of each of its dict/set fields at
+        ``MAX_VERIFY_COLLECTION_ENTRIES``, which catches a small body that
+        hides an oversized collection behind short keys/values.
         """
-        manifest = _lookup_manifest(request.manifest_id)
+        content_type_value = request.headers.get("content-type")
+        if content_type_value is not None:
+            message = email.message.Message()
+            message["content-type"] = content_type_value
+            subtype = message.get_content_subtype()
+            is_json = message.get_content_maintype() == "application" and (
+                subtype == "json" or subtype.endswith("+json")
+            )
+            if not is_json:
+                raise HTTPException(
+                    status_code=415,
+                    detail=ErrorResponse(
+                        error_code="UNSUPPORTED_MEDIA_TYPE",
+                        error_message=(
+                            "POST /verify accepts application/json "
+                            "(or a +json subtype) only."
+                        ),
+                    ).model_dump(),
+                )
+         # Cap the stream too: Content-Length is a claim, not a guarantee.
+        # Checked before extend(), not after, so the buffer itself is never
+        # intentionally grown past the limit regardless of how large a
+        # single ASGI receive chunk is.
+        body = bytearray()
+        async for chunk in request.stream():
+            if len(body) + len(chunk) > MAX_VERIFY_BODY_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=ErrorResponse(
+                        error_code="VERIFY_REQUEST_TOO_LARGE",
+                        error_message=(
+                            f"Request body may not exceed "
+                            f"{MAX_VERIFY_BODY_BYTES} bytes."
+                        ),
+                    ).model_dump(),
+                )
+            body.extend(chunk)
+
+        from pydantic import ValidationError
+
+        try:
+            parsed = VerifyRequest.model_validate_json(bytes(body))
+        except ValidationError as exc:
+            # include_context=False / include_input=False: pydantic's `ctx`
+            # can carry a raw exception object (not JSON-serializable), and
+            # `input` would echo the caller's payload - including, in the
+            # oversized-collection case this validator exists to catch, a
+            # large one - back into the error response. The "body" prefix on
+            # `loc` matches what FastAPI's own request-body validation would
+            # have produced here before this endpoint took the raw Request,
+            # so error-shape parity for existing callers is preserved.
+            errors = exc.errors(
+                include_url=False, include_context=False, include_input=False
+            )
+            for error in errors:
+                error["loc"] = ("body", *error["loc"])
+            raise HTTPException(status_code=422, detail=errors)
+        manifest = _lookup_manifest(parsed.manifest_id)
         ctx = VerificationContext(
-            enforce_hitl=request.enforce_hitl,
-            enforce_attestation=request.enforce_attestation,
-            trusted_keys=request.trusted_keys,
-            trusted_key_issuers=request.trusted_key_issuers,
-            delegation_public_keys=request.delegation_public_keys,
-            approver_public_keys=request.approver_public_keys,
-            verified_transparency_entry_ids=request.verified_transparency_entry_ids,
-            verified_transparency_receipt_hashes=request.verified_transparency_receipt_hashes,
-            transparency_evidence_manifest_id=request.transparency_evidence_manifest_id,
-            verified_attestation_manifest_hashes=request.verified_attestation_manifest_hashes,
-            attestation_evidence_manifest_id=request.attestation_evidence_manifest_id,
-            require_transparency=request.require_transparency,
-            require_delegation=request.require_delegation,
+            enforce_hitl=parsed.enforce_hitl,
+            enforce_attestation=parsed.enforce_attestation,
+            trusted_keys=parsed.trusted_keys,
+            trusted_key_issuers=parsed.trusted_key_issuers,
+            delegation_public_keys=parsed.delegation_public_keys,
+            approver_public_keys=parsed.approver_public_keys,
+            verified_transparency_entry_ids=parsed.verified_transparency_entry_ids,
+            verified_transparency_receipt_hashes=parsed.verified_transparency_receipt_hashes,
+            transparency_evidence_manifest_id=parsed.transparency_evidence_manifest_id,
+            verified_attestation_manifest_hashes=parsed.verified_attestation_manifest_hashes,
+            attestation_evidence_manifest_id=parsed.attestation_evidence_manifest_id,
+            require_transparency=parsed.require_transparency,
+            require_delegation=parsed.require_delegation,
         )
         return verify_manifest(manifest, ctx, revocation_store)
+
+    # Same reason as verify_cose below: `from __future__ import annotations`
+    # makes this a string annotation, and `Request` is imported lazily inside
+    # this function rather than at module scope, so it is not resolvable
+    # against the module globals FastAPI uses to evaluate annotations. Bind
+    # the real class before registering the route.
+    verify_post.__annotations__["request"] = Request
+    router.add_api_route(
+        "/verify",
+        verify_post,
+        methods=["POST"],
+        response_model=VerificationResult,
+        openapi_extra=_verify_post_openapi_extra,
+    )
 
     async def verify_cose(
         request: "Request",
@@ -1793,14 +1952,14 @@ def create_router(
         declared_length = request.headers.get("content-length")
         if declared_length is not None:
             try:
-                if int(declared_length) > MAX_COSE_ENVELOPE_BYTES:
+                if int(declared_length) > MAX_VERIFY_BODY_BYTES:
                     raise HTTPException(
                         status_code=413,
                         detail=ErrorResponse(
                             error_code="ENVELOPE_TOO_LARGE",
                             error_message=(
                                 f"A COSE manifest may not exceed "
-                                f"{MAX_COSE_ENVELOPE_BYTES} bytes."
+                                f"{MAX_VERIFY_BODY_BYTES} bytes."
                             ),
                         ).model_dump(),
                     )
@@ -1814,20 +1973,23 @@ def create_router(
                 )
 
         # Cap the stream too: Content-Length is a claim, not a guarantee.
+        # Checked before extend(), not after, so the buffer itself is never
+        # intentionally grown past the limit regardless of how large a
+        # single ASGI receive chunk is.
         body = bytearray()
         async for chunk in request.stream():
-            body.extend(chunk)
-            if len(body) > MAX_COSE_ENVELOPE_BYTES:
+            if len(body) + len(chunk) > MAX_VERIFY_BODY_BYTES:
                 raise HTTPException(
                     status_code=413,
                     detail=ErrorResponse(
                         error_code="ENVELOPE_TOO_LARGE",
                         error_message=(
                             f"A COSE manifest may not exceed "
-                            f"{MAX_COSE_ENVELOPE_BYTES} bytes."
+                            f"{MAX_VERIFY_BODY_BYTES} bytes."
                         ),
                     ).model_dump(),
                 )
+            body.extend(chunk)
 
         ctx = (cose_context or VerificationContext()).model_copy(
             update={

--- a/python/tests/test_cose_endpoint.py
+++ b/python/tests/test_cose_endpoint.py
@@ -18,7 +18,7 @@ from agent_manifest._cose import (
 )
 from agent_manifest._signing import generate_ed25519
 from agent_manifest._verify import (
-    MAX_COSE_ENVELOPE_BYTES,
+    MAX_VERIFY_BODY_BYTES,
     RevocationRecord,
     RevocationStore,
     VerificationContext,
@@ -216,7 +216,7 @@ def test_media_type_case_is_not_significant():
 
 
 def test_an_oversized_body_is_refused():
-    response = post(client(trust_store()), b"\x00" * (MAX_COSE_ENVELOPE_BYTES + 1))
+    response = post(client(trust_store()), b"\x00" * (MAX_VERIFY_BODY_BYTES + 1))
     assert response.status_code == 413
 
 
@@ -225,7 +225,7 @@ def test_a_lying_content_length_does_not_get_past_the_stream_cap():
     c = client(trust_store())
     response = c.post(
         "/verify/cose",
-        content=b"\x00" * (MAX_COSE_ENVELOPE_BYTES + 1),
+        content=b"\x00" * (MAX_VERIFY_BODY_BYTES + 1),
         headers={
             "Content-Type": MEDIA_TYPE_MANIFEST_COSE,
             # understated on purpose

--- a/python/tests/test_verify_post_bounds.py
+++ b/python/tests/test_verify_post_bounds.py
@@ -1,0 +1,400 @@
+"""POST /verify (JSON) body-size and field-cardinality bounds - issue #383.
+
+`POST /verify/cose` bounds its CBOR body before parsing it (see
+test_cose_endpoint.py); this endpoint took a `VerifyRequest` Pydantic model
+directly, so FastAPI would fully buffer and validate an arbitrarily large or
+high-cardinality JSON body before `verify_manifest` ever ran. These tests
+cover the fix: a shared byte cap on the raw body, and a shared entry-count
+cap on `VerifyRequest`'s dict/set fields, mirroring the COSE endpoint's
+defense-in-depth posture.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent_manifest._signing import generate_ed25519
+from agent_manifest._verify import (
+    MAX_VERIFY_BODY_BYTES,
+    MAX_VERIFY_COLLECTION_ENTRIES,
+    RevocationStore,
+    VerifyRequest,
+    create_router,
+)
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="fastapi not installed")
+
+NOW = datetime.now(timezone.utc)
+FUTURE = (NOW + timedelta(days=90)).isoformat().replace("+00:00", "Z")
+SHA = "sha256:" + "a" * 64
+SHA_B = "sha256:" + "b" * 64
+MANIFEST_ID = "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c"
+
+KP = generate_ed25519()
+
+
+def manifest(**overrides):
+    m = {
+        "manifest_id": MANIFEST_ID,
+        "agent_id": "spiffe://trust.example/agent/kyc/prod",
+        "version": "0.2",
+        "issued_at": NOW.isoformat().replace("+00:00", "Z"),
+        "expires_at": FUTURE,
+        "issuer": "spiffe://trust.example/signing-authority",
+        "crypto_profile": "standard",
+        "artifacts": {
+            "system_prompt": {"hash": SHA},
+            "policy_bundle": {"hash": SHA_B},
+            "model_identity": {"version": "claude-3", "deployment_type": "api"},
+        },
+    }
+    m.update(overrides)
+    return m
+
+
+def client(manifests=None, revocation_store=None):
+    app = FastAPI()
+    store = {MANIFEST_ID: manifest()} if manifests is None else manifests
+    app.include_router(
+        create_router(store, revocation_store or RevocationStore())
+    )
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Body-size bound (mirrors POST /verify/cose)
+# ---------------------------------------------------------------------------
+
+
+def test_an_oversized_body_is_refused():
+    huge = {"manifest_id": MANIFEST_ID, "trusted_keys": {"k": "v" * MAX_VERIFY_BODY_BYTES}}
+    body = json.dumps(huge).encode()
+    assert len(body) > MAX_VERIFY_BODY_BYTES
+    c = client()
+    response = c.post(
+        "/verify", content=body, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 413
+    assert response.json()["detail"]["error_code"] == "VERIFY_REQUEST_TOO_LARGE"
+
+
+def test_a_declared_content_length_cannot_be_used_to_smuggle_past_the_cap():
+    """Unlike POST /verify/cose, verify_post never reads the Content-Length
+    header at all - only the actual byte stream is counted. That means a
+    lying (understated) Content-Length can't help a caller evade the cap
+    (nothing ever trusts it in the first place), and this test's job is to
+    confirm the stream-based cap alone is sufficient regardless of what the
+    header claims."""
+    huge = {"manifest_id": MANIFEST_ID, "trusted_keys": {"k": "v" * MAX_VERIFY_BODY_BYTES}}
+    body = json.dumps(huge).encode()
+    c = client()
+    response = c.post(
+        "/verify",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            # understated on purpose - verify_post ignores this header either way
+            "Content-Length": "10",
+        },
+    )
+    assert response.status_code == 413
+
+
+def test_a_body_at_exactly_the_limit_is_not_rejected_for_size():
+    """The cap is `> MAX_VERIFY_BODY_BYTES`, not `>=`; a body landing exactly
+    on the boundary should fail (if at all) on content, not size."""
+    # Pad with a large, otherwise-harmless string value under the collection
+    # cap (one entry) so only the byte-size boundary is being exercised.
+    padding_key = "k"
+    overhead = len(
+        json.dumps({"manifest_id": MANIFEST_ID, "trusted_keys": {padding_key: ""}}).encode()
+    )
+    pad_len = max(0, MAX_VERIFY_BODY_BYTES - overhead)
+    payload = {"manifest_id": MANIFEST_ID, "trusted_keys": {padding_key: "v" * pad_len}}
+    body = json.dumps(payload).encode()
+    assert len(body) <= MAX_VERIFY_BODY_BYTES
+    c = client()
+    response = c.post(
+        "/verify", content=body, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 200
+
+
+def test_the_json_endpoint_still_accepts_normal_requests():
+    """Streaming the body manually must not disturb the existing contract."""
+    c = client()
+    response = c.post("/verify", json={"manifest_id": MANIFEST_ID})
+    assert response.status_code == 200
+    assert response.json()["manifest_id"] == MANIFEST_ID
+
+
+def test_manifest_not_found_is_still_reported_after_bounded_parsing():
+    c = client({})
+    response = c.post("/verify", json={"manifest_id": MANIFEST_ID})
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Content-Type enforcement
+#
+# verify_post takes a raw Request (to stream-cap the body before Pydantic
+# parses it), which means FastAPI's own automatic content-type gate for a
+# Pydantic-model body parameter no longer runs for this route. Without an
+# explicit check, model_validate_json() would happily accept a JSON payload
+# under any Content-Type (or none at all with an unexpected value), silently
+# widening the documented application/json-only contract advertised in the
+# OpenAPI schema.
+# ---------------------------------------------------------------------------
+
+
+def test_a_non_json_content_type_is_rejected_even_with_a_valid_json_body():
+    body = json.dumps({"manifest_id": MANIFEST_ID}).encode()
+    c = client()
+    response = c.post(
+        "/verify", content=body, headers={"Content-Type": "text/plain"}
+    )
+    assert response.status_code == 415
+    assert response.json()["detail"]["error_code"] == "UNSUPPORTED_MEDIA_TYPE"
+
+
+def test_a_bogus_content_type_is_rejected():
+    body = json.dumps({"manifest_id": MANIFEST_ID}).encode()
+    c = client()
+    response = c.post(
+        "/verify", content=body, headers={"Content-Type": "not/a/real/type"}
+    )
+    assert response.status_code == 415
+
+
+def test_form_encoded_content_type_is_rejected():
+    body = json.dumps({"manifest_id": MANIFEST_ID}).encode()
+    c = client()
+    response = c.post(
+        "/verify",
+        content=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 415
+
+
+def test_a_json_vendor_subtype_is_accepted():
+    """`application/vnd.api+json` and similar +json subtypes are valid JSON
+    media types (RFC 6839) and must be accepted, matching what FastAPI's own
+    body parsing does for a normal Pydantic-model parameter."""
+    body = json.dumps({"manifest_id": MANIFEST_ID}).encode()
+    c = client()
+    response = c.post(
+        "/verify",
+        content=body,
+        headers={"Content-Type": "application/vnd.api+json"},
+    )
+    assert response.status_code == 200
+
+
+def test_a_json_content_type_with_charset_parameter_is_accepted():
+    body = json.dumps({"manifest_id": MANIFEST_ID}).encode()
+    c = client()
+    response = c.post(
+        "/verify",
+        content=body,
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+    assert response.status_code == 200
+
+
+def test_a_missing_content_type_still_falls_back_to_json():
+    """No Content-Type header at all is what FastAPI's default (non-strict)
+    body parsing accepts for a Pydantic-model parameter; that must keep
+    working exactly as before. httpx sends no Content-Type of its own for
+    raw `content=bytes` (unlike `json=...`), so this genuinely exercises the
+    header-absent path rather than an empty header value."""
+    body = json.dumps({"manifest_id": MANIFEST_ID}).encode()
+    c = client()
+    response = c.post("/verify", content=body)
+    assert response.status_code == 200
+
+def test_malformed_json_is_a_422_not_a_server_error():
+    c = client()
+    response = c.post(
+        "/verify", content=b"{not valid json", headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 422
+
+
+def test_validation_error_shape_matches_the_pre_fix_pydantic_body_contract():
+    """`verify_post` used to take `VerifyRequest` directly, so FastAPI's own
+    body validation produced errors with a leading "body" element in `loc`.
+    Parsing the body by hand must not silently change that wire contract for
+    existing callers that key off `detail[i]["loc"][0] == "body"`."""
+    c = client()
+    response = c.post("/verify", json={})  # missing required manifest_id
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail[0]["loc"] == ["body", "manifest_id"]
+    assert detail[0]["type"] == "missing"
+    # Deliberately dropped relative to FastAPI's default: `ctx` can carry a
+    # non-serializable exception object, and `input` would echo the caller's
+    # (potentially oversized) payload back in the response.
+    assert "ctx" not in detail[0]
+    assert "input" not in detail[0]
+
+
+def test_the_json_request_body_schema_is_still_documented():
+    """`verify_post` takes a raw `Request` now (to stream-cap the body before
+    Pydantic parses it), which on its own would make FastAPI drop the request
+    body from the generated OpenAPI schema entirely, since it can no longer
+    infer it from a Pydantic-typed parameter. Callers, Swagger UI, and
+    codegen tools still need to see what POST /verify accepts."""
+    app = FastAPI()
+    app.include_router(create_router({}, RevocationStore()))
+    schema = app.openapi()
+    request_body = schema["paths"]["/verify"]["post"].get("requestBody")
+    assert request_body is not None, "POST /verify lost its documented request body"
+    assert request_body["required"] is True
+    body_schema = request_body["content"]["application/json"]["schema"]
+    for field in (
+        "manifest_id",
+        "trusted_keys",
+        "trusted_key_issuers",
+        "delegation_public_keys",
+        "approver_public_keys",
+        "verified_transparency_entry_ids",
+        "verified_transparency_receipt_hashes",
+        "verified_attestation_manifest_hashes",
+    ):
+        assert field in body_schema["properties"], f"missing from documented schema: {field}"
+
+
+def test_the_result_is_unaffected_by_the_new_bounds():
+    """A normal, valid POST /verify call still behaves as before (v0.1
+    detached-signature form, since Ed25519Signer.sign targets that format)."""
+    from agent_manifest._signing import Ed25519Signer
+
+    ctx_keys = {KP.key_id: KP.public_b64url()}
+    m = manifest(version="0.1")
+    del m["issuer"]
+    m["signature"] = Ed25519Signer(KP).sign(m)
+    c = client({MANIFEST_ID: m})
+    response = c.post(
+        "/verify", json={"manifest_id": MANIFEST_ID, "trusted_keys": ctx_keys}
+    )
+    assert response.status_code == 200
+    assert response.json()["signature_verified"] is True
+
+
+# ---------------------------------------------------------------------------
+# Field-cardinality bound
+# ---------------------------------------------------------------------------
+
+FIELD_KINDS = {
+    "trusted_keys": dict,
+    "trusted_key_issuers": dict,
+    "delegation_public_keys": dict,
+    "approver_public_keys": dict,
+    "verified_transparency_entry_ids": set,
+    "verified_transparency_receipt_hashes": set,
+    "verified_attestation_manifest_hashes": set,
+}
+
+
+@pytest.mark.parametrize("field_name,kind", FIELD_KINDS.items())
+def test_each_unbounded_field_rejects_over_the_entry_ceiling(field_name, kind):
+    """A small request body can still hide an oversized collection behind
+    short keys/values - the entry-count cap catches that independently of
+    the byte-size cap."""
+    too_many = MAX_VERIFY_COLLECTION_ENTRIES + 1
+    if kind is dict:
+        if field_name == "trusted_key_issuers":
+            value = {str(i): ["spiffe://x/y"] for i in range(too_many)}
+        else:
+            value = {str(i): "v" for i in range(too_many)}
+    else:
+        value = [str(i) for i in range(too_many)]
+
+    with pytest.raises(Exception):
+        VerifyRequest(manifest_id=MANIFEST_ID, **{field_name: value})
+
+
+@pytest.mark.parametrize("field_name,kind", FIELD_KINDS.items())
+def test_each_unbounded_field_accepts_at_the_entry_ceiling(field_name, kind):
+    exactly = MAX_VERIFY_COLLECTION_ENTRIES
+    if kind is dict:
+        if field_name == "trusted_key_issuers":
+            value = {str(i): ["spiffe://x/y"] for i in range(exactly)}
+        else:
+            value = {str(i): "v" for i in range(exactly)}
+    else:
+        value = [str(i) for i in range(exactly)]
+
+    req = VerifyRequest(manifest_id=MANIFEST_ID, **{field_name: value})
+    assert len(getattr(req, field_name)) == exactly
+
+
+def test_an_oversized_collection_over_http_is_rejected_as_a_client_error():
+    """The small-body / huge-collection shape the issue describes: short
+    keys keep the wire body well under MAX_VERIFY_BODY_BYTES, so only the
+    cardinality cap on VerifyRequest can catch it."""
+    too_many = MAX_VERIFY_COLLECTION_ENTRIES + 1
+    trusted_keys = {str(i): "v" for i in range(too_many)}
+    body = json.dumps({"manifest_id": MANIFEST_ID, "trusted_keys": trusted_keys}).encode()
+    assert len(body) < MAX_VERIFY_BODY_BYTES
+
+    c = client()
+    response = c.post(
+        "/verify", content=body, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 422
+
+
+def test_the_field_the_issue_report_missed_is_covered_too():
+    """verified_attestation_manifest_hashes is a set[str] with the exact
+    same shape as the two transparency hash sets sitting right above it in
+    the model, and it reaches VerificationContext through the identical
+    assignment in verify_post - but the original issue's field list didn't
+    name it. A fix copied mechanically from that list would leave this one
+    field open as a drop-in substitute for the six that got capped."""
+    too_many = MAX_VERIFY_COLLECTION_ENTRIES + 1
+    hashes = [str(i) for i in range(too_many)]
+    body = json.dumps(
+        {"manifest_id": MANIFEST_ID, "verified_attestation_manifest_hashes": hashes}
+    ).encode()
+    assert len(body) < MAX_VERIFY_BODY_BYTES
+
+    c = client()
+    response = c.post(
+        "/verify", content=body, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 422
+
+
+def test_transparency_and_attestation_hash_sets_are_also_capped():
+    """The transparency/attestation hash sets belong to the family of
+    fields the issue describes; confirm both are wired into the validator
+    (the fixture list above already covers all three sets individually -
+    this checks the model directly for the full field set the validator
+    actually protects, including verified_attestation_manifest_hashes,
+    which the original issue report's field list omitted but which has
+    the identical unbounded set[str] shape)."""
+    from agent_manifest._verify import VerifyRequest as VR
+
+    validated_fields = set()
+    for name, validator in VR.__pydantic_decorators__.field_validators.items():
+        validated_fields.update(validator.info.fields)
+
+    assert validated_fields == {
+        "trusted_keys",
+        "trusted_key_issuers",
+        "delegation_public_keys",
+        "approver_public_keys",
+        "verified_transparency_entry_ids",
+        "verified_transparency_receipt_hashes",
+        "verified_attestation_manifest_hashes",
+    }


### PR DESCRIPTION
## What

Adds the same body-size and collection-cardinality limits to `POST /verify` (JSON) that `POST /verify/cose` already has.

## Why

`POST /verify` took a `VerifyRequest` Pydantic model directly, so FastAPI would fully buffer and validate an arbitrarily large JSON body e.g. a `trusted_keys` dict with millions of entries before any verification logic ran. `POST /verify/cose` already guards against this; this endpoint didn't. 

Closes #383.

## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [ ] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
