### PR TITLE
fix(deps): add missing prometheus-client to dev lockfile

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -19,6 +19,7 @@ click>=8.1
 mypy>=1.10
 bandit[toml]>=1.7
 pip-audit>=2.7
+prometheus-client>=0.20,<1
 ruff
 pyyaml
 setuptools>=83.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1040,6 +1040,10 @@ pluggy==1.6.0 \
     # via
     #   pytest
     #   pytest-cov
+prometheus-client==0.26.0 \
+    --hash=sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b \
+    --hash=sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6
+    # via -r requirements/dev.in
 py-serializable==2.1.0 \
     --hash=sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103 \
     --hash=sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304


### PR DESCRIPTION
## What

Adds `prometheus-client` to `requirements/dev.in` and regenerates `requirements/dev.txt`.


## Why

`pyproject.toml`'s `dev` extra declares `prometheus-client>=0.20,<1` (needed for the `operations/monitoring.md` tutorial test), but `requirements/dev.in` never had it so `requirements/dev.txt`, the file CI actually installs via `pip install --require-hashes`, was missing it too.


Due to this `test_followup_tutorial[operations/monitoring.md-expected0]` to fail with `ModuleNotFoundError: No module named 'prometheus_client.

## Spec impact

None

## Test plan

- [x] `pytest -v` passes
- [x] `mypy src/agent_manifest` passes
- [x] `ruff check src/ tests/` passes
- [x] New or updated tests cover the change
- [ ] If spec change: `CHANGELOG.md` updated

## DCO

All commits in this PR are signed off (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
