### PR TITLE
Fix empty trusted_key_issuers semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -725,7 +725,7 @@ Makes agent-manifest the canonical hardware-verification library for the org: SE
 
 ### Security
 
-**\[SDK\]** Verification can now bind trusted signing keys to authorized issuers. `VerificationContext.trusted_key_issuers` maps each trusted `key_id` to the issuer SPIFFE URIs allowed to sign with it; when supplied, a manifest whose signing key is not authorized for its declared `issuer` is rejected (fail-closed). Opt-in and backward compatible: an empty map preserves prior behavior.
+**\[SDK\]** Verification can now bind trusted signing keys to authorized issuers. `VerificationContext.trusted_key_issuers` maps each trusted `key_id` to the issuer SPIFFE URIs allowed to sign with it; when supplied, a manifest whose signing key is not authorized for its declared `issuer` is rejected (fail-closed). Opt-in and backward compatible: an omitted value preserves prior behavior, while an explicitly empty map authorizes no issuers.
 
 ### Added
 

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -283,6 +283,8 @@ class VerifyRequest(BaseModel):
     )
     @classmethod
     def _cap_collection_size(cls, v: Any) -> Any:
+        if v is None:
+            return v
         if len(v) > MAX_VERIFY_COLLECTION_ENTRIES:
             raise ValueError(
                 f"exceeds {MAX_VERIFY_COLLECTION_ENTRIES}-entry limit"

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -239,7 +239,7 @@ class VerifyRequest(BaseModel):
     # key_id (sha256 hex of pub key bytes) -> base64url-encoded public key bytes
     trusted_keys: dict[str, str] = Field(default_factory=dict)
     # key_id -> issuer SPIFFE URIs authorized to use that signing key
-    trusted_key_issuers: dict[str, list[str]] = Field(default_factory=dict)
+    trusted_key_issuers: Optional[dict[str, list[str]]] = Field(default=None)
     # principal_id -> base64url-encoded public key bytes (for delegation chain)
     delegation_public_keys: dict[str, str] = Field(default_factory=dict)
     # approver_id -> base64url-encoded Ed25519 public key bytes (for HITL)
@@ -355,7 +355,7 @@ class VerificationContext(BaseModel):
     # key_id (sha256 hex of pub key bytes) -> base64url-encoded public key bytes
     trusted_keys: dict[str, str] = Field(default_factory=dict)
     # key_id -> issuer SPIFFE URIs authorized to use that signing key
-    trusted_key_issuers: dict[str, list[str]] = Field(default_factory=dict)
+    trusted_key_issuers: Optional[dict[str, list[str]]] = Field(default=None)
     # principal_id -> base64url-encoded public key bytes (for delegation chain)
     delegation_public_keys: dict[str, str] = Field(default_factory=dict)
     # approver_id -> base64url-encoded Ed25519 public key bytes (for HITL)
@@ -447,10 +447,10 @@ def _split_hybrid_public_key(
 def _signature_key_issuer_mismatch(
     manifest: dict[str, Any],
     key_id: str,
-    trusted_key_issuers: dict[str, list[str]],
+    trusted_key_issuers: Optional[dict[str, list[str]]],
 ) -> Optional[MismatchDetail]:
     """Return a mismatch when a trusted key is not authorized for the issuer."""
-    if not trusted_key_issuers:
+    if trusted_key_issuers is None:
         return None
 
     issuer = manifest.get("issuer")

--- a/python/tests/test_verify_post_bounds.py
+++ b/python/tests/test_verify_post_bounds.py
@@ -305,6 +305,14 @@ FIELD_KINDS = {
 }
 
 
+def test_trusted_key_issuers_none_is_accepted():
+    req = VerifyRequest(
+        manifest_id=MANIFEST_ID,
+        trusted_key_issuers=None,
+    )
+    assert req.trusted_key_issuers is None
+
+
 @pytest.mark.parametrize("field_name,kind", FIELD_KINDS.items())
 def test_each_unbounded_field_rejects_over_the_entry_ceiling(field_name, kind):
     """A small request body can still hide an oversized collection behind

--- a/python/tests/vectors/AM-VEC-024.json
+++ b/python/tests/vectors/AM-VEC-024.json
@@ -1,0 +1,76 @@
+{
+  "id": "AM-VEC-024",
+  "description": "An explicitly empty issuer authorization mapping rejects the signing key.",
+  "spec_refs": [
+    "5.3"
+  ],
+  "manifest": {
+    "manifest_id": "018f4a3b-2c1d-7e5f-a8b9-0d1e2f3a4b5c",
+    "agent_id": "spiffe://trust.example/agent/kyc/prod",
+    "version": "0.1",
+    "issued_at": "2025-01-01T00:00:00Z",
+    "expires_at": "2099-12-31T23:59:59Z",
+    "issuer": "spiffe://trust.example/signing-authority",
+    "crypto_profile": "standard",
+    "artifacts": {
+      "system_prompt": {
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "policy_bundle": {
+        "hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "model_identity": {
+        "model_hash": null,
+        "version": "claude-3",
+        "deployment_type": "api"
+      }
+    },
+    "delegation_chain": [],
+    "hitl_record": null,
+    "signature": {
+      "algorithm": "Ed25519",
+      "key_id": "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
+      "key_type": "software",
+      "signed_at": "2025-01-01T00:00:00Z",
+      "signature_value": "YUnGWwyv4mUTUrjmXi5FakUaEzPo_JkqEXxT4d6txlN_gFKpXPS2lG52SfuT7trQzwyvc4hwZ28uCg5Ve_0lBg",
+      "signed_fields": [
+        "@context",
+        "@type",
+        "manifest_id",
+        "previous_manifest_id",
+        "agent_id",
+        "agent_instance_id",
+        "version",
+        "min_verifier_version",
+        "issued_at",
+        "expires_at",
+        "issuer",
+        "crypto_profile",
+        "profile",
+        "unbound_artifacts",
+        "source_bundle",
+        "artifacts",
+        "delegation_chain",
+        "hitl_record",
+        "prior_transparency_log_entry",
+        "log_retention",
+        "data_scope",
+        "operational_lifecycle",
+        "intent"
+      ]
+    }
+  },
+  "context": {
+    "system_prompt_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "policy_bundle_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "model_version": "claude-3",
+    "trusted_keys": {
+      "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "trusted_key_issuers": {}
+  },
+  "expected": {
+    "result": "MISMATCH",
+    "signature_verified": false
+  }
+}

--- a/python/tests/vectors/generate.py
+++ b/python/tests/vectors/generate.py
@@ -979,6 +979,21 @@ def build() -> list[dict[str, Any]]:
         ),
         {"result": "MISMATCH", "signature_verified": False},
     ))
+    # 024 - issuer authorization explicitly configured with no authorized keys.
+    # None means issuer authorization is not configured; an empty mapping means
+    # it is configured but authorizes no signing key. The latter must therefore
+    # fail closed rather than taking the "not configured" path.
+    vectors.append(_vector(
+        "AM-VEC-024",
+        "An explicitly empty issuer authorization mapping rejects the signing key.",
+        ["5.3"],
+        base_manifest(),
+        base_context(trusted_key_issuers={}),
+        {
+            "result": "MISMATCH",
+            "signature_verified": False,
+        },
+    ))
 
     # --- version 0.2, COSE envelope (ADR-0011, issue #243) -----------------
     vectors.append(cose_encoding_vector())

--- a/python/tests/vectors/index.json
+++ b/python/tests/vectors/index.json
@@ -134,6 +134,11 @@
       "description": "A key authorized for the subject (agent_id) but not the issuer is rejected."
     },
     {
+      "id": "AM-VEC-024",
+      "file": "AM-VEC-024.json",
+      "description": "An explicitly empty issuer authorization mapping rejects the signing key."
+    },
+    {
       "id": "AM-VEC-COSE-001",
       "file": "AM-VEC-COSE-001.json",
       "description": "COSE_Sign1 encoding is pinned byte-for-byte: CBOR tag 18, a four-element array, and a zero-length unprotected header map before any receipt is attached."


### PR DESCRIPTION
Fixes #413

`trusted_key_issuers=None` now represents an unset issuer authorization policy, while an explicitly empty mapping authorizes no issuers and therefore fails closed.

Adds regression vector AM-VEC-024 and updates the changelog accordingly.

Existing behavior for omitted `trusted_key_issuers` remains unchanged.

## Implementation and verification

This PR distinguishes between an unset issuer authorization policy and an explicitly empty issuer authorization policy.

### Implementation

`trusted_key_issuers` now uses an optional mapping on both `VerifyRequest` and `VerificationContext`:

```python
trusted_key_issuers: Optional[dict[str, list[str]]] = Field(default=None)
```

The semantics are:

* `None` means issuer authorization is not configured. Existing callers that omit the field retain the previous behavior.
* `{}` means issuer authorization is explicitly configured but authorizes no signing key for any issuer. Verification therefore fails closed for every signing key.
* A populated mapping authorizes the listed issuer SPIFFE URIs for the corresponding key IDs.

`_signature_key_issuer_mismatch()` now distinguishes `None` from an empty mapping by checking explicitly for `None` before applying the issuer authorization policy.

### Reviewer follow-up

The shared collection-size validator originally called `len(v)` unconditionally. After making `trusted_key_issuers` optional, an explicit `null` value could therefore reach the validator and raise `TypeError`.

The validator now accepts `None` and continues to enforce the existing entry-count limit for configured collections:

```python
if v is None:
    return v
if len(v) > MAX_VERIFY_COLLECTION_ENTRIES:
    raise ValueError(
        f"exceeds {MAX_VERIFY_COLLECTION_ENTRIES}-entry limit"
    )
```

A regression test verifies that `VerifyRequest(..., trusted_key_issuers=None)` is accepted and preserves `None`.

### Verification

The change was checked at the model, verification, HTTP, and collection-boundary levels.

* `python/tests/test_verify_post_bounds.py`: **33 passed**
* `python/tests/test_verify.py`: **93 passed, 4 skipped**
* `python/tests/test_am_verify.py`: **55 passed**
* Targeted `trusted_key_issuers` HTTP test: **1 passed**
* `git diff --check`: **clean**

The current GitHub CI suite passes across the supported matrix. The full Python 3.11 Ubuntu test job reports **1606 passed, 10 skipped, 2 warnings**, with 90.23% coverage.

The existing COSE issuer-authorization tests were also reviewed to confirm that authorized issuers remain valid, unauthorized issuers remain mismatches, and hybrid signatures require authorization for every signing key.

The `None` value was additionally traced through request parsing into `VerificationContext` to confirm that it is preserved and is not normalized back to `{}` before reaching the issuer authorization check.