### PR TITLE
fix(verify): recompute the declared tool catalog root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
 
 ### Fixed
 
+- **[SDK]** `verify_manifest()` now recomputes a tool catalog's Merkle root
+  from its supplied `tools` before accepting the declared `catalog_hash`.
+  A valid signature and a matching runtime hash no longer hide inconsistent
+  catalog contents (spec 3.2.3, issue #416). The runtime comparison remains
+  independent, and legacy bindings that omit `tools` retain their existing
+  hash-comparison behavior. Observed by solloek369-arch on #340 and filed as
+  #416 by Imran Siddique.
+
 - **[SDK]** `verify_manifest()` returned `MISMATCH`/`EXPIRED`/`INVALID`/
   `UNVERIFIABLE` for `hitl_record` when *any* approval in `hitl_record.approvals`
   failed, even if a later approval in the same array was present, valid,

--- a/python/src/agent_manifest/_verify.py
+++ b/python/src/agent_manifest/_verify.py
@@ -1088,6 +1088,39 @@ def verify_manifest(
         tm.get("catalog_hash"),
         context.tool_catalog_hash,
     )
+    # Spec 3.2.3: the declared root also commits to the adjacent tools. A
+    # matching runtime hash cannot establish that internal consistency.
+    # Preserve legacy omitted bindings, but hash an explicitly empty catalog.
+    if tm.get("catalog_hash") is not None and "tools" in tm:
+        from ._merkle import build_catalog_tree
+        from ._types import HashValue
+        from .models import ToolEntry
+
+        try:
+            # HashValue fields were validated by the schema gate, but its str
+            # coercions are not applied to this raw dict. Reject Python-only
+            # tool IDs before passing them to the builder.
+            catalog_tools = []
+            for tool in tm["tools"]:
+                if not isinstance(tool, dict) or not isinstance(tool.get("tool_id"), str):
+                    raise ValueError("catalog tools require string tool IDs")
+                # Construct only the Merkle inputs so legacy omissions of
+                # nonhashed metadata do not become new validation failures.
+                catalog_tools.append(ToolEntry.model_construct(
+                    tool_id=tool["tool_id"],
+                    schema_hash=HashValue(tool["schema_hash"]),
+                    description_hash=HashValue(tool["description_hash"]),
+                ))
+            computed_catalog_hash = build_catalog_tree(
+                catalog_tools, algorithm=HashValue(tm["catalog_hash"]).algorithm,
+            )
+        except (KeyError, ValueError):
+            # Missing leaf inputs and construction failures cannot prove a root.
+            computed_catalog_hash = "<unverifiable tools>"
+        if _check(
+            "tool_manifest.catalog_hash", tm["catalog_hash"], computed_catalog_hash,
+        ) == FieldResult.MISMATCH:
+            fields.tool_manifest = FieldResult.MISMATCH
 
     mi = artifacts.get("model_identity") or {}
     # For api-deployed models, bind by version string, not binary hash

--- a/python/tests/test_am_verify.py
+++ b/python/tests/test_am_verify.py
@@ -8,7 +8,9 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from agent_manifest._cose import sign_cose_sign1
 from agent_manifest._delegation import HitlApprovalSigner
+from agent_manifest._merkle import build_catalog_tree
 from agent_manifest._signing import Ed25519Signer, generate_ed25519
 from agent_manifest._verify import (
     DelegationResult,
@@ -21,6 +23,7 @@ from agent_manifest._verify import (
     VerificationContext,
     verify_manifest,
 )
+from agent_manifest.models import ToolEntry
 
 NOW = datetime.now(timezone.utc)
 TS_FUTURE = (NOW + timedelta(days=90)).isoformat().replace("+00:00", "Z")
@@ -221,6 +224,268 @@ def test_mismatch_tool_catalog():
     m["artifacts"]["tool_manifest"] = {"catalog_hash": SHA_A}
     r = verify_manifest(sign(m), ctx(tool_catalog_hash=SHA_B), store())
     assert r.fields_verified.tool_manifest == FieldResult.MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# Tool catalog consistency (AM-VERIFY-20, spec 3.2.3 - issue #416)
+# ---------------------------------------------------------------------------
+
+def tool_catalog(tools=None, algorithm="sha256"):
+    if tools is None:
+        tools = [
+            {
+                "tool_id": tool_id,
+                "tool_name": tool_id.rsplit(".", 1)[-1],
+                "endpoint_id": "spiffe://trust.example/mcp/server",
+                "schema_hash": SHA_A,
+                "description_hash": SHA_B,
+                "version": "1.0.0",
+            }
+            for tool_id in ("com.example.read", "com.example.send")
+        ]
+    return {
+        "catalog_hash": build_catalog_tree(
+            [ToolEntry.model_validate(tool) for tool in tools], algorithm=algorithm,
+        ),
+        "tools": tools,
+        "allow_dynamic_registration": False,
+        "rug_pull_policy": "deny-and-alert",
+        "bound_at": NOW.isoformat(),
+    }
+
+
+def sign_catalog_manifest(m, version):
+    if version == "0.2":
+        m["version"] = version
+        m["issuer"] = ISSUER_A
+        return sign_cose_sign1(m, KP)
+    return sign(m)
+
+
+@pytest.mark.parametrize("version", ["0.1", "0.2"])
+@pytest.mark.parametrize("algorithm", ["sha256", "shake256"])
+@pytest.mark.parametrize("empty", [False, True], ids=["two-tools", "empty"])
+def test_tool_catalog_rejects_root_unrelated_to_tools(version, algorithm, empty):
+    """AM-VERIFY-20 / spec 3.2.3: a valid signature cannot bless a false root."""
+    m = manifest()
+    catalog = tool_catalog(tools=[] if empty else None, algorithm=algorithm)
+    computed_root = catalog["catalog_hash"]
+    catalog["catalog_hash"] = f"{algorithm}:" + "f" * 64
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(
+        sign_catalog_manifest(m, version),
+        ctx(tool_catalog_hash=catalog["catalog_hash"]), store(),
+    )
+
+    assert r.signature_verified
+    assert r.result == OverallResult.MISMATCH
+    assert r.fields_verified.tool_manifest == FieldResult.MISMATCH
+    assert len(r.mismatch_details) == 1
+    detail = r.mismatch_details[0]
+    assert detail.field == "tool_manifest.catalog_hash"
+    assert detail.expected_hash == catalog["catalog_hash"]
+    assert detail.actual_hash == computed_root
+
+
+@pytest.mark.parametrize("version", ["0.1", "0.2"])
+@pytest.mark.parametrize("algorithm", ["sha256", "shake256"])
+@pytest.mark.parametrize("empty", [False, True], ids=["two-tools", "empty"])
+def test_tool_catalog_valid_root_and_context_match(version, algorithm, empty):
+    """AM-VERIFY-07 / spec 3.2.3: honest catalogs, including empty ones, match."""
+    m = manifest()
+    catalog = tool_catalog(tools=[] if empty else None, algorithm=algorithm)
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(
+        sign_catalog_manifest(m, version),
+        ctx(tool_catalog_hash=catalog["catalog_hash"]), store(),
+    )
+
+    assert r.signature_verified
+    assert r.result == OverallResult.VALID
+    assert r.fields_verified.tool_manifest == FieldResult.MATCH
+    assert r.mismatch_details == []
+
+
+def test_tool_catalog_correct_root_still_checks_context():
+    """AM-VERIFY-20: internal consistency does not replace runtime comparison."""
+    m = manifest()
+    catalog = tool_catalog()
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(sign(m), ctx(tool_catalog_hash=SHA_C), store())
+
+    assert r.signature_verified
+    assert r.result == OverallResult.MISMATCH
+    assert r.fields_verified.tool_manifest == FieldResult.MISMATCH
+    assert [(d.field, d.expected_hash, d.actual_hash) for d in r.mismatch_details] == [
+        ("tool_manifest", catalog["catalog_hash"], SHA_C),
+    ]
+
+
+@pytest.mark.parametrize("algorithm", ["sha256", "shake256"])
+@pytest.mark.parametrize("field,value", [
+    ("tool_id", "com.example.changed"),
+    ("schema_hash", SHA_C),
+    ("description_hash", SHA_C),
+])
+def test_tool_catalog_detects_changed_leaf_before_signing(algorithm, field, value):
+    """AM-VERIFY-20 / spec 3.2.3: every committed leaf component is checked."""
+    m = manifest()
+    catalog = tool_catalog(algorithm=algorithm)
+    approved_root = catalog["catalog_hash"]
+    catalog["tools"][0][field] = value
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(sign(m), ctx(tool_catalog_hash=approved_root), store())
+
+    assert r.signature_verified
+    assert r.result == OverallResult.MISMATCH
+    assert r.fields_verified.tool_manifest == FieldResult.MISMATCH
+    assert [d.field for d in r.mismatch_details] == ["tool_manifest.catalog_hash"]
+    assert r.mismatch_details[0].expected_hash == approved_root
+    assert r.mismatch_details[0].actual_hash == tool_catalog(
+        catalog["tools"], algorithm=algorithm,
+    )["catalog_hash"]
+
+
+def test_tool_catalog_reordered_tools_match():
+    """AM-VERIFY-07 / spec 3.2.3: tools are sorted by ID, not input order."""
+    m = manifest()
+    catalog = tool_catalog()
+    catalog["tools"].reverse()
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(sign(m), ctx(tool_catalog_hash=catalog["catalog_hash"]), store())
+
+    assert r.result == OverallResult.VALID
+    assert r.fields_verified.tool_manifest == FieldResult.MATCH
+    assert r.mismatch_details == []
+
+
+@pytest.mark.parametrize("wrong_root", [False, True])
+@pytest.mark.parametrize("strict", [False, True])
+def test_tool_catalog_without_runtime_hash(wrong_root, strict):
+    """AM-VERIFY-08 / AM-VERIFY-20: absent runtime evidence cannot hide drift."""
+    m = manifest()
+    catalog = tool_catalog()
+    if wrong_root:
+        catalog["catalog_hash"] = SHA_C
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(sign(m), ctx(strict_artifact_verification=strict), store())
+
+    assert r.signature_verified
+    if wrong_root:
+        assert r.result == OverallResult.MISMATCH
+        assert r.fields_verified.tool_manifest == FieldResult.MISMATCH
+        assert [d.field for d in r.mismatch_details] == ["tool_manifest.catalog_hash"]
+    else:
+        assert r.result == (OverallResult.INCOMPLETE if strict else OverallResult.VALID)
+        assert r.fields_verified.tool_manifest == FieldResult.NOT_BOUND
+        assert r.mismatch_details == []
+
+
+def test_tool_catalog_legacy_hash_without_tools_remains_compatible():
+    """AM-VERIFY-07: legacy nested omissions retain hash comparison behavior."""
+    m = manifest()
+    m["artifacts"]["tool_manifest"] = {"catalog_hash": SHA_A}
+
+    r = verify_manifest(sign(m), ctx(tool_catalog_hash=SHA_A), store())
+
+    assert r.result == OverallResult.VALID
+    assert r.fields_verified.tool_manifest == FieldResult.MATCH
+    assert r.mismatch_details == []
+
+
+def test_tool_catalog_without_declared_root_is_not_bound():
+    """AM-VERIFY-08: a legacy binding without its root remains NOT_BOUND."""
+    m = manifest()
+    catalog = tool_catalog()
+    runtime_root = catalog.pop("catalog_hash")
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(sign(m), ctx(tool_catalog_hash=runtime_root), store())
+
+    assert r.result == OverallResult.VALID
+    assert r.fields_verified.tool_manifest == FieldResult.NOT_BOUND
+    assert r.mismatch_details == []
+
+
+@pytest.mark.parametrize("field", ["tool_name", "endpoint_id", "version"])
+def test_tool_catalog_legacy_missing_nonhashed_metadata(field):
+    """AM-VERIFY-07 / spec 3.2.3: only the three committed fields enter a leaf."""
+    m = manifest()
+    catalog = tool_catalog()
+    del catalog["tools"][0][field]
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(sign(m), ctx(tool_catalog_hash=catalog["catalog_hash"]), store())
+
+    assert r.signature_verified
+    assert r.result == OverallResult.VALID
+    assert r.fields_verified.tool_manifest == FieldResult.MATCH
+    assert r.mismatch_details == []
+
+
+@pytest.mark.parametrize("field", ["tool_id", "schema_hash", "description_hash"])
+def test_tool_catalog_missing_committed_input_fails_closed(field):
+    """AM-VERIFY-20 / spec 3.2.3: an incomplete leaf cannot prove the root."""
+    m = manifest()
+    catalog = tool_catalog()
+    del catalog["tools"][0][field]
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(sign(m), ctx(tool_catalog_hash=catalog["catalog_hash"]), store())
+
+    assert r.signature_verified
+    assert r.result == OverallResult.MISMATCH
+    assert r.fields_verified.tool_manifest == FieldResult.MISMATCH
+    assert [d.field for d in r.mismatch_details] == ["tool_manifest.catalog_hash"]
+    assert r.mismatch_details[0].expected_hash == catalog["catalog_hash"]
+    assert r.mismatch_details[0].actual_hash == "<unverifiable tools>"
+
+
+@pytest.mark.parametrize("tool_id", [b"com.example.read", bytearray(b"com.example.read")])
+@pytest.mark.parametrize("single_tool", [False, True], ids=["two-tools", "single-tool"])
+def test_tool_catalog_raw_python_ids_fail_closed(tool_id, single_tool):
+    """AM-VERIFY-20: schema coercion must not leave unusable raw catalog inputs."""
+    m = manifest()
+    catalog = tool_catalog()
+    if single_tool:
+        catalog = tool_catalog(catalog["tools"][:1])
+    catalog["tools"][0]["tool_id"] = tool_id
+    m["artifacts"]["tool_manifest"] = catalog
+
+    # These Python-only values cannot be signed as JSON. With no trusted key,
+    # signature verification is skipped, but catalog validation must not crash.
+    r = verify_manifest(m, ctx(tool_catalog_hash=catalog["catalog_hash"], trusted_keys={}), store())
+
+    assert not r.signature_verified
+    assert r.result == OverallResult.MISMATCH
+    assert r.fields_verified.tool_manifest == FieldResult.MISMATCH
+    assert [d.field for d in r.mismatch_details] == ["tool_manifest.catalog_hash"]
+    assert r.mismatch_details[0].actual_hash == "<unverifiable tools>"
+
+
+def test_tool_catalog_reports_internal_and_runtime_mismatches():
+    """AM-VERIFY-20: preserve both findings when the two comparisons fail."""
+    m = manifest()
+    catalog = tool_catalog()
+    computed_root = catalog["catalog_hash"]
+    catalog["catalog_hash"] = SHA_A
+    m["artifacts"]["tool_manifest"] = catalog
+
+    r = verify_manifest(sign(m), ctx(tool_catalog_hash=SHA_C), store())
+
+    assert r.signature_verified
+    assert r.result == OverallResult.MISMATCH
+    assert r.fields_verified.tool_manifest == FieldResult.MISMATCH
+    assert [(d.field, d.expected_hash, d.actual_hash) for d in r.mismatch_details] == [
+        ("tool_manifest", SHA_A, SHA_C),
+        ("tool_manifest.catalog_hash", SHA_A, computed_root),
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Recompute a supplied tool catalog's declared Merkle root during `verify_manifest()`, independently of the existing runtime-context comparison.

## Why

Closes #416. This implements the issue reported by @solloek369-arch on #340 and confirmed/filed by @imran-siddique; I am not claiming the original discovery.

A valid signature authenticates the declared root and tools, but does not make them consistent. Previously, an incorrect root could return `VALID` when the caller supplied that same root in `VerificationContext`. The initial regression run on unchanged production code produced **12 failures / 15 passing controls**.

The patch uses the existing `build_catalog_tree()` with the root's declared algorithm. Internal mismatches are reported as `tool_manifest.catalog_hash`; the existing `tool_manifest` runtime comparison remains independent. Neither can override the other into a match. Missing committed leaf inputs and unusable Python-dict inputs fail with a bounded diagnostic.

Compatibility is deliberate: legacy omitted bindings retain their existing behavior; an explicitly empty `tools` array is hashed. Nonhashed metadata does not become a new required input. No Merkle construction or public return shape changes.

## Spec impact

None; SDK enforcement of the existing §3.2.3 construction. This does **not** unify the Agent Manifest Merkle root with cMCP's separate catalog commitment (#340), authenticate live tool schemas from their declared hashes, or establish hardware/runtime behavior.

## Test plan

- [x] Full host suite: **1,647 passed / 10 existing optional skips**.
- [x] Clean committed-source, no-cache Linux container: **1,647 passed / 10 existing optional skips**, 90.26% coverage; runtime network disabled.
- [x] `mypy src/agent_manifest`: 26 files clean.
- [x] Exact CI lint command: `ruff check src/ tests/ --select E,F,W --ignore E501`.
- [x] **41 added cases**: signed v0.1 JSON and v0.2 COSE; SHA-256/SHAKE256; wrong roots; each committed leaf mutation; reordered/empty catalogs; separate runtime mismatch; missing runtime context; legacy omissions; malformed Python-dict inputs. No new skip/xfail.
- [x] Bandit, dependency audit (`--skip-editable`), Gitleaks diff scan, detect-secrets changed-file scan, and whitespace checks pass.
- [x] Wheel/sdist build and Twine validation; each artifact installed into a separate fresh environment, imported and verified outside the checkout, with CLI smoke and archive inspection.
- [x] Changelog updated with attribution. A separate source-review pass found a Python-dict coercion edge case, now rejected and regression-tested.

Both host and container verification use the repository's hash-locked `requirements/dev.txt`; no dependencies were changed. Optional skips are reported, not counted as passes. No live TPM/TEE claim is made by these tests.

## DCO

All commits are signed off as Noah Ingwers (`git commit -s`). By submitting this PR I certify the [Developer Certificate of Origin](https://developercertificate.org/).
